### PR TITLE
[bug 1262889] Pass the request to the Client in the preview view.

### DIFF
--- a/normandy/base/api/mixins.py
+++ b/normandy/base/api/mixins.py
@@ -1,0 +1,24 @@
+from django.db import transaction
+
+from reversion import revisions as reversion
+
+
+class RevisionMixin(object):
+    """
+    ViewSet mixin that creates revisions when objects are created,
+    modified, or deleted.
+    """
+    @transaction.atomic()
+    @reversion.create_revision()
+    def create(self, *args, **kwargs):
+        return super().create(*args, **kwargs)
+
+    @transaction.atomic()
+    @reversion.create_revision()
+    def update(self, *args, **kwargs):
+        return super().update(*args, **kwargs)
+
+    @transaction.atomic()
+    @reversion.create_revision()
+    def delete(self, *args, **kwargs):
+        return super().delete(*args, **kwargs)

--- a/normandy/base/utils.py
+++ b/normandy/base/utils.py
@@ -1,4 +1,12 @@
+from datetime import datetime
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from django.utils import timezone
+
+
+def aware_datetime(*args, **kwargs):
+    """Return an aware datetime using Django's configured timezone."""
+    return timezone.make_aware(datetime(*args, **kwargs))
 
 
 def urlparams(url, fragment=None, **kwargs):

--- a/normandy/classifier/admin/forms.py
+++ b/normandy/classifier/admin/forms.py
@@ -8,6 +8,10 @@ from normandy.classifier.models import Client
 
 class ClientForm(forms.Form):
     """Form to specify client configurations for testing purposes."""
+    def __init__(self, *args, request=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.request = request
+
     locale = forms.ModelChoiceField(Locale.objects.all(), empty_label=None, to_field_name='code')
     release_channel = forms.ModelChoiceField(
         ReleaseChannel.objects.all(),
@@ -24,6 +28,7 @@ class ClientForm(forms.Form):
 
     def save(self):
         return Client(
+            request=self.request,
             locale=self.cleaned_data['locale'].code,
             country=self.cleaned_data['country'].code,
             request_time=self.cleaned_data.get('request_time', timezone.now()),

--- a/normandy/classifier/admin/views.py
+++ b/normandy/classifier/admin/views.py
@@ -8,7 +8,7 @@ from normandy.recipes.models import match_sample_rate
 
 @admin_site.register_view('classifier_preview', name='Classifier Preview')
 def classifier_preview(request):
-    form = ClientForm(request.GET or None)
+    form = ClientForm(request.GET or None, request=request)
     if form.is_valid():
         client = form.save()
         bundle = Bundle.for_client(client, exclude=[match_sample_rate])

--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -6,6 +6,7 @@ from rest_framework import generics, permissions, viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
+from normandy.base.api.mixins import RevisionMixin
 from normandy.base.api.permissions import AdminEnabled
 from normandy.base.api.renderers import JavaScriptRenderer
 from normandy.recipes.models import Action
@@ -13,7 +14,7 @@ from normandy.recipes.api.permissions import NotInUse
 from normandy.recipes.api.serializers import ActionSerializer
 
 
-class ActionViewSet(viewsets.ModelViewSet):
+class ActionViewSet(RevisionMixin, viewsets.ModelViewSet):
     """Viewset for viewing and uploading recipe actions."""
     queryset = Action.objects.all()
     serializer_class = ActionSerializer

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -2,6 +2,7 @@ import hashlib
 
 import pytest
 from rest_framework.reverse import reverse
+from reversion import revisions as reversion
 
 from normandy.base.api.permissions import AdminEnabled
 from normandy.base.tests import Whatever
@@ -142,6 +143,24 @@ class TestActionAPI(object):
         res = api_client.get('/api/v1/action/')
         assert res.status_code == 403
         assert res.data['detail'] == AdminEnabled.message
+
+    def test_it_creates_revisions(self, api_client):
+        res = api_client.post('/api/v1/action/', {
+            'name': 'foo',
+            'implementation': 'foobar',
+            'arguments_schema': {'type': 'object'},
+        })
+        assert res.status_code == 201
+
+        action = Action.objects.all()[0]
+        assert len(reversion.get_for_object(action)) == 1
+
+        res = api_client.patch('/api/v1/action/foo/', {'implementation': 'changed'})
+        assert res.status_code == 200
+        assert len(reversion.get_for_object(action)) == 2
+
+        res = api_client.delete('/api/v1/action/foo/')
+        assert len(reversion.get_deleted(Action)) == 1
 
 
 @pytest.mark.django_db

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -46,8 +46,6 @@ class Core(Configuration):
         'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-        'reversion.middleware.RevisionMiddleware',
     ]
 
     ROOT_URLCONF = 'normandy.urls'


### PR DESCRIPTION
@rehandalal r?

The bug here was that `Bundle.for_client` was attempting to match a recipe with a start and end time to a client object that didn't have a `request`. Thus, when it tried to access `request.received_at` to figure out when the request was received, it found a `None` value. The fix passes the request from the view into the form that builds the client.