### PR TITLE
Add a link to the commit in the __version__ endpoint

### DIFF
--- a/normandy/health/api/views.py
+++ b/normandy/health/api/views.py
@@ -23,16 +23,20 @@ def get_commit():
             with open(path) as f:
                 _commit = f.read().strip()
         except OSError:
-            _commit = 'unknown'
+            _commit = None
 
     return _commit
 
 
 @api_view(['GET'])
 def version(request):
+    repo_url = 'https://github.com/mozilla/normandy'
+    commit = get_commit()
+
     return Response({
-        'source': 'https://github.com/mozilla/normandy',
-        'commit': get_commit(),
+        'source': repo_url,
+        'commit': commit,
+        'commit_link': '{0}/commit/{1}'.format(repo_url, commit) if commit else None,
     })
 
 

--- a/normandy/health/tests/test_api.py
+++ b/normandy/health/tests/test_api.py
@@ -13,6 +13,7 @@ def test_version(client, mocker):
     assert res.data == {
         'source': 'https://github.com/mozilla/normandy',
         'commit': '<git hash>',
+        'commit_link': 'https://github.com/mozilla/normandy/commit/<git hash>',
     }
 
 


### PR DESCRIPTION
I'm tired of copying and pasting the hash into GitHub to figure out what is deployed.

@rehandalal r?