### PR TITLE
add /__lbheartbeat__ so the elb can see the application is responsive

### DIFF
--- a/normandy/health/api/views.py
+++ b/normandy/health/api/views.py
@@ -36,7 +36,7 @@ def version(request):
 @api_view(['GET'])
 def lbheartbeat(request):
     # lets the load balancer know the application is running and available
-    return Response('', status=status.HTTP_200_OK)
+    return Response('', status=status.HTTP_204_NO_CONTENT)
 
 
 @api_view(['GET'])

--- a/normandy/health/api/views.py
+++ b/normandy/health/api/views.py
@@ -34,6 +34,12 @@ def version(request):
 
 
 @api_view(['GET'])
+def lbheartbeat(request):
+    # lets the load balancer know the application is running and available
+    return Response('', status=status.HTTP_200_OK)
+
+
+@api_view(['GET'])
 def heartbeat(request):
     all_checks = checks_registry.get_checks(include_deployment_checks=not settings.DEBUG)
     details = {check.__name__: heartbeat_check_detail(check) for check in all_checks}

--- a/normandy/health/api/views.py
+++ b/normandy/health/api/views.py
@@ -36,7 +36,9 @@ def version(request):
 @api_view(['GET'])
 def lbheartbeat(request):
     # lets the load balancer know the application is running and available
-    return Response('', status=status.HTTP_204_NO_CONTENT)
+    # must return 200 (not 204) for ELB
+    # http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-healthchecks.html
+    return Response('', status=status.HTTP_200_OK)
 
 
 @api_view(['GET'])

--- a/normandy/health/urls.py
+++ b/normandy/health/urls.py
@@ -5,4 +5,5 @@ from normandy.health.api import views
 urlpatterns = [
     url(r'^__version__', views.version, name='normandy.version'),
     url(r'^__heartbeat__', views.heartbeat, name='normandy.heartbeat'),
+    url(r'^__lbheartbeat__', views.heartbeat, name='normandy.lbheartbeat'),
 ]


### PR DESCRIPTION
not sure if it should return `Response('', status=status.HTTP_200_OK)` or just `Response('')` or something else. Expected behavior is to return 200 with an empty body.