### PR TITLE
Generate SHA-256 cert for SSL dev server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ db.sqlite3
 GeoLite2-Country.mmdb
 _build
 /.cache/
+/etc/ssl

--- a/bin/download_geolite2.sh
+++ b/bin/download_geolite2.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 # This script downloads and extracts the free GeoLite2 country database
 # from MaxMind for use in development.
-BASE_DIR="$(dirname "$(dirname "$0")")"
+BASE_DIR="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
 DOWNLOAD_URL=http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz
 LOCAL_ARCHIVE=/tmp/GeoLite2-Country.mmdb.gz
 LOCAL_EXTRACTED=/tmp/GeoLite2-Country.mmdb

--- a/bin/runsslserver.sh
+++ b/bin/runsslserver.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# This script starts an SSL development server so that you don't have to
+# pass annoying arguments to manage.py all the time.
+BASE_DIR="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
+SSL_DIR="$BASE_DIR/etc/ssl"
+KEY="$SSL_DIR/normandy_dev.key"
+CERT="$SSL_DIR/normandy_dev.cert"
+
+
+# If the key or cert don't exist, generate them.
+if [ ! -f $KEY ]; then
+    mkdir -p $SSL_DIR
+    openssl genrsa -out $KEY 2048
+fi
+
+if [ ! -f $CERT ]; then
+    openssl req -new -x509 -nodes -sha256 -key $KEY \
+        -subj "/C=US/ST=Test/L=Test/O=Mozilla/CN=normandy_dev" > $CERT
+fi
+
+
+$BASE_DIR/manage.py runsslserver \
+    --certificate=$CERT \
+    --key=$KEY \
+    "$@"


### PR DESCRIPTION
The certificate included with runsslserver is SHA1 and will stop
working with Firefox soon, and having all the devs trust a single cert
instead of generating their own personal ones is a bad idea anyway.

@mythmon r?