### PR TITLE
Avoid data loss by always populating the arguments editor.

### DIFF
--- a/normandy/recipes/static/css/arguments_editor.css
+++ b/normandy/recipes/static/css/arguments_editor.css
@@ -39,3 +39,14 @@
 .arguments-editor .tabs span {
     margin-left: 5px;
 }
+
+/* The JSON editor modal hangs off the button, which is floated right.
+   It's absolutely positioned, so we set it's right edge to the button's
+   right edge to be able to see it.
+
+   We use !important because these are set as style attributes on the DOM
+   nodes in question in a place we can't easily override. */
+.arguments-editor .modal {
+    left: unset !important;
+    right: 0 !important;
+}

--- a/normandy/recipes/static/js/arguments_editor.js
+++ b/normandy/recipes/static/js/arguments_editor.js
@@ -42,12 +42,10 @@
                     theme: 'django'
                 });
 
-                // Only assign data if it validates.
-                // In the future we might be smarter about this.
+                // Assign data regardless of validation to avoid data
+                // loss.
                 var data = JSON.parse($argumentsJson.val());
-                if (!editor.validate(data).length) {
-                    editor.setValue(data);
-                }
+                editor.setValue(data);
             });
         });
     }
@@ -70,6 +68,12 @@
         getFormInputDescription: function(text) {
             var el = this._super(text);
             el.style.marginLeft = '5px';
+            return el;
+        },
+
+        getModal: function(text) {
+            var el = this._super(text);
+            el.classList.add('modal');
             return el;
         },
     });


### PR DESCRIPTION
If the argument schema changes for an existing recipe, validation
will fail and the argument editor will be blank. Instead, we want
to preserve the existing data and always populate the editor.

@mythmon r?