### PR TITLE
Update self-repair protocol in architecture docs

### DIFF
--- a/docs/dev/architecture.rst
+++ b/docs/dev/architecture.rst
@@ -1,10 +1,10 @@
 Architecture
 ============
-Normandy is a component in a larger system called SHIELD. The end goal of SHIELD
-is to allow Firefox to perform a variety of actions to aid the user and gather
-feedback to guide us in developing a better browser for them. To do this, we
-need a way to instruct Firefox to perform certain actions without having to
-download an update or wait for a new release.
+Normandy is a component in a larger system called SHIELD. The end goal of
+SHIELD is to allow Firefox to perform a variety of actions to aid the user and
+gather feedback to guide us in developing a better browser for them. To do
+this, we need a way to instruct Firefox to perform certain actions without
+having to download an update or wait for a new release.
 
 To accomplish this goal, the SHIELD system consists of:
 
@@ -16,24 +16,24 @@ Self-Repair System Addon
    from Normandy and executing them within Firefox.
 
 .. note:: Normandy provides both the names of actions and, separately,
-   implementations for them to be used in the self-repair system addon. Other
-   Firefox features may also query Normandy and implement the actions however
-   they wish, and are not required to use the implementations that Normandy
-   provides.
+   implementations for them to be used in self-repair executors. Other Firefox
+   features may also query Normandy and implement the actions however they
+   wish, although they are recommended to use the implementations that
+   Normandy provides if possible.
 
 Normandy / Self-Repair Protocol
 -------------------------------
 The following section describes the protocol used to communicate between
-Normandy and the Self-Repair system addon. The domain ``shield.mozilla.org``
-is used as a stand-in domain; the actual domain Normandy is hosted at may be
-different.
+Normandy and clients in Firefox that execute Self-Repair recipes. The domain
+``shield.mozilla.org`` is used as a stand-in domain; the actual domain Normandy
+is hosted at may be different.
 
 .. warning:: The following documentation is still in flux and does not describe
    a live system yet. Expect the protocol to change.
 
 Retrieving Recipes
 ^^^^^^^^^^^^^^^^^^
-The Self-Repair addon retrieves a list of recipes by making an HTTP POST request
+The Self-Repair addon retrieves a recipe bundle by making an HTTP POST request
 to the URL::
 
    https://shield.mozilla.org/api/v1/fetch_bundle/
@@ -44,35 +44,47 @@ The request should contain a JSON object of the form:
 
    {
       "locale": "en-US",
-      "firefox_version": "42.0.1"
+      "version": "42.0.1",
+      "release_channel": "release",
+      "user_id": "bd3ece30-ddb1-46ce-b3e9-c2816e59103f"
    }
 
-The API will respond with a JSON object:
+The API will respond with a JSON object containing metadata the server
+calculated (such as location), and a list of recipes. Each recipe will include
+a link to the JS implementation of the action for that recipe, an arguments
+schema, the arguments to pass to the implementation, and metadata about the
+action.
 
 .. code-block:: json
 
    {
+      "country": "US",
       "recipes": [
          {
-            "name": "heartbeat.australis.1",
-            "implementation": {
-               "name": "show_survey",
-               "hash": "4011cf569f3639b9069fc2c50117d3f8597e83c61be2014081ad06ee0fe427c2",
-               "url": "https://shield.mozilla.org/media/actions/show_survey.js"
+            "id": 1,
+            "name": "Console Log Test",
+            "revision_id": 12,
+            "action": {
+               "name": "console-log",
+               "implementation_url": "https://shield.mozilla.org/api/v1/action/console-log/implementation/8ee8e7621fc08574f854972ee77be2a5280fb546/",
+               "arguments_schema": {
+                  "$schema": "http://json-schema.org/draft-04/schema#",
+                  "description": "Log a message to the console",
+                  "type": "object",
+                  "properties": {
+                     "message": {
+                        "default": "",
+                        "description": "Message to log to the console",
+                        "type": "string",
+                     }
+                  },
+                  "required": [
+                     "message"
+                  ],
+               }
             },
             "arguments": {
-               "url": "https://somesurvey.com/blah"
-            }
-         },
-         {
-            "name": "remove.bad.toolbar",
-            "implementation": {
-               "name": "check_for_bad_toolbar",
-               "hash": "4011cf569f3639b9069fc2c50117d3f8597e83c61be2014081ad06ee0fe427c2",
-               "url": "https://shield.mozilla.org/media/actions/check_for_bad_toolbar.js"
-            },
-            "arguments": {
-               "toolbar_name": "Shady Tim's Totally Legit Search"
+               "message": "It works!"
             }
          }
       ]
@@ -81,8 +93,8 @@ The API will respond with a JSON object:
 Retrieving an Action
 ^^^^^^^^^^^^^^^^^^^^
 The Self-Repair addon retrieves the code necessary to execute an action by
-making an HTTP GET to the URL provided in the ``implementation`` property of an
-action. The response is the JavaScript code for the requested action.
+making an HTTP GET to the URL provided in the ``implementation_url`` property
+of an action. The response is the JavaScript code for the requested action.
 
 Legacy Self-Repair
 ------------------
@@ -103,6 +115,6 @@ Which returns an HTML page roughly of the form:
          <meta charset="utf-8">
       </head>
       <body>
-         <script>/* Do something */</script>
+         <script>/* Code to retrieve and execute recipes and actions. */</script>
       </body>
    </html>


### PR DESCRIPTION
This updates the architecture docs to match what the dev server is currently doing and should help chartjes in his QA efforts.

@Osmose r?