### PR TITLE
Make migration check catch db errors

### DIFF
--- a/normandy/health/checks.py
+++ b/normandy/health/checks.py
@@ -3,6 +3,7 @@ from django.db import connection
 from django.db.utils import OperationalError
 
 
+INFO_CANT_CHECK_MIGRATIONS = 'normandy.health.I001'
 WARNING_UNAPPLIED_MIGRATION = 'normandy.health.W001'
 ERROR_CANNOT_CONNECT_DATABASE = 'normandy.health.E001'
 ERROR_UNUSABLE_DATABASE = 'normandy.health.E002'
@@ -27,7 +28,11 @@ def migrations_applied(app_configs, **kwargs):
     errors = []
 
     # Load migrations from disk/DB
-    loader = MigrationLoader(connection, ignore_no_migrations=True)
+    try:
+        loader = MigrationLoader(connection, ignore_no_migrations=True)
+    except OperationalError:
+        msg = "Can't connect to database to check migrations"
+        return [Info(msg, id=INFO_CANT_CHECK_MIGRATIONS)]
     graph = loader.graph
 
     if app_configs:

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -91,7 +91,6 @@ class Core(Configuration):
     }
 
 
-
 class Base(Core):
     """Settings that may change per-environment, some with defaults."""
     # General settings


### PR DESCRIPTION
Checks generally need to be resilient to the DB being down so that the heartbeat page works when the DB is down. This makes the migration check do that.

When we figure out how to run the checks in CI, we should make them test this case too.

@Osmose r?