### PR TITLE
Add setting for editing actions in use and disable it on dev.

### DIFF
--- a/normandy/recipes/api/permissions.py
+++ b/normandy/recipes/api/permissions.py
@@ -1,10 +1,13 @@
+from django.conf import settings
+
 from rest_framework import permissions
 
 
 class NotInUse(permissions.BasePermission):
     """Only allows editing of objects if object.in_use is False."""
     def has_object_permission(self, request, view, obj):
-        if request.method not in permissions.SAFE_METHODS and obj.in_use:
+        unsafe_method = request.method not in permissions.SAFE_METHODS
+        if not settings.CAN_EDIT_ACTIONS_IN_USE and unsafe_method and obj.in_use:
             return False
         else:
             return True

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -70,11 +70,22 @@ class TestActionAPI(object):
         assert action.implementation_content == b'foobar'
         assert action.arguments_schema == {'type': 'object'}
 
-    def test_it_cant_edit_actions_in_use(self, api_client):
+    def test_it_cant_edit_actions_in_use(self, api_client, settings):
         RecipeActionFactory(action__name='active', recipe__enabled=True)
+        settings.CAN_EDIT_ACTIONS_IN_USE = False
 
         res = api_client.patch('/api/v1/action/active/', {'implementation': 'foobar'})
         assert res.status_code == 403
 
         res = api_client.delete('/api/v1/action/active/')
         assert res.status_code == 403
+
+    def test_it_can_edit_actions_in_use_with_setting(self, api_client, settings):
+        RecipeActionFactory(action__name='active', recipe__enabled=True)
+        settings.CAN_EDIT_ACTIONS_IN_USE = True
+
+        res = api_client.patch('/api/v1/action/active/', {'implementation': 'foobar'})
+        assert res.status_code == 200
+
+        res = api_client.delete('/api/v1/action/active/')
+        assert res.status_code == 204

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -124,6 +124,8 @@ class Base(Core):
         'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     }
 
+    CAN_EDIT_ACTIONS_IN_USE = values.BooleanValue(False)
+
 
 class Development(Base):
     """Settings for local development."""
@@ -137,6 +139,7 @@ class Development(Base):
     EMAIL_BACKEND = values.Value('django.core.mail.backends.console.EmailBackend')
 
     GEOIP2_DATABASE = values.Value(os.path.join(Core.BASE_DIR, 'GeoLite2-Country.mmdb'))
+    CAN_EDIT_ACTIONS_IN_USE = values.BooleanValue(True)
 
 
 class Production(Base):


### PR DESCRIPTION
During local development editing actions that are in use is common and acceptable, while we want to disable it everywhere else for safety.

I ran into this a ton while working on actions. I'm also hoping to add a watch action to the normandy actions repo, which would work well with this setting to enable rapid testing of actions.

@mythmon r?