### PR TITLE
Use Python Slim docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
-FROM python:3.5.1
+FROM python:3.5.1-slim
 WORKDIR /app
 RUN groupadd --gid 1001 app && useradd -g app --uid 1001 --shell /usr/sbin/nologin app
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc libpq-dev
+
 COPY ./requirements.txt /app/requirements.txt
 RUN pip install -U 'pip>=8' && pip install --upgrade --no-cache-dir -r requirements.txt
+
 COPY . /app
-RUN DJANGO_CONFIGURATION=Build ./manage.py collectstatic --no-input
-RUN mkdir -p media && chown app:app media
-RUN mkdir -p __version__
-RUN git rev-parse HEAD > __version__/commit
+RUN DJANGO_CONFIGURATION=Build ./manage.py collectstatic --no-input && \
+    mkdir -p media && chown app:app media && \
+    mkdir -p __version__ && \
+    # Get the current git commit. Done by hand to avoid installing Git.
+    cat .git/$(cat .git/HEAD | awk '{print $2}') > __version__/commit && \
+    rm -rf .git
+
 USER app
-ENV DJANGO_SETTINGS_MODULE=normandy.settings
-ENV DJANGO_CONFIGURATION=Production
-ENV PORT=8000
+ENV DJANGO_SETTINGS_MODULE=normandy.settings \
+    DJANGO_CONFIGURATION=Production \
+    PORT=8000
 EXPOSE $PORT
 CMD gunicorn normandy.wsgi:application --log-file -


### PR DESCRIPTION
Locally, this makes images that are 40% smaller than before (895.2 MB  to 537.7 MB). This should translate into faster CI and faster deploys.

The difference between `python:3.5.1` and `python:3.5.1-slim` is largely that `python:3.5.1` installs several Debian packages we don't care about, including MySQL bindings. This new Dockerfile installs only the ones we need.

Note: this PR and the first deploy is going to have slower CI since it will miss the cache.

@relud r?