### PR TITLE
[bug 1262889] Pass the request to the Client in the preview view.

### DIFF
--- a/normandy/base/utils.py
+++ b/normandy/base/utils.py
@@ -1,4 +1,12 @@
+from datetime import datetime
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from django.utils import timezone
+
+
+def aware_datetime(*args, **kwargs):
+    """Return an aware datetime using Django's configured timezone."""
+    return timezone.make_aware(datetime(*args, **kwargs))
 
 
 def urlparams(url, fragment=None, **kwargs):

--- a/normandy/classifier/admin/forms.py
+++ b/normandy/classifier/admin/forms.py
@@ -8,6 +8,10 @@ from normandy.classifier.models import Client
 
 class ClientForm(forms.Form):
     """Form to specify client configurations for testing purposes."""
+    def __init__(self, *args, request=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.request = request
+
     locale = forms.ModelChoiceField(Locale.objects.all(), empty_label=None, to_field_name='code')
     release_channel = forms.ModelChoiceField(
         ReleaseChannel.objects.all(),
@@ -24,6 +28,7 @@ class ClientForm(forms.Form):
 
     def save(self):
         return Client(
+            request=self.request,
             locale=self.cleaned_data['locale'].code,
             country=self.cleaned_data['country'].code,
             request_time=self.cleaned_data.get('request_time', timezone.now()),

--- a/normandy/classifier/admin/views.py
+++ b/normandy/classifier/admin/views.py
@@ -8,7 +8,7 @@ from normandy.recipes.models import match_sample_rate
 
 @admin_site.register_view('classifier_preview', name='Classifier Preview')
 def classifier_preview(request):
-    form = ClientForm(request.GET or None)
+    form = ClientForm(request.GET or None, request=request)
     if form.is_valid():
         client = form.save()
         bundle = Bundle.for_client(client, exclude=[match_sample_rate])


### PR DESCRIPTION
@rehandalal r?

The bug here was that `Bundle.for_client` was attempting to match a recipe with a start and end time to a client object that didn't have a `request`. Thus, when it tried to access `request.received_at` to figure out when the request was received, it found a `None` value. The fix passes the request from the view into the form that builds the client.