### PR TITLE
[Bug 1271272] Recipe history

### DIFF
--- a/normandy/control/static/control/admin/sass/control.scss
+++ b/normandy/control/static/control/admin/sass/control.scss
@@ -182,6 +182,28 @@
 }
 
 
+/* Recipe History */
+li {
+  p {
+    display: inline-block;
+    line-height: 20px;
+    margin: 0px 20px;
+    vertical-align: top;
+
+    &.revision-number {
+      font-weight: 600;
+    }
+  }
+
+  span {
+
+    &.label {
+      padding: 0px;
+    }
+  }
+}
+
+
 /* Login Page */
 .login {
   padding: 100px 0px;

--- a/normandy/control/static/control/admin/sass/partials/_colors.scss
+++ b/normandy/control/static/control/admin/sass/partials/_colors.scss
@@ -12,6 +12,8 @@ $green: #6DBA6D;
 $greenHover: #71D571;
 $red: #EC5858;
 $redHover: #FF5151;
+$yellow: #F8F8C3;
+
 
 .red { color: $red; }
 .green { color: $green; }

--- a/normandy/control/static/control/admin/sass/partials/_common.scss
+++ b/normandy/control/static/control/admin/sass/partials/_common.scss
@@ -175,3 +175,20 @@ i {
   &.pre { margin-right: 5px; }
   &.post { margin-left: 5px; }
 }
+
+
+/* Notifications */
+.notification {
+  border: 1px solid;
+  border-radius: 3px;
+  font-size: 12px;
+  line-height: 30px;
+  margin: 5px 0px;
+  padding: 5px 15px;
+}
+
+.info {
+  background-color: $yellow;
+  border-color: rgba(0,0,0,0.15);
+  color: rgba(0,0,0,0.5);
+}

--- a/normandy/control/static/control/admin/sass/partials/_common.scss
+++ b/normandy/control/static/control/admin/sass/partials/_common.scss
@@ -23,7 +23,7 @@ a:hover {
 
 
 /* Form Elements */
-label {
+label, .label {
   color: rgba($darkBrown, 0.6);
   display: block;
   font: normal normal 400 12px/16px $OpenSans;
@@ -148,6 +148,22 @@ td {
 
 tbody {
   tr:hover {
+    background: rgba(26, 183, 218, 0.1);
+    cursor: pointer;
+  }
+}
+
+
+/* Unordered List */
+li {
+  list-style-type: none;
+  padding: 25px;
+
+  &:nth-child(even) {
+    background: rgba($cream, 0.5);
+  }
+
+  &:hover {
     background: rgba(26, 183, 218, 0.1);
     cursor: pointer;
   }

--- a/normandy/control/static/control/js/actions/ControlActions.js
+++ b/normandy/control/static/control/js/actions/ControlActions.js
@@ -47,6 +47,16 @@ const apiRequestMap = {
     };
   },
 
+  fetchSingleRevision(recipeInfo) {
+    return {
+      url: `/api/v1/recipe_version/${recipeInfo.revisionId}/`,
+      settings: {
+        method: 'get'
+      },
+      actionOnSuccess: singleRevisionReceived
+    }
+  },
+
   addRecipe(recipeInfo) {
     return {
       url: BASE_API_URL,
@@ -106,6 +116,13 @@ function singleRecipeReceived(recipe) {
   return {
     type: SINGLE_RECIPE_RECEIVED,
     recipe
+  };
+}
+
+function singleRevisionReceived(revision) {
+  return {
+    type: SINGLE_RECIPE_RECEIVED,
+    recipe: revision.recipe
   };
 }
 

--- a/normandy/control/static/control/js/components/RecipeContainer.jsx
+++ b/normandy/control/static/control/js/components/RecipeContainer.jsx
@@ -12,10 +12,15 @@ export default function composeRecipeContainer(Component) {
     }
 
     getRecipeData(recipeId) {
-      const { dispatch } = this.props;
-      if (!this.props.recipe) {
+      const { dispatch, location, recipe } = this.props;
+      if (!recipe) {
         dispatch(ControlActions.setSelectedRecipe(recipeId));
-        dispatch(ControlActions.makeApiRequest('fetchSingleRecipe', { recipeId: recipeId }));
+
+        if (location.query.revisionId) {
+          dispatch(ControlActions.makeApiRequest('fetchSingleRevision', { revisionId: location.query.revisionId }));
+        } else {
+          dispatch(ControlActions.makeApiRequest('fetchSingleRecipe', { recipeId: recipeId }));
+        }
       }
     }
 

--- a/normandy/control/static/control/js/components/RecipeContainer.jsx
+++ b/normandy/control/static/control/js/components/RecipeContainer.jsx
@@ -13,7 +13,7 @@ export default function composeRecipeContainer(Component) {
 
     getRecipeData(recipeId) {
       const { dispatch } = this.props;
-      if (!this.props.recipes) {
+      if (!this.props.recipe) {
         dispatch(ControlActions.setSelectedRecipe(recipeId));
         dispatch(ControlActions.makeApiRequest('fetchSingleRecipe', { recipeId: recipeId }));
       }

--- a/normandy/control/static/control/js/components/RecipeForm.jsx
+++ b/normandy/control/static/control/js/components/RecipeForm.jsx
@@ -61,8 +61,12 @@ RecipeForm.propTypes = {
 export default composeRecipeContainer(reduxForm({
     form: 'recipe',
     fields: ['name', 'filter_expression']
-  }, (state, props) => ({
-    initialValues: ((props.location.state) ? props.location.state.selectedRevision : props.recipe),
-    viewingRevision: ((props.location.state && props.location.state.selectedRevision))
-  })
+  }, (state, props) => {
+    let selectedRecipeRevision = (props.location.state) ? props.location.state.selectedRevision : null;
+
+    return {
+      initialValues: selectedRecipeRevision || props.recipe,
+      viewingRevision: ((selectedRecipeRevision || props.location.query.revisionId) ? true : false)
+    }
+  }
 )(RecipeForm))

--- a/normandy/control/static/control/js/components/RecipeForm.jsx
+++ b/normandy/control/static/control/js/components/RecipeForm.jsx
@@ -22,11 +22,14 @@ class RecipeForm extends React.Component {
 
   render() {
     const { fields: { name, filter_expression }, recipeId, handleSubmit, viewingRevision } = this.props;
-    const notification = (viewingRevision) ? `You are viewing a revision of this recipe.` : '';
 
     return (
       <form onSubmit={handleSubmit(this.submitForm)} className="crud-form">
-        <p className="notification info">{notification}</p>
+        { viewingRevision ?
+          <p className="notification info">
+            You are viewing a past version of this recipe. Saving this form will rollback the recipe to this revision.
+          </p> : ''
+        }
         <div className="row">
           <div className="fluid-3">
             <label>Name</label>

--- a/normandy/control/static/control/js/components/RecipeForm.jsx
+++ b/normandy/control/static/control/js/components/RecipeForm.jsx
@@ -21,9 +21,12 @@ class RecipeForm extends React.Component {
   }
 
   render() {
-    const { fields: { name, filter_expression }, recipeId, handleSubmit } = this.props;
+    const { fields: { name, filter_expression }, recipeId, handleSubmit, viewingRevision } = this.props;
+    const notification = (viewingRevision) ? `You are viewing a revision of this recipe.` : '';
+
     return (
       <form onSubmit={handleSubmit(this.submitForm)} className="crud-form">
+        <p className="notification info">{notification}</p>
         <div className="row">
           <div className="fluid-3">
             <label>Name</label>
@@ -55,7 +58,8 @@ RecipeForm.propTypes = {
 export default composeRecipeContainer(reduxForm({
     form: 'recipe',
     fields: ['name', 'filter_expression']
-  }, (state, props) => ({ // mapStateToProps
-    initialValues: (props.recipe || null)
+  }, (state, props) => ({
+    initialValues: ((props.location.state) ? props.location.state.selectedRevision : props.recipe),
+    viewingRevision: ((props.location.state && props.location.state.selectedRevision))
   })
 )(RecipeForm))

--- a/normandy/control/static/control/js/components/RecipeHistory.jsx
+++ b/normandy/control/static/control/js/components/RecipeHistory.jsx
@@ -41,7 +41,7 @@ class RecipeHistory extends React.Component {
                     dispatch(push({
                       pathname: `/control/recipe/${recipeId}/`,
                       query: {
-                        revisionId: `${revision.recipe.revision_id}`
+                        revisionId: `${revision.id}`
                       },
                       state: {
                         selectedRevision: revision.recipe

--- a/normandy/control/static/control/js/components/RecipeHistory.jsx
+++ b/normandy/control/static/control/js/components/RecipeHistory.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { push } from 'react-router-redux'
+import moment from 'moment'
+import composeRecipeContainer from './RecipeContainer.jsx'
+import apiFetch from '../utils/apiFetch.js';
+
+class RecipeHistory extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      revisionLog: []
+    }
+    this.getHistory = this.getHistory.bind(this);
+  }
+
+  getHistory(recipeId) {
+    apiFetch(`/api/v1/recipe/${recipeId}/history/`)
+      .then(response => {
+        this.setState({
+          revisionLog: response
+        })
+      });
+  }
+
+  componentDidMount() {
+    const { recipeId } = this.props;
+    this.getHistory(recipeId);
+  }
+
+  render() {
+    const { revisionLog } = this.state;
+    const { recipeId, recipe, dispatch } = this.props;
+    return (
+      <div className="fluid-8">
+        <h3>Viewing revision log for: <b>{recipe ? recipe.name : ''}</b></h3>
+        <ul>
+            {
+              this.state.revisionLog.map(revision => {
+                return (
+                  <li key={revision.date_created} onClick={(e) => {
+                    dispatch(push({
+                      pathname: `/control/recipe/${recipeId}/`,
+                      query: {
+                        revisionId: `${revision.recipe.revision_id}`
+                      },
+                      state: {
+                        selectedRevision: revision.recipe
+                      }
+                    }))
+                  }}><p className="revision-number">#{revision.recipe.revision_id} </p>
+                    <p><span className="label">Created On:</span>{ moment(revision.date_created).format('MMM Do YYYY - h:mmA') }</p>
+                  </li>)
+              })
+            }
+        </ul>
+      </div>
+    )
+  }
+}
+
+export default composeRecipeContainer(RecipeHistory);

--- a/normandy/control/static/control/js/components/RecipeHistory.jsx
+++ b/normandy/control/static/control/js/components/RecipeHistory.jsx
@@ -17,7 +17,7 @@ class RecipeHistory extends React.Component {
     apiFetch(`/api/v1/recipe/${recipeId}/history/`)
       .then(response => {
         this.setState({
-          revisionLog: response
+          revisionLog: response.reverse()
         })
       });
   }

--- a/normandy/control/static/control/js/routes.js
+++ b/normandy/control/static/control/js/routes.js
@@ -3,6 +3,7 @@ import { Route } from 'react-router';
 import ControlApp from './components/ControlApp.jsx';
 import RecipeList from './components/RecipeList.jsx';
 import RecipeForm from './components/RecipeForm.jsx';
+import RecipeHistory from './components/RecipeHistory.jsx';
 import RecipePreview from './components/RecipePreview.jsx';
 import DeleteRecipe from './components/DeleteRecipe.jsx';
 
@@ -29,6 +30,10 @@ export default (
     <Route path='control/recipe/:id/preview/'
       component={RecipePreview}
       pageTitle="Preview Recipe"
+    />
+    <Route path='control/recipe/:id/history/'
+      component={RecipeHistory}
+      pageTitle="History"
     />
     <Route
       path='control/recipe/:id/delete/'

--- a/normandy/control/tests/actions/controlActions.js
+++ b/normandy/control/tests/actions/controlActions.js
@@ -11,6 +11,26 @@ const fixtureRecipes = [
   { "id": 3, "name": "Consequitar adipscing", "enabled": false }
 ];
 
+const fixtureRevisions = [
+  {
+    "id": 169,
+    "date_created": "2016-05-13T17:20:35.698735Z",
+    "recipe": {
+        "id": 36,
+        "name": "Consequestar",
+        "enabled": true,
+        "revision_id": 22,
+        "action_name": "console-log",
+        "arguments": {
+            "message": "hi there message here"
+        },
+        "filter_expression": "()",
+        "approver": null,
+        "is_approved": false
+    }
+  }
+]
+
 const initialState = {
     recipes: null,
     isFetching: false,
@@ -85,7 +105,7 @@ describe('controlApp Actions', () => {
     expect(store.getActions()).toEqual([]);
   });
 
-  it('creates SINGLE_RECIPE_RECEIVED when fetching a single recipes is successful', () => {
+  it('creates SINGLE_RECIPE_RECEIVED when fetching a single recipe is successful', () => {
     const expectedAction = { type: actions.SINGLE_RECIPE_RECEIVED, recipe: fixtureRecipes[0] };
     spyOn(window, 'fetch').and.returnValue(successPromise(fixtureRecipes[0]));
 
@@ -93,6 +113,18 @@ describe('controlApp Actions', () => {
       .then(() => {
         expect(window.fetch).toHaveBeenCalled();
         expect(window.fetch).toHaveBeenCalledWith('/api/v1/recipe/1/?format=json&', jasmine.any(Object));
+        expect(store.getActions()).toContain(expectedAction);
+      })
+  });
+
+  it('creates SINGLE_RECIPE_RECEIVED when fetching a single revision is successful', () => {
+    const expectedAction = { type: actions.SINGLE_RECIPE_RECEIVED, recipe: fixtureRevisions[0].recipe };
+    spyOn(window, 'fetch').and.returnValue(successPromise(fixtureRevisions[0]));
+
+    return store.dispatch(actions.makeApiRequest('fetchSingleRevision', { revisionId: 169 }))
+      .then(() => {
+        expect(window.fetch).toHaveBeenCalled();
+        expect(window.fetch).toHaveBeenCalledWith('/api/v1/recipe_version/1/?format=json&', jasmine.any(Object));
         expect(store.getActions()).toContain(expectedAction);
       })
   });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jexl": "^1.1.3",
     "jquery": "^2.2.3",
     "json-editor": "^0.7.23",
+    "moment": "^2.13.0",
     "node-sass": "^3.4.2",
     "node-uuid": "^1.4.7",
     "react": "^15.0.2",


### PR DESCRIPTION
Adds a history route & component for viewing a recipe's revisions.

The history page is kind of sparse right now, but I think it might make sense to integrate some of the approval stuff here, which will fill it out a bit more. Thoughts on that tk.

I added some rough notification text to the recipe form page to let users know they are viewing a revision rather than the current state of the recipe. This should eventually be broken out into a separate notification component so we can do more with it (e.g. handle api response error/success messages) but I think that should be saved for another PR. 

@rehandalal  r?