### PR TITLE
Don't show revision notification if clicking first history record

### DIFF
--- a/normandy/control/static/control/js/components/RecipeHistory.jsx
+++ b/normandy/control/static/control/js/components/RecipeHistory.jsx
@@ -35,17 +35,19 @@ class RecipeHistory extends React.Component {
         <h3>Viewing revision log for: <b>{recipe ? recipe.name : ''}</b></h3>
         <ul>
             {
-              this.state.revisionLog.map(revision => {
+              this.state.revisionLog.map((revision, index) => {
                 return (
                   <li key={revision.date_created} onClick={(e) => {
+                    let revisionInfo = {};
+                    if (index !== 0) {
+                      revisionInfo = {
+                        query: { revisionId: `${revision.id}` },
+                        state: { selectedRevision: revision.recipe }
+                      }
+                    }
                     dispatch(push({
                       pathname: `/control/recipe/${recipeId}/`,
-                      query: {
-                        revisionId: `${revision.id}`
-                      },
-                      state: {
-                        selectedRevision: revision.recipe
-                      }
+                      ...revisionInfo
                     }))
                   }}><p className="revision-number">#{revision.recipe.revision_id} </p>
                     <p><span className="label">Created On:</span>{ moment(revision.date_created).format('MMM Do YYYY - h:mmA') }</p>


### PR DESCRIPTION
Quick fix on the recipe history stuff. The top record listed in the RecipeHistory component is always the current recipe, not an outdated revision. If a user clicks on this record, it should bring you to the edit page for the recipe and not display a notification that you are viewing an older version. 