### PR TITLE
Run CI in Python 3.4 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: python
-python: 3.5
+python:
+    - "3.5.1" # for Heroku
+    - "3.4.3" # for production
 script: py.test
 addons:
   postgresql: "9.4"


### PR DESCRIPTION
@relud has informed me that Python 3.4.3 will be a bit easier to get into production, so lets make sure we can support it.