### PR TITLE
Add setting to disable admin interface

### DIFF
--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -125,6 +125,7 @@ class Base(Core):
     }
 
     CAN_EDIT_ACTIONS_IN_USE = values.BooleanValue(False)
+    ADMIN_ENABLED = values.BooleanValue(True)
 
 
 class Development(Base):

--- a/normandy/urls.py
+++ b/normandy/urls.py
@@ -4,14 +4,16 @@ from django.conf.urls.static import static
 from django.contrib import admin
 
 
-urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+urlpatterns = []
 
+if settings.ADMIN_ENABLED:
+    urlpatterns += [url(r'^admin/', admin.site.urls)]
+
+urlpatterns += [
     url(r'', include('normandy.recipes.urls')),
     url(r'', include('normandy.classifier.urls')),
     url(r'', include('normandy.selfrepair.urls')),
 ]
-
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
I couldn't figure out how to test this. Changing the setting during the test doesn't cause urls.py to reload. I think this will have to be a pre-deployment test, once we have those. And we definitely want to test it there, because of the security considerations.

Another thought I had was a proxy view that intercepted all the `/admin/.*` urls and either forwarded them to the real admin app or 404ed them, depending on the setting. That seemed too complex though.

r?