### PR TITLE
Use git to get current commit, instead of being clever

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.5.1-slim
 WORKDIR /app
 RUN groupadd --gid 1001 app && useradd -g app --uid 1001 --shell /usr/sbin/nologin app
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc libpq-dev curl apt-transport-https libffi-dev
+    gcc libpq-dev curl apt-transport-https libffi-dev git
 
 # Install node from NodeSource
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
@@ -17,8 +17,7 @@ COPY . /app
 RUN DJANGO_CONFIGURATION=Build ./manage.py collectstatic --no-input && \
     mkdir -p media && chown app:app media && \
     mkdir -p __version__ && \
-    # Get the current git commit. Done by hand to avoid installing Git.
-    cat .git/$(cat .git/HEAD | awk '{print $2}') > __version__/commit && \
+    git rev-parse HEAD > __version__/commit && \
     rm -rf .git
 
 USER app


### PR DESCRIPTION
It seems something changed about how Circle gets the code from GitHub for the master builds. Instead of trying to increase the cleverness I was using to get the current git commit without using git, this just installs git and uses it. This make a bigger image, which slows down CI and deploys, but it should be more reliable.

@Osmose r?