### PR TITLE
Use consistent STATICFILES_STORAGE across environments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _build
 /.cache/
 /etc/ssl
 /__version__/
+/tmp

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -84,6 +84,7 @@ class Base(Core):
     ALLOWED_HOSTS = values.ListValue([])
     DATABASES = values.DatabaseURLValue('postgres://postgres@localhost/normandy')
     ADMINS = values.SingleNestedListValue([])
+    STATICFILES_STORAGE = values.Value('whitenoise.django.GzipManifestStaticFilesStorage')
 
     EMAIL_HOST_USER = values.Value()
     EMAIL_HOST = values.Value()
@@ -146,7 +147,6 @@ class Development(Base):
 
 class Production(Base):
     """Settings for the production environment."""
-    STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
 
 class Test(Base):


### PR DESCRIPTION
collectstatic only adds hashes to static file filenames when
STATICFILES_STORAGE is set correctly. We want the Dockerfile and
other things to have the hashed filenames, but the Dockerfile runs
collectstatic under the Development environment. Also, there's no
problem using the manifest storage during development.

So we move the setting.

@mythmon r?