### PR TITLE
[fix bug 1262617] Replace RevisionMiddleware with decorators.

### DIFF
--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -1,10 +1,12 @@
 from django.conf import settings
+from django.db import transaction
 from django.http import Http404
 from django.views.decorators.cache import cache_control
 
 from rest_framework import generics, permissions, viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
+from reversion import revisions as reversion
 
 from normandy.base.api.permissions import AdminEnabled
 from normandy.base.api.renderers import JavaScriptRenderer
@@ -26,6 +28,13 @@ class ActionViewSet(viewsets.ModelViewSet):
     lookup_field = 'name'
     lookup_value_regex = r'[_\-\w]+'
 
+    @transaction.atomic()
+    @reversion.create_revision()
+    def create(self, *args, **kwargs):
+        return super().create(*args, **kwargs)
+
+    @transaction.atomic()
+    @reversion.create_revision()
     def update(self, request, *args, **kwargs):
         """
         Intercept PUT requests and have them create instead of update

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -46,8 +46,6 @@ class Core(Configuration):
         'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-        'reversion.middleware.RevisionMiddleware',
     ]
 
     ROOT_URLCONF = 'normandy.urls'


### PR DESCRIPTION
RevisionMiddleware automatically creates revisions when things
change. However, viewing the revert page in the admin interface
triggers a revert (in order to generate the preview data before
actually reverting) within a transaction, and then rolls back the
transaction. But, as far as I can tell, django-reversion doesn't
handle transaction rollback and saves the revision from the revert
anyway.

Removing the middleware fixes this, but we still have to manually
trigger revision creation outside the admin. This commit adds a
ViewSet mixin that triggers revision creation for DRF views.

@mythmon r?