### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.cache
+.env*
+.floo*
+docs/_build
+GeoLite2-Country.mmdb
+media
+node_modules
+pip-cache
+site-packages
+venv
+webpack-stats.json


### PR DESCRIPTION
This prevents these files from being copied into Docker images. This makes building them faster, since there is less to copy, and avoids problems with mismatched versions of Node, Python etc.

r?