### PR TITLE
[bug 1264386] Add plugin data to the client object.

### DIFF
--- a/normandy/selfrepair/static/js/normandy_driver.js
+++ b/normandy/selfrepair/static/js/normandy_driver.js
@@ -68,7 +68,19 @@ let Normandy = {
 
     client() {
         return new Promise(resolve => {
-            let client = {};
+            let client = {
+                plugins: {}
+            };
+
+            // Populate plugin info.
+            for (let plugin of navigator.plugins) {
+                client.plugins[plugin.name] = {
+                    name: plugin.name,
+                    filename: plugin.filename,
+                    description: plugin.description,
+                    version: plugin.version,
+                }
+            }
 
             // Keys are UITour configs, functions are given the data
             // returned by UITour for that config.


### PR DESCRIPTION
Adds the `plugin` attribute as described in https://github.com/mozilla/normandy-actions/pull/10.

@mythmon r?