### PR TITLE
Accept lower case booleans in recipes API filters.

### DIFF
--- a/normandy/base/api/filters.py
+++ b/normandy/base/api/filters.py
@@ -1,0 +1,17 @@
+import django_filters
+
+
+class CaseInsensitiveBooleanFilter(django_filters.Filter):
+    # The default django_filters boolean filter *only* accepts True and False
+    # which is problematic when dealing with non-Python clients. This allows
+    # the lower case variants, as well as 0 and 1.
+
+    def filter(self, qs, value):
+        if value is not None:
+            lc_value = value.lower()
+            if lc_value in ['true', '1']:
+                value = True
+            if lc_value in ['false', '0']:
+                value = False
+            return qs.filter(**{self.name: value})
+        return qs

--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.views.decorators.cache import cache_control
 
+import django_filters
 from rest_framework import generics, permissions, status, views, viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import NotFound
@@ -9,6 +10,7 @@ from rest_framework.response import Response
 from reversion.models import Version
 
 from normandy.base.api import UpdateOrCreateModelViewSet
+from normandy.base.api.filters import CaseInsensitiveBooleanFilter
 from normandy.base.api.permissions import AdminEnabledOrReadOnly
 from normandy.base.api.renderers import JavaScriptRenderer
 from normandy.base.decorators import reversion_transaction
@@ -66,11 +68,19 @@ class ActionImplementationView(generics.RetrieveAPIView):
         return Response(action.implementation)
 
 
+class RecipeFilters(django_filters.FilterSet):
+    enabled = CaseInsensitiveBooleanFilter(name='enabled', lookup_type='eq')
+
+    class Meta:
+        model = Recipe
+        fields = ['action', 'enabled']
+
+
 class RecipeViewSet(UpdateOrCreateModelViewSet):
     """Viewset for viewing and uploading recipes."""
     queryset = Recipe.objects.all()
     serializer_class = RecipeSerializer
-    filter_fields = ('action', 'enabled')
+    filter_class = RecipeFilters
     permission_classes = [
         permissions.DjangoModelPermissionsOrAnonReadOnly,
         AdminEnabledOrReadOnly,

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -358,6 +358,14 @@ class TestRecipeAPI(object):
         assert res.data[0]['id'] == ar2.id
         assert res.data[1]['id'] == ar1.id
 
+    def test_filtering_by_enabled_lowercase(self, api_client):
+        r1 = RecipeFactory(enabled=True)
+        RecipeFactory(enabled=False)
+
+        res = api_client.get('/api/v1/recipe/?enabled=true')
+        assert res.status_code == 200
+        assert [r['id'] for r in res.data] == [r1.id]
+
 
 @pytest.mark.django_db
 class TestRecipeVersionAPI(object):


### PR DESCRIPTION
I was having the hardest time getting the addon to filter this, because I was using `?enabled=true`.

@rehandalal r?