### PR TITLE
Add cache-control headers to implementation API

### DIFF
--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -54,4 +54,9 @@ class ActionImplementationView(generics.RetrieveAPIView):
         if impl_hash != action.implementation_hash:
             raise NotFound('Hash does not match current stored action.')
 
-        return Response(action.implementation)
+        max_age = 60 * 60 * 24 * 365  # one year in seconds
+        headers = {
+            'Cache-Control': 'public, max-age={}'.format(max_age),
+        }
+
+        return Response(action.implementation, headers=headers)

--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.http import Http404
+from django.views.decorators.cache import cache_control
 
 from rest_framework import generics, permissions, viewsets
 from rest_framework.exceptions import NotFound
@@ -49,14 +51,10 @@ class ActionImplementationView(generics.RetrieveAPIView):
     permission_classes = []
     renderer_classes = [JavaScriptRenderer]
 
+    @cache_control(public=True, max_age=settings.ACTION_IMPLEMENTATION_CACHE_TIME)
     def retrieve(self, request, name, impl_hash):
         action = self.get_object()
         if impl_hash != action.implementation_hash:
             raise NotFound('Hash does not match current stored action.')
 
-        max_age = 60 * 60 * 24 * 365  # one year in seconds
-        headers = {
-            'Cache-Control': 'public, max-age={}'.format(max_age),
-        }
-
-        return Response(action.implementation, headers=headers)
+        return Response(action.implementation)

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -167,11 +167,17 @@ class TestImplementationAPI(object):
         assert res.content.decode() == '/* Hash does not match current stored action. */'
         assert res['Content-Type'] == 'application/javascript; charset=utf-8'
 
-    def test_it_includes_cache_headers(self, api_client):
+    def test_it_includes_cache_headers(self, api_client, settings):
+        # Note: Can't override the cache time setting, since it is read
+        # when invoking the decorator at import time. Changing it would
+        # require mocking, and that isn't worth it.
         action = ActionFactory()
         res = api_client.get('/api/v1/action/{name}/implementation/{hash}/'.format(
             name=action.name,
             hash=action.implementation_hash,
         ))
         assert res.status_code == 200
-        assert res['Cache-Control'].startswith('public, max-age=')
+
+        max_age = 'max-age={}'.format(settings.ACTION_IMPLEMENTATION_CACHE_TIME)
+        assert max_age in res['Cache-Control']
+        assert 'public' in res['Cache-Control']

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -166,3 +166,12 @@ class TestImplementationAPI(object):
         assert res.status_code == 404
         assert res.content.decode() == '/* Hash does not match current stored action. */'
         assert res['Content-Type'] == 'application/javascript; charset=utf-8'
+
+    def test_it_includes_cache_headers(self, api_client):
+        action = ActionFactory()
+        res = api_client.get('/api/v1/action/{name}/implementation/{hash}/'.format(
+            name=action.name,
+            hash=action.implementation_hash,
+        ))
+        assert res.status_code == 200
+        assert res['Cache-Control'].startswith('public, max-age=')

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -178,6 +178,7 @@ class Base(Core):
     # Normandy settings
     CAN_EDIT_ACTIONS_IN_USE = values.BooleanValue(False)
     ADMIN_ENABLED = values.BooleanValue(True)
+    ACTION_IMPLEMENTATION_CACHE_TIME = values.IntegerValue(60 * 60 * 24 * 365)
 
 
 class Development(Base):


### PR DESCRIPTION
This will make the CDN happy. And really everyone who wants this service to be fast fast fast. I confirmed that Cloudfront (the CDN we will be using) will pay attention tot his cache header.

@Osmose r?