### PR TITLE
Refactor Client, and read user_id from request data, if provided

### DIFF
--- a/normandy/classifier/admin/forms.py
+++ b/normandy/classifier/admin/forms.py
@@ -1,22 +1,12 @@
-from collections import namedtuple
-
 from django import forms
 from django.contrib.admin import widgets
 from django.utils import timezone
 
 from normandy.recipes.models import Country, Locale, ReleaseChannel
+from normandy.classifier.models import Client
 
 
-FakeClient = namedtuple('FakeClient', (
-    'locale',
-    'country',
-    'request_time',
-    'release_channel',
-    'user_id'
-))
-
-
-class FakeClientForm(forms.Form):
+class ClientForm(forms.Form):
     """Form to specify client configurations for testing purposes."""
     locale = forms.ModelChoiceField(Locale.objects.all(), empty_label=None, to_field_name='code')
     release_channel = forms.ModelChoiceField(
@@ -33,7 +23,7 @@ class FakeClientForm(forms.Form):
     request_time = forms.SplitDateTimeField(required=False, widget=widgets.AdminSplitDateTime)
 
     def save(self):
-        return FakeClient(
+        return Client(
             locale=self.cleaned_data['locale'].code,
             country=self.cleaned_data['country'].code,
             request_time=self.cleaned_data.get('request_time', timezone.now()),

--- a/normandy/classifier/admin/views.py
+++ b/normandy/classifier/admin/views.py
@@ -1,14 +1,14 @@
 from django.shortcuts import render
 
 from normandy.base.admin import site as admin_site
-from normandy.classifier.admin.forms import FakeClientForm
+from normandy.classifier.admin.forms import ClientForm
 from normandy.classifier.models import Bundle
 from normandy.recipes.models import match_sample_rate
 
 
 @admin_site.register_view('classifier_preview', name='Classifier Preview')
 def classifier_preview(request):
-    form = FakeClientForm(request.GET or None)
+    form = ClientForm(request.GET or None)
     if form.is_valid():
         client = form.save()
         bundle = Bundle.for_client(client, exclude=[match_sample_rate])

--- a/normandy/classifier/api.py
+++ b/normandy/classifier/api.py
@@ -1,4 +1,4 @@
-from rest_framework import serializers, views, status
+from rest_framework import views
 from rest_framework.response import Response
 
 from normandy.classifier.serializers import BundleSerializer
@@ -11,9 +11,6 @@ class FetchBundle(views.APIView):
     permission_classes = []
     serializer_class = BundleSerializer
 
-    class Parameters(serializers.Serializer):
-        locale = serializers.CharField(default=None)
-
     @classmethod
     def as_view(cls, **initkwargs):
         view = super().as_view(**initkwargs)
@@ -24,11 +21,7 @@ class FetchBundle(views.APIView):
         """
         Determine the recipes that matches the requesting client.
         """
-        params = self.Parameters(data=request.data)
-        if not params.is_valid():
-            return Response(params.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        client = Client(request, locale=params.data['locale'])
+        client = Client(request)
         bundle = Bundle.for_client(client)
         serializer = self.serializer_class(bundle, context={'request': request})
         return Response(serializer.data)

--- a/normandy/classifier/models.py
+++ b/normandy/classifier/models.py
@@ -16,6 +16,7 @@ class Client(object):
     class Parameters(serializers.Serializer):
         """For parsing the bodies of requests to retrieve client data"""
         locale = serializers.CharField(default=None)
+        user_id = serializers.CharField(default=None)
 
     def __init__(self, request=None, **kwargs):
         self.request = request
@@ -27,7 +28,7 @@ class Client(object):
         else:
             self.data = {}
 
-        fields = ['locale', 'release_channel', 'country', 'request_time']
+        fields = ['locale', 'release_channel', 'country', 'user_id', 'request_time']
         for field in fields:
             val = kwargs.get(field)
             if val is not None:
@@ -53,7 +54,8 @@ class Client(object):
 
         If the user did not provide an ID, this returns a random UUID.
         """
-        # TODO: Eventually this will be something from the request.
+        if self.data.get('user_id'):
+            return self.data['user_id']
         return str(uuid.uuid4())
 
     @cached_property

--- a/normandy/selfrepair/static/js/self_repair_runner.js
+++ b/normandy/selfrepair/static/js/self_repair_runner.js
@@ -45,6 +45,19 @@ function loadAction(recipe) {
 }
 
 /**
+ * Get a user_id. If one doesn't exist yet, make one up and store it in local storage.
+ * @return {String} A stored or generated UUID
+ */
+function get_user_id() {
+    let user_id = localStorage.getItem('user_id');
+    if (user_id === null) {
+        user_id = uuid.v4();
+        localStorage.setItem('user_id', user_id);
+    }
+    return user_id;
+}
+
+/**
  * Fetch recipes from the Recipe server.
  *
  * @promise {Array<Recipe>} List of recipes.
@@ -53,7 +66,10 @@ function fetchRecipes() {
     let {recipeUrl, locale} = document.documentElement.dataset;
 
     return xhr.post(recipeUrl, {
-        data: {locale: locale},
+        data: {
+            locale: locale,
+            user_id: get_user_id(),
+        },
         headers: {Accept: 'application/json'}
     }).then(request => {
         return JSON.parse(request.responseText).recipes;


### PR DESCRIPTION
The required part of this is pretty easy, just another field on `Client` and a little logic in the recipe runner. The more complex change isn't strictly needed, and could be excised if it is hated.