### PR TITLE
Fixed show-heartbeat action's handling of telemetry data

### DIFF
--- a/docs/dev/driver.rst
+++ b/docs/dev/driver.rst
@@ -55,7 +55,7 @@ The driver object contains the following attributes:
    :param learnMoreUrl: URL to open when the "Learn More" button is clicked.
    :param surveyId: Extra data to be stored in telemetry.
    :param surveyVersion: Extra data to be stored in telemetry.
-   :param testing: Extra data to be stored in telemetry when Normandy is in testing.
+   :param testing: Extra data to be stored in telemetry when Normandy is in testing mode.
    :returns: A Promise that resolves with an event emitter.
 
    The emitter returned by this function can be subscribed to using ``on``

--- a/docs/dev/driver.rst
+++ b/docs/dev/driver.rst
@@ -53,9 +53,9 @@ The driver object contains the following attributes:
       the user won't be shown anything.
    :param learnMoreMessage: Text to show on the "Learn More" button.
    :param learnMoreUrl: URL to open when the "Learn More" button is clicked.
-   :param extraTelemetryArgs: Object containing extra arguments to send to
-      telemetry associated with this heartbeat call. Defaults to an empty
-      object.
+   :param surveyId: Extra data to be stored in telemetry.
+   :param surveyVersion: Extra data to be stored in telemetry.
+   :param testing: Extra data to be stored in telemetry when Normandy is in testing.
    :returns: A Promise that resolves with an event emitter.
 
    The emitter returned by this function can be subscribed to using ``on``

--- a/normandy/recipes/static/actions/show-heartbeat/index.js
+++ b/normandy/recipes/static/actions/show-heartbeat/index.js
@@ -116,17 +116,12 @@ export default class ShowHeartbeatAction extends Action {
         let flow = new HeartbeatFlow(this);
         flow.save();
 
-        let extraTelemetryArgs = {
-            surveyId: surveyId,
-            surveyVersion: this.recipe.revision_id,
-        };
-        if (this.normandy.testing) {
-            extraTelemetryArgs.testing = 1;
-        }
-
+        // Object declared for showHeartbeat call below, so that optional
+        //telemetry arg can be added if necessary
         // A bit redundant but the action argument names shouldn't necessarily rely
         // on the argument names showHeartbeat takes.
-        let heartbeat = await this.normandy.showHeartbeat({
+
+        var heartbeatData = {
             message: this.survey.message,
             engagementButtonLabel: this.survey.engagementButtonLabel,
             thanksMessage: this.survey.thanksMessage,
@@ -134,8 +129,15 @@ export default class ShowHeartbeatAction extends Action {
             postAnswerUrl: await this.annotatePostAnswerUrl(this.survey.postAnswerUrl),
             learnMoreMessage: this.survey.learnMoreMessage,
             learnMoreUrl: this.survey.learnMoreUrl,
-            extraTelemetryArgs: extraTelemetryArgs,
-        });
+            surveyId: surveyId,
+            surveyVersion: this.recipe.revision_id
+        };
+
+        if (this.normandy.testing) {
+            heartbeatData.testing = 1;
+        }
+
+        let heartbeat = await this.normandy.showHeartbeat(heartbeatData);
 
         heartbeat.on('NotificationOffered', data => {
             flow.setPhaseTimestamp('offered', data.timestamp);

--- a/normandy/recipes/static/actions/show-heartbeat/index.js
+++ b/normandy/recipes/static/actions/show-heartbeat/index.js
@@ -116,8 +116,6 @@ export default class ShowHeartbeatAction extends Action {
         let flow = new HeartbeatFlow(this);
         flow.save();
 
-        // Object declared for showHeartbeat call below, so that optional
-        //telemetry arg can be added if necessary
         // A bit redundant but the action argument names shouldn't necessarily rely
         // on the argument names showHeartbeat takes.
 

--- a/normandy/recipes/tests/actions/show-heartbeat.js
+++ b/normandy/recipes/tests/actions/show-heartbeat.js
@@ -170,14 +170,12 @@ describe('ShowHeartbeatAction', function() {
 
         await action.execute();
         expect(this.normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
-            extraTelemetryArgs: {
-                surveyId: 'my-survey',
-                surveyVersion: 42,
-            },
+            surveyId: 'my-survey',
+            surveyVersion: 42,
         }));
     });
 
-    it('should include a testing argument in extraTelemetryArgs when in testing mode', async function() {
+    it('should include a testing argument when in testing mode', async function() {
         let recipe = recipeFactory({revision_id: 42});
         recipe.arguments.surveyId = 'my-survey';
         let action = new ShowHeartbeatAction(this.normandy, recipe);
@@ -186,11 +184,9 @@ describe('ShowHeartbeatAction', function() {
 
         await action.execute();
         expect(this.normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
-            extraTelemetryArgs: {
-                surveyId: 'my-survey',
-                surveyVersion: 42,
-                testing: 1,
-            },
+            surveyId: 'my-survey',
+            surveyVersion: 42,
+            testing: 1,
         }));
     });
 

--- a/normandy/recipes/tests/actions/show-heartbeat.js
+++ b/normandy/recipes/tests/actions/show-heartbeat.js
@@ -184,9 +184,7 @@ describe('ShowHeartbeatAction', function() {
 
         await action.execute();
         expect(this.normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
-            surveyId: 'my-survey',
-            surveyVersion: 42,
-            testing: 1,
+            testing: 1
         }));
     });
 

--- a/normandy/selfrepair/static/js/normandy_driver.js
+++ b/normandy/selfrepair/static/js/normandy_driver.js
@@ -153,7 +153,9 @@ let Normandy = {
                 options.postAnswerUrl,
                 options.learnMoreMessage,
                 options.learnMoreUrl,
-                options
+                options.surveyId,
+                options.surveyVersion,
+                options.testing
             );
 
             resolve(emitter);

--- a/normandy/selfrepair/static/js/normandy_driver.js
+++ b/normandy/selfrepair/static/js/normandy_driver.js
@@ -153,9 +153,11 @@ let Normandy = {
                 options.postAnswerUrl,
                 options.learnMoreMessage,
                 options.learnMoreUrl,
-                options.surveyId,
-                options.surveyVersion,
-                options.testing
+                {
+                    surveyId: options.surveyId,
+                    surveyVersion: options.surveyVersion,
+                    testing: options.testing
+                }
             );
 
             resolve(emitter);


### PR DESCRIPTION
Updated the driver to take `surveyId`, `surveyVersion`, and `testing` as options rather than
bundled in a single object option. Updated index.js to pass these options on directly to the
UITour.showHeartbeat call in the options object. Updated documentation to reflect this.

fixes bug 1277700