### PR TITLE
Fix leftover nits

### DIFF
--- a/normandy/control/static/control/js/components/RecipePreview.jsx
+++ b/normandy/control/static/control/js/components/RecipePreview.jsx
@@ -46,8 +46,7 @@ class RecipePreview extends React.Component {
 
   render() {
     const {recipe} = this.props;
-    let statusClasses = classNames({
-      'preview-status': true,
+    let statusClasses = classNames('preview-status', {
       'green': this.state.recipeExecuted,
       'red': this.state.errorRunningRecipe,
     });

--- a/normandy/control/static/control/js/components/action_forms/HeartbeatForm.jsx
+++ b/normandy/control/static/control/js/components/action_forms/HeartbeatForm.jsx
@@ -30,8 +30,7 @@ const SurveyForm = (props) => {
   const { selectedSurvey, fields, showDefaults } = props;
   const surveyObject = selectedSurvey || fields.defaults;
   let headerText = 'Default Survey Values';
-  let containerClasses = classNames({
-    'fluid-8': true,
+  let containerClasses = classNames('fluid-8', {
     'active': selectedSurvey
   });
 


### PR DESCRIPTION
Some lefover nits that I missed in my last pull request. Using positional arguments for classes that are definite with `classNames`. @casebenton r?