### PR TITLE
[Bug 1253717] Keep history of changes to Actions / Recipes

### DIFF
--- a/normandy/recipes/admin.py
+++ b/normandy/recipes/admin.py
@@ -5,9 +5,11 @@ from normandy.base.admin import site as admin_site
 from normandy.recipes import models
 from normandy.recipes.forms import ActionAdminForm, RecipeAdminForm
 
+from reversion.admin import VersionAdmin
+
 
 @admin.register(models.Recipe, site=admin_site)
-class RecipeAdmin(admin.ModelAdmin):
+class RecipeAdmin(VersionAdmin):
     form = RecipeAdminForm
     list_display = [
         'name',
@@ -54,7 +56,7 @@ class RecipeAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.Action, site=admin_site)
-class ActionAdmin(admin.ModelAdmin):
+class ActionAdmin(VersionAdmin):
     form = ActionAdminForm
     list_display = ['name', 'implementation_hash', 'in_use']
     fieldsets = [

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -68,6 +68,7 @@ class Country(models.Model):
         return self.code == client_val or self.name == client_val
 
 
+@reversion.register()
 class Recipe(models.Model):
     """A set of actions to be fetched and executed by users."""
     name = models.CharField(max_length=255, unique=True)
@@ -207,6 +208,7 @@ def get_release_channels(recipe):
     return recipe.release_channels.all()
 
 
+@reversion.register()
 class Action(models.Model):
     """A single executable action that can take arguments."""
     name = models.SlugField(max_length=255, unique=True)

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -5,6 +5,7 @@ import logging
 from django.db import models
 
 from rest_framework.reverse import reverse
+from reversion import revisions as reversion
 
 from normandy.recipes import utils
 from normandy.recipes.fields import PercentField

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -20,6 +20,7 @@ class Core(Configuration):
         'product_details',
         'rest_framework',
         'rest_framework.authtoken',
+        'reversion',
         'storages',
         'raven.contrib.django.raven_compat',
 

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -44,6 +44,8 @@ class Core(Configuration):
         'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+        'reversion.middleware.RevisionMiddleware',
     ]
 
     ROOT_URLCONF = 'normandy.urls'

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ django-countries==3.4.1 \
 django-mozilla-product-details==0.10 \
     --hash=sha256:400e59be3c163aebfc8c078879e87a895dad249589d8bc332bb76dc9c9b63efb \
     --hash=sha256:33add704683a5d7f9ff49c03e40a4d8c500882589aee970d5ed81ad11c7ae75c
+django-reversion==1.10.0 \
+    --hash=sha256:a7df6a438bb7f2135bd6c9f5a7bf2879d700e381c0e1336bb8606c1275168395
 django-sslserver==0.18 \
     --hash=sha256:e7180255546c6e1e1652de032d212aa63b19a26b2c817b5f7babca24711f03ad
 django-storages-redux==1.3.2 \


### PR DESCRIPTION
I added the [django-reversion](http://django-reversion.readthedocs.org/en/latest/) library & its middleware to keep track of changes to recipes/actions as per [bug 1253717](https://bugzilla.mozilla.org/show_bug.cgi?id=1253717). You'll have to run `manage.py migrate` and `manage.py createinitialrevisions` to populate the new reversion tables. 

There were a couple of options listed for creating revisions with django-reversion. I went with the middleware but it did come with this [warning](http://django-reversion.readthedocs.org/en/latest/api.html?highlight=json#revisionmiddleware). Do we care about that? I don't totally understand what it means.

We can also add extra metadata to our revisions if we want. As is, it gives us all the serialized data for each revision of a recipe/action so I think we've got what we need, but let me know if there's anything else we might want to keep track of. Each row has its own `revision_id` field which could maybeee get confusing with the `revision_id` field that was added to recipes in Rehan's recent [pull request for salt hashes](https://github.com/mozilla/normandy/pull/75/files)? Thoughts?

I haven't added any sort of front-end for this information yet - just wanted to make sure this was on the right track first.  I can file a new bug and PR for that assuming the work here is all good.