### PR TITLE
Try to make no database queries in fetch_bundle

### DIFF
--- a/normandy/classifier/tests/test_api.py
+++ b/normandy/classifier/tests/test_api.py
@@ -1,3 +1,6 @@
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
 import pytest
 from rest_framework.reverse import reverse
 
@@ -13,7 +16,7 @@ class TestFetchBundleAPI(object):
         assert res.status_code == 200
         assert res.data == {'recipes': []}
 
-    def test_it_serves_recipes(self, client):
+    def test_it_serves_recipes(self, client, django_cache):
         recipe_action = RecipeActionFactory(arguments={'foo': 'bar'})
         res = client.post('/api/v1/fetch_bundle/')
 
@@ -37,7 +40,7 @@ class TestFetchBundleAPI(object):
             ],
         }]
 
-    def test_it_filters_by_locale(self, client):
+    def test_it_filters_by_locale(self, client, django_cache):
         english = LocaleFactory(code='en-US')
         german = LocaleFactory(code='de')
 
@@ -52,3 +55,22 @@ class TestFetchBundleAPI(object):
 
         recipe_names = set(r['name'] for r in res.data['recipes'])
         assert recipe_names == {'german', 'any', 'both'}
+
+    @pytest.mark.xfail
+    def test_it_makes_no_db_queries(self, client, django_cache):
+        # Prepare some interesting data
+        recipe_action = RecipeActionFactory(recipe__enabled=True)
+        recipe = recipe_action.recipe
+
+        # Warm up the cache
+        res1 = client.post('/api/v1/fetch_bundle/', {'locale': 'de'})
+        assert res1.status_code == 200
+        assert res1.data['recipes'][0]['name'] == recipe.name
+
+        # Fire!
+        queries = CaptureQueriesContext(connection)
+        with queries:
+            res2 = client.post('/api/v1/fetch_bundle/', {'locale': 'de'})
+            assert res2.status_code == 200
+        assert res1.data == res2.data
+        assert (len(queries), list(queries)) == (0, [])

--- a/normandy/classifier/tests/test_api.py
+++ b/normandy/classifier/tests/test_api.py
@@ -16,7 +16,7 @@ class TestFetchBundleAPI(object):
         assert res.status_code == 200
         assert res.data == {'recipes': []}
 
-    def test_it_serves_recipes(self, client, django_cache):
+    def test_it_serves_recipes(self, client):
         recipe_action = RecipeActionFactory(arguments={'foo': 'bar'})
         res = client.post('/api/v1/fetch_bundle/')
 
@@ -40,7 +40,7 @@ class TestFetchBundleAPI(object):
             ],
         }]
 
-    def test_it_filters_by_locale(self, client, django_cache):
+    def test_it_filters_by_locale(self, client):
         english = LocaleFactory(code='en-US')
         german = LocaleFactory(code='de')
 
@@ -57,7 +57,7 @@ class TestFetchBundleAPI(object):
         assert recipe_names == {'german', 'any', 'both'}
 
     @pytest.mark.xfail
-    def test_it_makes_no_db_queries(self, client, django_cache):
+    def test_it_makes_no_db_queries(self, client):
         # Prepare some interesting data
         recipe_action = RecipeActionFactory(recipe__enabled=True)
         recipe = recipe_action.recipe

--- a/normandy/classifier/tests/test_api.py
+++ b/normandy/classifier/tests/test_api.py
@@ -73,4 +73,4 @@ class TestFetchBundleAPI(object):
             res2 = client.post('/api/v1/fetch_bundle/', {'locale': 'de'})
             assert res2.status_code == 200
         assert res1.data == res2.data
-        assert (len(queries), list(queries)) == (0, [])
+        assert list(queries) == []

--- a/normandy/classifier/tests/test_views.py
+++ b/normandy/classifier/tests/test_views.py
@@ -14,7 +14,7 @@ class TestClientClassifier(object):
         response = admin_client.get('/admin/classifier_preview')
         assert response.status_code == 200
 
-    def test_classify(self, admin_client):
+    def test_classify(self, admin_client, django_cache):
         locale, other_locale = LocaleFactory.create_batch(2)
         country = CountryFactory()
         release_channel = ReleaseChannelFactory()
@@ -36,7 +36,7 @@ class TestClientClassifier(object):
         assert response.status_code == 200
         assert list(response.context['bundle']) == [matching_recipe]
 
-    def test_classify_no_sample(self, admin_client):
+    def test_classify_no_sample(self, admin_client, django_cache):
         """The classify view should ignore sampling."""
         locale = LocaleFactory()
         country = CountryFactory()

--- a/normandy/classifier/tests/test_views.py
+++ b/normandy/classifier/tests/test_views.py
@@ -14,7 +14,7 @@ class TestClientClassifier(object):
         response = admin_client.get('/admin/classifier_preview')
         assert response.status_code == 200
 
-    def test_classify(self, admin_client, django_cache):
+    def test_classify(self, admin_client):
         locale, other_locale = LocaleFactory.create_batch(2)
         country = CountryFactory()
         release_channel = ReleaseChannelFactory()
@@ -36,7 +36,7 @@ class TestClientClassifier(object):
         assert response.status_code == 200
         assert list(response.context['bundle']) == [matching_recipe]
 
-    def test_classify_no_sample(self, admin_client, django_cache):
+    def test_classify_no_sample(self, admin_client):
         """The classify view should ignore sampling."""
         locale = LocaleFactory()
         country = CountryFactory()

--- a/normandy/conftest.py
+++ b/normandy/conftest.py
@@ -16,13 +16,9 @@ def api_client():
     return client
 
 
-@pytest.yield_fixture()
+@pytest.yield_fixture(autouse=True)
 def django_cache(request):
     """Require a django test cache"""
-    for cache_name in settings.CACHES.keys():
-        caches[cache_name].clear()
-
     yield None
-
     for cache_name in settings.CACHES.keys():
         caches[cache_name].clear()

--- a/normandy/conftest.py
+++ b/normandy/conftest.py
@@ -1,3 +1,6 @@
+from django.core.cache import caches
+from django.conf import settings
+
 import pytest
 from rest_framework.test import APIClient
 
@@ -11,3 +14,15 @@ def api_client():
     client = APIClient()
     client.force_authenticate(user=user)
     return client
+
+
+@pytest.yield_fixture()
+def django_cache(request):
+    """Require a django test cache"""
+    for cache_name in settings.CACHES.keys():
+        caches[cache_name].clear()
+
+    yield None
+
+    for cache_name in settings.CACHES.keys():
+        caches[cache_name].clear()

--- a/normandy/health/tests/test_api.py
+++ b/normandy/health/tests/test_api.py
@@ -1,5 +1,7 @@
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
 import pytest
-from rest_framework.reverse import reverse
 
 
 def test_version(client, mocker):
@@ -12,3 +14,12 @@ def test_version(client, mocker):
         'source': 'https://github.com/mozilla/normandy',
         'commit': '<git hash>',
     }
+
+
+@pytest.mark.django_db
+def test_lbheartbeat_makes_no_db_queries(client):
+    queries = CaptureQueriesContext(connection)
+    with queries:
+        res = client.get('/__lbheartbeat__')
+        assert res.status_code == 200
+    assert len(queries) == 0

--- a/normandy/selfrepair/tests/test_views.py
+++ b/normandy/selfrepair/tests/test_views.py
@@ -1,0 +1,15 @@
+from django.core.urlresolvers import reverse
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_selfrepair_makes_no_db_queries(client):
+    queries = CaptureQueriesContext(connection)
+    with queries:
+        url = reverse('normandy.selfrepair', args={'locale': 'en-US'})
+        res = client.get(url)
+        assert res.status_code == 200
+    assert len(queries) == 0

--- a/normandy/selfrepair/views.py
+++ b/normandy/selfrepair/views.py
@@ -1,6 +1,9 @@
 from django.shortcuts import render
 
+from normandy.base.decorators import short_circuit_middlewares
 
+
+@short_circuit_middlewares
 def repair(request, locale):
     return render(request, 'selfrepair/repair.html', {
         'locale': locale,

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -90,6 +90,17 @@ class Core(Configuration):
         'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     }
 
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'default',
+        },
+        'recipes': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'recipes',
+        },
+    }
+
 
 class Base(Core):
     """Settings that may change per-environment, some with defaults."""


### PR DESCRIPTION
This doesn't completely eliminate the database accesses in fetch_bundle, but it reduces them. The rest of the reduction will come after the make the relation between `Recipe`s and `Action`s not use a through-table. At that point, this might just work.

@Osmose r?