### PR TITLE
Add notification bar for handling form submissions

### DIFF
--- a/normandy/control/static/control/admin/sass/partials/_common.scss
+++ b/normandy/control/static/control/admin/sass/partials/_common.scss
@@ -178,17 +178,57 @@ i {
 
 
 /* Notifications */
-.notification {
-  border: 1px solid;
-  border-radius: 3px;
-  font-size: 12px;
-  line-height: 30px;
-  margin: 5px 0px;
-  padding: 5px 15px;
+#notification-bar {
+  transition: top 0.25s;
+  background-color: #fff;
+  left: 40px;
+  position: fixed;
+  right: 40px;
+  top: -55px;
+  z-index: 1;
+
+  &.active {
+    top: 2px;
+  }
 }
 
-.info {
-  background-color: $yellow;
-  border-color: rgba(0,0,0,0.15);
-  color: rgba(0,0,0,0.5);
+p.notification {
+  color: rgba(0,0,0,0.6);
+  font-size: 12px;
+  line-height: 22px;
+  padding: 15px 30px;
+  position: relative;
+  text-indent: 20px;
+
+  &::before {
+    font: normal normal 400 14px/1 FontAwesome;
+    left: 10px;
+    opacity: 0.75;
+    position: absolute;
+    top: 36%;
+  }
+
+  &.success {
+    background-color: rgba($green, 0.75);
+    &::before {  content: "\f00c"; }
+  }
+
+  &.error {
+    background-color: rgba($red, 0.75);
+    &::before {  content: "\f12a"; }
+  }
+
+  &.info {
+    background-color: rgba($yellow, 0.75);
+    &::before {  content: "\f129"; }
+  }
+
+  i.remove-message {
+    float: right;
+    padding: 5px;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
 }

--- a/normandy/control/static/control/admin/sass/partials/_common.scss
+++ b/normandy/control/static/control/admin/sass/partials/_common.scss
@@ -179,7 +179,6 @@ i {
 
 /* Notifications */
 #notification-bar {
-  transition: top 0.25s;
   background-color: #fff;
   left: 40px;
   position: fixed;
@@ -188,8 +187,18 @@ i {
   z-index: 1;
 
   &.active {
+    animation-name: notification-bar;
+    animation-duration: 10s;
+    animation-fill-mode: forwards;
     top: 2px;
   }
+}
+
+@keyframes notification-bar {
+    0%   { top: -55px;}
+    2%  { top: 2px; }
+    98%  { top: 2px; }
+    100% { top: -55px;}
 }
 
 p.notification {

--- a/normandy/control/static/control/js/components/ControlApp.jsx
+++ b/normandy/control/static/control/js/components/ControlApp.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import Header from './Header.jsx'
+import NotificationBar from './NotificationBar.jsx'
 
 export default class ControlApp extends React.Component {
   render() {
     return (
       <div>
+        <NotificationBar />
         <Header pageType={this.props.children.props.route} currentLocation={this.props.location.pathname} />
         <div id="content" className="wrapper">
           <div className="fluid-8">

--- a/normandy/control/static/control/js/components/NotificationBar.jsx
+++ b/normandy/control/static/control/js/components/NotificationBar.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { setNotification } from '../actions/ControlActions.js'
+import classNames from 'classnames'
+
+class NotificationBar extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      isVisible: false
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.notification) {
+      this.setState({
+        isVisible: true
+      });
+      this.setVisibilityTimer();
+    }
+  }
+
+  setVisibilityTimer() {
+    this.visibilityTimer !== null ? clearTimeout(this.visibilityTimer) : null;
+
+    this.visibilityTimer = setTimeout(() => {
+      this.setState({
+        isVisible: false
+      })
+    }, 10000);
+  }
+
+  hideNotificationBar() {
+    this.setState({
+      isVisible: false
+    });
+    clearTimeout(this.visibilityTimer);
+  }
+
+  render() {
+    const { notification, dispatch } = this.props;
+    return (
+      <div id="notification-bar" className={classNames({ 'active': this.state.isVisible })}>
+        { notification &&
+          <p className={classNames('notification', notification.messageType)}>
+            { notification.message }
+            <i className="fa fa-lg fa-times remove-message" onClick={::this.hideNotificationBar}></i>
+          </p>
+        }
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = (state) => {
+  return { notification: state.controlApp.notification }
+}
+
+export default connect(
+  mapStateToProps
+)(NotificationBar);

--- a/normandy/control/static/control/js/components/NotificationBar.jsx
+++ b/normandy/control/static/control/js/components/NotificationBar.jsx
@@ -1,50 +1,34 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { setNotification } from '../actions/ControlActions.js'
+import ControlActions from '../actions/ControlActions.js'
 import classNames from 'classnames'
 
 class NotificationBar extends React.Component {
   constructor() {
     super();
-    this.state = {
-      isVisible: false
-    }
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.notification) {
-      this.setState({
-        isVisible: true
-      });
-      this.setVisibilityTimer();
+      setTimeout(() => {
+        this.removeNotification();
+      }, 10000);
     }
   }
 
-  setVisibilityTimer() {
-    this.visibilityTimer !== null ? clearTimeout(this.visibilityTimer) : null;
-
-    this.visibilityTimer = setTimeout(() => {
-      this.setState({
-        isVisible: false
-      })
-    }, 10000);
-  }
-
-  hideNotificationBar() {
-    this.setState({
-      isVisible: false
-    });
-    clearTimeout(this.visibilityTimer);
+  removeNotification() {
+    const { dispatch } = this.props;
+    dispatch(ControlActions.setNotification());
   }
 
   render() {
     const { notification, dispatch } = this.props;
     return (
-      <div id="notification-bar" className={classNames({ 'active': this.state.isVisible })}>
+      <div id="notification-bar" className={classNames({ 'active': notification })}>
         { notification &&
           <p className={classNames('notification', notification.messageType)}>
             { notification.message }
-            <i className="fa fa-lg fa-times remove-message" onClick={::this.hideNotificationBar}></i>
+            <i className="fa fa-lg fa-times remove-message" onClick={::this.removeNotification}></i>
           </p>
         }
       </div>

--- a/normandy/control/static/control/js/index.js
+++ b/normandy/control/static/control/js/index.js
@@ -12,7 +12,8 @@ const store = controlStore({
     recipes: null,
     isFetching: false,
     selectedRecipe: null,
-    recipeListNeedsFetch: true
+    recipeListNeedsFetch: true,
+    notification: null
   }
 });
 

--- a/normandy/control/static/control/js/reducers/ControlAppReducer.js
+++ b/normandy/control/static/control/js/reducers/ControlAppReducer.js
@@ -2,13 +2,14 @@ import {
   REQUEST_IN_PROGRESS, REQUEST_COMPLETE,
   RECIPES_RECEIVED, SINGLE_RECIPE_RECEIVED,
   RECIPE_ADDED, RECIPE_UPDATED, RECIPE_DELETED,
-  SET_SELECTED_RECIPE } from '../actions/ControlActions.js';
+  SET_SELECTED_RECIPE, SET_NOTIFICATION } from '../actions/ControlActions.js';
 
 let initialState = {
   recipes: null,
   isFetching: false,
   selectedRecipe: null,
-  recipeListNeedsFetch: true
+  recipeListNeedsFetch: true,
+  notification: null,
 };
 
 function controlAppReducer(state = initialState, action) {
@@ -38,6 +39,11 @@ function controlAppReducer(state = initialState, action) {
     case SET_SELECTED_RECIPE:
       return Object.assign({}, state, {
         selectedRecipe: action.recipeId
+      });
+
+    case SET_NOTIFICATION:
+      return Object.assign({}, state, {
+        notification: action.notification
       });
 
     case RECIPE_ADDED:

--- a/normandy/control/tests/actions/controlActions.js
+++ b/normandy/control/tests/actions/controlActions.js
@@ -1,43 +1,10 @@
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import controlActions, * as actionTypes from '../../static/control/js/actions/ControlActions'
+import { fixtureRecipes, fixtureRevisions, initialState } from '../fixtures/fixtures';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
-
-const fixtureRecipes = [
-  { "id": 1, "name": "Lorem Ipsum", "enabled": true },
-  { "id": 2, "name": "Dolor set amet", "enabled": true },
-  { "id": 3, "name": "Consequitar adipscing", "enabled": false }
-];
-
-const fixtureRevisions = [
-  {
-    "id": 169,
-    "date_created": "2016-05-13T17:20:35.698735Z",
-    "recipe": {
-        "id": 36,
-        "name": "Consequestar",
-        "enabled": true,
-        "revision_id": 22,
-        "action": "console-log",
-        "arguments": {
-            "message": "hi there message here"
-        },
-        "filter_expression": "()",
-        "approver": null,
-        "is_approved": false
-    }
-  }
-]
-
-const initialState = {
-    recipes: null,
-    isFetching: false,
-    selectedRecipe: null,
-    recipeListNeedsFetch: true
-};
-
 const store = mockStore({ controlApp: initialState });
 
 const successPromise = (responseData) => {
@@ -56,6 +23,10 @@ const failurePromise = () => {
 
 
 describe('controlApp Actions', () => {
+
+  beforeEach(() => {
+    store.clearActions();
+  });
 
   it('creates REQUEST_IN_PROGRESS when initiating an api call', () => {
     const expectedAction = { type: actionTypes.REQUEST_IN_PROGRESS };
@@ -76,8 +47,17 @@ describe('controlApp Actions', () => {
       });
     })
 
-    it('returns with `status: failure` if the request failed', () => {
-      const expectedAction = { type: actionTypes.REQUEST_COMPLETE, status: 'failure' };
+    it('returns with `status: error` if the request failed', () => {
+      const expectedAction = { type: actionTypes.REQUEST_COMPLETE, status: 'error' };
+      spyOn(window, 'fetch').and.returnValue(failurePromise());
+
+      return store.dispatch(controlActions.makeApiRequest('fetchAllRecipes')).then(() => {
+        expect(store.getActions()).toContain(expectedAction);
+      });
+    });
+
+    it('creates a SET_NOTIFICATION action if provided', () => {
+      const expectedAction = { type: actionTypes.SET_NOTIFICATION, notification: { messageType: 'error', 'message': 'Error fetching recipes.'} };
       spyOn(window, 'fetch').and.returnValue(failurePromise());
 
       return store.dispatch(controlActions.makeApiRequest('fetchAllRecipes')).then(() => {

--- a/normandy/control/tests/fixtures/fixtures.js
+++ b/normandy/control/tests/fixtures/fixtures.js
@@ -1,0 +1,33 @@
+export const fixtureRecipes = [
+  { "id": 1, "name": "Lorem Ipsum", "enabled": true },
+  { "id": 2, "name": "Dolor set amet", "enabled": true },
+  { "id": 3, "name": "Consequitar adipscing", "enabled": false }
+];
+
+export const initialState = {
+  recipes: null,
+  isFetching: false,
+  selectedRecipe: null,
+  recipeListNeedsFetch: true,
+  notification: null
+};
+
+export const fixtureRevisions = [
+  {
+    "id": 169,
+    "date_created": "2016-05-13T17:20:35.698735Z",
+    "recipe": {
+        "id": 36,
+        "name": "Consequestar",
+        "enabled": true,
+        "revision_id": 22,
+        "action_name": "console-log",
+        "arguments": {
+            "message": "hi there message here"
+        },
+        "filter_expression": "()",
+        "approver": null,
+        "is_approved": false
+    }
+  }
+];

--- a/normandy/control/tests/reducers/controlAppReducer.js
+++ b/normandy/control/tests/reducers/controlAppReducer.js
@@ -1,18 +1,6 @@
 import controlAppReducer from '../../static/control/js/reducers/ControlAppReducer';
 import * as actions from '../../static/control/js/actions/ControlActions';
-
-const initialState = {
-  recipes: null,
-  isFetching: false,
-  selectedRecipe: null,
-  recipeListNeedsFetch: true
-};
-
-const fixtureRecipes = [
-  { "id": 1, "name": "Lorem Ipsum", "enabled": true },
-  { "id": 2, "name": "Dolor set amet", "enabled": true },
-  { "id": 3, "name": "Consequitar adipscing", "enabled": false }
-];
+import { fixtureRecipes, initialState } from '../fixtures/fixtures';
 
 describe('controlApp reducer', () => {
   it('should return initial state by default', () => {
@@ -67,6 +55,16 @@ describe('controlApp reducer', () => {
     })).toEqual({
       ...initialState,
       selectedRecipe: 2
+    })
+  })
+
+  it('should handle SET_NOTIFICATION', () => {
+    expect(controlAppReducer(undefined, {
+      type: actions.SET_NOTIFICATION,
+      notification: { messageType: 'success', 'message': 'Success message' }
+    })).toEqual({
+      ...initialState,
+      notification: { messageType: 'success', 'message': 'Success message' }
     })
   })
 


### PR DESCRIPTION
This adds a super bare-bones notification component to let you know if you successfully added/updated a recipe or not. We'll probably want to make it a bit more robust in the future (e.g. handling multiple messages) but I think for our current use case this will do.

I hard-coded some generic success/error messages for the form submission actions, but have another branch with more specific error handling [here](https://github.com/brittanystoroz/normandy/tree/validate-forms). Just wanted to split these PRs up to keep 'em tiny.

Fixes bug 1271276 r?

demo gifs tktk