### PR TITLE
[bug 1257660] Include implementation hash in its URL.

### DIFF
--- a/normandy/base/api/renderers.py
+++ b/normandy/base/api/renderers.py
@@ -8,12 +8,12 @@ class TextRenderer(renderers.BaseRenderer):
     def render(self, data, media_type=None, renderer_context=None):
         response = renderer_context.get('response') if renderer_context else None
         if response and response.exception:
-            return self.render_error(data)
+            data = self.render_error(data)
 
         return data.encode(self.charset)
 
     def render_error(self, data):
-        return data['detail'].encode(self.charset)
+        return data['detail']
 
 
 class JavaScriptRenderer(TextRenderer):
@@ -21,4 +21,4 @@ class JavaScriptRenderer(TextRenderer):
     format = 'js'
 
     def render_error(self, data):
-        return '/* {} */'.format(data['detail'])
+        return '/* {} */'.format(super().render_error(data))

--- a/normandy/base/api/renderers.py
+++ b/normandy/base/api/renderers.py
@@ -6,9 +6,19 @@ class TextRenderer(renderers.BaseRenderer):
     format = 'txt'
 
     def render(self, data, media_type=None, renderer_context=None):
+        response = renderer_context.get('response') if renderer_context else None
+        if response and response.exception:
+            return self.render_error(data)
+
         return data.encode(self.charset)
+
+    def render_error(self, data):
+        return data['detail'].encode(self.charset)
 
 
 class JavaScriptRenderer(TextRenderer):
     media_type = 'application/javascript'
     format = 'js'
+
+    def render_error(self, data):
+        return '/* {} */'.format(data['detail'])

--- a/normandy/classifier/tests/test_api.py
+++ b/normandy/classifier/tests/test_api.py
@@ -21,7 +21,10 @@ class TestFetchBundleAPI(object):
         res = client.post('/api/v1/fetch_bundle/')
 
         action = recipe.action
-        impl_url = reverse('action-implementation', args=[action.name])
+        impl_url = reverse('action-implementation', kwargs={
+            'name': action.name,
+            'impl_hash': action.implementation_hash,
+        })
         assert res.status_code == 200
         assert res.data['recipes'] == [{
             'name': recipe.name,

--- a/normandy/recipes/api/fields.py
+++ b/normandy/recipes/api/fields.py
@@ -3,6 +3,8 @@ from contextlib import closing
 from django.core.files.base import ContentFile
 
 from rest_framework.fields import CharField
+from rest_framework.reverse import reverse
+from rest_framework.serializers import HyperlinkedIdentityField
 
 
 class ContentFileField(CharField):
@@ -18,3 +20,12 @@ class ContentFileField(CharField):
         value.open()
         with closing(value) as value:
             return value.read().decode('utf-8')
+
+
+class ActionImplementationHyperlinkField(HyperlinkedIdentityField):
+    """
+    Serializer field for actions that links to their implementation.
+    """
+    def get_url(self, obj, view_name, request, format):
+        kwargs = {'name': obj.name, 'impl_hash': obj.implementation_hash}
+        return reverse(view_name, kwargs=kwargs, request=request, format=format)

--- a/normandy/recipes/api/fields.py
+++ b/normandy/recipes/api/fields.py
@@ -26,6 +26,9 @@ class ActionImplementationHyperlinkField(HyperlinkedIdentityField):
     """
     Serializer field for actions that links to their implementation.
     """
+    def __init__(self, view_name='action-implementation', **kwargs):
+        super().__init__(view_name=view_name, **kwargs)
+
     def get_url(self, obj, view_name, request, format):
         kwargs = {'name': obj.name, 'impl_hash': obj.implementation_hash}
         return reverse(view_name, kwargs=kwargs, request=request, format=format)

--- a/normandy/recipes/api/serializers.py
+++ b/normandy/recipes/api/serializers.py
@@ -1,14 +1,13 @@
 from rest_framework import serializers
 
+from normandy.recipes.api.fields import ActionImplementationHyperlinkField
 from normandy.recipes.models import Action, Recipe
 
 
 class ActionSerializer(serializers.ModelSerializer):
     arguments_schema = serializers.JSONField()
     implementation = serializers.CharField(write_only=True)
-    implementation_url = serializers.HyperlinkedIdentityField(
-        view_name='action-implementation',
-        lookup_field='name')
+    implementation_url = ActionImplementationHyperlinkField(view_name='action-implementation')
 
     class Meta:
         model = Action
@@ -24,9 +23,7 @@ class ActionSerializer(serializers.ModelSerializer):
 class ImplementationSerializer(serializers.Serializer):
     name = serializers.CharField()
     hash = serializers.CharField(source='implementation_hash', read_only=True)
-    url = serializers.HyperlinkedIdentityField(
-        view_name='action-implementation',
-        lookup_field='name')
+    url = ActionImplementationHyperlinkField(view_name='action-implementation')
 
 
 class RecipeSerializer(serializers.Serializer):

--- a/normandy/recipes/api/serializers.py
+++ b/normandy/recipes/api/serializers.py
@@ -7,7 +7,7 @@ from normandy.recipes.models import Action, Recipe
 class ActionSerializer(serializers.ModelSerializer):
     arguments_schema = serializers.JSONField()
     implementation = serializers.CharField(write_only=True)
-    implementation_url = ActionImplementationHyperlinkField(view_name='action-implementation')
+    implementation_url = ActionImplementationHyperlinkField()
 
     class Meta:
         model = Action
@@ -23,7 +23,7 @@ class ActionSerializer(serializers.ModelSerializer):
 class ImplementationSerializer(serializers.Serializer):
     name = serializers.CharField()
     hash = serializers.CharField(source='implementation_hash', read_only=True)
-    url = ActionImplementationHyperlinkField(view_name='action-implementation')
+    url = ActionImplementationHyperlinkField()
 
 
 class RecipeSerializer(serializers.Serializer):

--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -41,13 +41,13 @@ class ActionViewSet(viewsets.ModelViewSet):
 class ActionImplementationView(generics.RetrieveAPIView):
     """
     Retrieves the implementation code for an action. Raises a 404 if the
-    given hash doesn't match the has we've stored.
+    given hash doesn't match the hash we've stored.
     """
     queryset = Action.objects.all()
     lookup_field = 'name'
 
-    permission_classes = ()
-    renderer_classes = (JavaScriptRenderer,)
+    permission_classes = []
+    renderer_classes = [JavaScriptRenderer]
 
     def retrieve(self, request, name, impl_hash):
         action = self.get_object()

--- a/normandy/recipes/tests/test_serializers.py
+++ b/normandy/recipes/tests/test_serializers.py
@@ -13,7 +13,10 @@ def test_recipe_serializer(rf):
     action = recipe.action
     serializer = RecipeSerializer(recipe, context={'request': rf.get('/')})
 
-    action_url = reverse('action-implementation', args=[action.name])
+    action_url = reverse('action-implementation', kwargs={
+        'name': action.name,
+        'impl_hash': action.implementation_hash,
+    })
     assert serializer.data == {
         'name': recipe.name,
         'implementation': {

--- a/normandy/recipes/urls.py
+++ b/normandy/recipes/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url, include
 
 from rest_framework.routers import DefaultRouter
 
-from normandy.recipes.api.views import ActionViewSet
+from normandy.recipes.api.views import ActionImplementationView, ActionViewSet
 
 # API Router
 router = DefaultRouter()
@@ -11,4 +11,9 @@ router.register(r'action', ActionViewSet)
 
 urlpatterns = [
     url(r'^api/v1/', include(router.urls)),
+    url(
+        r'^api/v1/action/(?P<name>[_\-\w]+)/implementation/(?P<impl_hash>[0-9a-f]{40})/$',
+        ActionImplementationView.as_view(),
+        name='action-implementation'
+    ),
 ]


### PR DESCRIPTION
Turns out our JavaScript/Plaintext renderers don't handle 404s properly. Also they were in a file named `renders.py`. Fixed all that.

I had to move to using a separate view in order to accept more than one argument in the URL.

@mythmon r?