### PR TITLE
Make `npm start` run webpack in watch mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git://github.com/mozilla/normandy.git"
   },
+  "scripts": {
+    "start": "webpack --config ./webpack.config.js --watch"
+  },
   "license": "MPL-2.0",
   "dependencies": {
     "babel-polyfill": "^6.7.2",


### PR DESCRIPTION
I got tired of calling webpack from `node_modules`.

@brittanystoroz r?