### PR TITLE
Add reactable for sorting and filtering recipe list

### DIFF
--- a/normandy/control/static/control/admin/sass/control.scss
+++ b/normandy/control/static/control/admin/sass/control.scss
@@ -57,6 +57,7 @@
 #secondary-header {
   background-color: $secondaryColor;
   border-top: 1px solid #fff;
+  margin: 0 0 30px 0;
   padding: 0px;
 
   h3 {

--- a/normandy/control/static/control/admin/sass/partials/_common.scss
+++ b/normandy/control/static/control/admin/sass/partials/_common.scss
@@ -131,6 +131,7 @@ input, select, textarea {
 table {
   border-collapse: collapse;
   font-family: $SourceSansPro;
+  table-layout: fixed;
   width: 100%;
 
   a:link, a:visited {
@@ -147,8 +148,37 @@ thead {
   th {
     outline: 0;
     padding: 5px 0px;
+    position: relative;
     &:hover { cursor: pointer; }
-    i { color: $secondaryColor; }
+
+    &.reactable-th-name { width: 30%; }
+
+    span::after {
+      color: $secondaryColor;
+      content: "\f0dc";
+      display: inline-block;
+      font: normal normal 400 16px/18px FontAwesome;
+      margin: 0 0 0 10px;
+      position: absolute;
+    }
+
+    &.reactable-header-sort-asc {
+      span::after {
+        color: $cta;
+        content: "\f0de";
+        font-size-adjust: 0.85;
+        margin-top: 6px;
+      }
+    }
+
+    &.reactable-header-sort-desc {
+      span::after {
+        color: $cta;
+        content: "\f0dd";
+        font-size-adjust: 0.85;
+        margin-top: -5px;
+      }
+    }
   }
 }
 

--- a/normandy/control/static/control/admin/sass/partials/_common.scss
+++ b/normandy/control/static/control/admin/sass/partials/_common.scss
@@ -63,9 +63,10 @@ input, select, textarea {
   }
 }
 
-.switch-label {
+.switch span {
   color: $darkBrown;
   cursor: pointer;
+  font-size: 12px;
   float: left;
   line-height: 26px;
   padding: 0px;
@@ -74,15 +75,12 @@ input, select, textarea {
   text-transform: none;
   width: 33%;
   z-index: 2;
-}
 
-.switch-label:active { font-weight: 600; }
-.switch-input { display: none; }
-
-.switch-input:checked + .switch-label {
-  font-weight: 600;
-  text-shadow: 0 1px rgba(255, 255, 255, 0.25);
-  transition: 0.15s ease-out;
+  &.active {
+    font-weight: 600;
+    height: 26px;
+    text-shadow: 0 1px rgba(255, 255, 255, 0.25);
+  }
 }
 
 .switch-selection {
@@ -91,9 +89,15 @@ input, select, textarea {
   box-shadow: inset 0 1px rgba(255, 255, 255, 0.5), 0 0 2px rgba(0, 0, 0, 0.2);
   display: block;
   height: 26px;
+  left: 5px;
   position: absolute;
+  top: 5px;
   transition: left 0.15s ease-out;
   width: 33%;
+  z-index: 1;
+
+  &.position-1 { left: 33%; }
+  &.position-2 { left: 65%; }
 }
 
 
@@ -139,6 +143,13 @@ thead {
   font-weight: 600;
   font-size: 13px;
   font-family: $OpenSans;
+
+  th {
+    outline: 0;
+    padding: 5px 0px;
+    &:hover { cursor: pointer; }
+    i { color: $secondaryColor; }
+  }
 }
 
 tr:nth-child(even) {

--- a/normandy/control/static/control/js/components/ControlApp.jsx
+++ b/normandy/control/static/control/js/components/ControlApp.jsx
@@ -9,11 +9,9 @@ export default class ControlApp extends React.Component {
         <NotificationBar />
         <Header pageType={this.props.children.props.route} currentLocation={this.props.location.pathname} />
         <div id="content" className="wrapper">
-          <div className="fluid-8">
-            {
-              React.Children.map(this.props.children, (child) => React.cloneElement(child))
-            }
-          </div>
+          {
+            React.Children.map(this.props.children, (child) => React.cloneElement(child))
+          }
         </div>
       </div>
     )

--- a/normandy/control/static/control/js/components/RecipeForm.jsx
+++ b/normandy/control/static/control/js/components/RecipeForm.jsx
@@ -76,7 +76,7 @@ export class RecipeForm extends React.Component {
     const { availableActions, selectedAction } = this.state;
 
     return (
-      <form onSubmit={handleSubmit(::this.submitForm)} className="crud-form">
+      <form onSubmit={handleSubmit(::this.submitForm)} className="crud-form fluid-8">
 
         { viewingRevision &&
           <p id="viewing-revision" className="notification info">

--- a/normandy/control/static/control/js/components/RecipeList.jsx
+++ b/normandy/control/static/control/js/components/RecipeList.jsx
@@ -13,11 +13,26 @@ const BooleanIcon = (props) => {
   }
 }
 
-const SwitchFilter = (props) => {
-  const { options, selectedFilter, updateFilter } = props;
+const FilterBar = ({searchText, filterStatus, updateSearch, updateFilter}) => {
+  return (
+    <div id="secondary-header" className="fluid-8">
+      <div className="fluid-2">
+        <div className="search input-with-icon">
+          <input type="text" placeholder="Search" value={searchText} onChange={updateSearch} />
+        </div>
+      </div>
+      <div id="filters-container" className="fluid-6">
+        <h4>Filter By:</h4>
+        <SwitchFilter options={['All', 'Enabled', 'Disabled']} selectedFilter={filterStatus} updateFilter={updateFilter} />
+      </div>
+    </div>
+  );
+}
+
+const SwitchFilter = ({ options, selectedFilter, updateFilter }) => {
   return (
     <div className="switch">
-      <div className={classNames('switch-selection', `position-${options.indexOf(selectedFilter)}`)}>&nbsp;</div>
+      <div className={`switch-selection position-${options.indexOf(selectedFilter)}`}>&nbsp;</div>
       { options.map(option =>
         <span key={option}
           className={classNames({ 'active': (option === selectedFilter) })}
@@ -89,44 +104,33 @@ class RecipeList extends React.Component {
 
     return (
       <div>
-        <div id="secondary-header" className="fluid-8">
-          <div className="fluid-2">
-            <div className="search input-with-icon">
-              <input type="text" placeholder="Search" value={this.state.searchText} onChange={::this.updateSearch} />
-            </div>
-          </div>
-          <div id="filters-container" className="fluid-6">
-            <h4>Filter By:</h4>
-            <SwitchFilter options={['All', 'Enabled', 'Disabled']} selectedFilter={this.state.filterStatus} updateFilter={::this.updateFilter} />
-          </div>
-        </div>
-
-        <div className="fluid-8">
-          <Table id="recipe-list" sortable={true} hideFilterInput
-            filterable={[
-              { column: 'name', filterFunction: ::this.parseFilter },
-              { column: 'action', filterFunction: ::this.parseFilter }
-            ]}
-            filterBy={this.state.searchQuery}>
-            <Thead>
-              <Th column="name">Name <i className="fa fa-sort post">&nbsp;</i></Th>
-              <Th column="action">Action Name <i className="fa fa-sort post">&nbsp;</i></Th>
-              <Th column="enabled">Enabled <i className="fa fa-sort post">&nbsp;</i></Th>
-              <Th column="is_approved">Approved <i className="fa fa-sort post">&nbsp;</i></Th>
-              <Th column="last_updated">Last Updated <i className="fa fa-sort post">&nbsp;</i></Th>
-            </Thead>
-            { recipes.map(recipe =>
-              <Tr key={recipe.id} onClick={(e) => { ::this.viewRecipe(recipe); }}>
-                <Td column="name" value={this.formatFilterValue(recipe, 'name')}>{recipe.name}</Td>
-                <Td column="action" value={this.formatFilterValue(recipe, 'action')}>{recipe.action}</Td>
-                <Td column="enabled" value={recipe.enabled ? 'Enabled' : 'Disabled'}><BooleanIcon value={recipe.enabled} /></Td>
-                <Td column="is_approved" value={recipe.is_approved}><BooleanIcon value={recipe.is_approved} /></Td>
-                <Td column="last_updated" value={recipe.last_updated}>{moment(recipe.last_updated).fromNow()}</Td>
-              </Tr>
-              )
-            }
-          </Table>
-        </div>
+      <FilterBar {...this.state} updateFilter={::this.updateFilter} updateSearch={::this.updateSearch} />
+      <div className="fluid-8">
+        <Table id="recipe-list" sortable={true} hideFilterInput
+          filterable={[
+            { column: 'name', filterFunction: ::this.parseFilter },
+            { column: 'action', filterFunction: ::this.parseFilter }
+          ]}
+          filterBy={this.state.searchQuery}>
+          <Thead>
+            <Th column="name"><span>Name</span></Th>
+            <Th column="action"><span>Action Name</span></Th>
+            <Th column="enabled"><span>Enabled</span></Th>
+            <Th column="is_approved"><span>Approved</span></Th>
+            <Th column="last_updated"><span>Last Updated</span></Th>
+          </Thead>
+          { recipes.map(recipe =>
+            <Tr key={recipe.id} onClick={(e) => { ::this.viewRecipe(recipe); }}>
+              <Td column="name" value={this.formatFilterValue(recipe, 'name')}>{recipe.name}</Td>
+              <Td column="action" value={this.formatFilterValue(recipe, 'action')}>{recipe.action}</Td>
+              <Td column="enabled" value={recipe.enabled ? 'Enabled' : 'Disabled'}><BooleanIcon value={recipe.enabled} /></Td>
+              <Td column="is_approved" value={recipe.is_approved}><BooleanIcon value={recipe.is_approved} /></Td>
+              <Td column="last_updated" value={recipe.last_updated}>{moment(recipe.last_updated).fromNow()}</Td>
+            </Tr>
+            )
+          }
+        </Table>
+      </div>
       </div>
     )
   }

--- a/normandy/control/static/control/js/components/RecipeList.jsx
+++ b/normandy/control/static/control/js/components/RecipeList.jsx
@@ -1,41 +1,41 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
+import { Table, Thead, Th, Tr, Td, applyFilter } from 'reactable'
+import classNames from 'classnames'
 import moment from 'moment'
 import ControlActions from '../actions/ControlActions.js'
 
-class BooleanIcon extends React.Component {
-  render() {
-    switch(this.props.value) {
-      case true: return <i className="fa fa-lg fa-check green">&nbsp;</i>;
-      case false: return <i className="fa fa-lg fa-times red">&nbsp;</i>;
-    }
+const BooleanIcon = (props) => {
+  switch(props.value) {
+    case true: return <i className="fa fa-lg fa-check green">&nbsp;</i>;
+    case false: return <i className="fa fa-lg fa-times red">&nbsp;</i>;
   }
 }
 
-class RecipeDataRow extends React.Component {
-  render() {
-    const { recipe, dispatch } = this.props;
-
-    return (
-      <tr key={recipe.id} onClick={(e) => {
-        dispatch(ControlActions.setSelectedRecipe(recipe.id));
-        dispatch(push(`/control/recipe/${recipe.id}/`))
-      }}>
-        <td>{recipe.name}</td>
-        <td>{recipe.action}</td>
-        <td><BooleanIcon value={recipe.enabled} /></td>
-        <td><BooleanIcon value={recipe.is_approved} /></td>
-        <td>{ moment(recipe.last_updated).fromNow() }</td>
-      </tr>
-    )
-  }
+const SwitchFilter = (props) => {
+  const { options, selectedFilter, updateFilter } = props;
+  return (
+    <div className="switch">
+      <div className={classNames('switch-selection', `position-${options.indexOf(selectedFilter)}`)}>&nbsp;</div>
+      { options.map(option =>
+        <span key={option}
+          className={classNames({ 'active': (option === selectedFilter) })}
+          onClick={() => updateFilter(option)}>{option}
+        </span>
+      )}
+    </div>
+  )
 }
-
 
 class RecipeList extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      searchText: '',
+      searchQuery: '',
+      filterStatus: 'All'
+    }
   }
 
   componentWillMount() {
@@ -44,27 +44,89 @@ class RecipeList extends React.Component {
     dispatch(ControlActions.setSelectedRecipe(null));
   }
 
+  viewRecipe(recipe) {
+    const { dispatch } = this.props;
+    dispatch(ControlActions.setSelectedRecipe(recipe.id));
+    dispatch(push(`/control/recipe/${recipe.id}/`));
+  }
+
+  updateSearch(event) {
+    this.setState({
+      searchText: event.target.value,
+      searchQuery: `${event.target.value}:${this.state.filterStatus}`
+    });
+  }
+
+  updateFilter(filterStatus) {
+    let searchQuery = this.state.searchText;
+    if (filterStatus !== 'All') {
+      searchQuery = `${this.state.searchText}:${filterStatus}`;
+    }
+
+    this.setState({
+      searchQuery,
+      filterStatus
+    })
+  }
+
+  parseFilter(contents, filter) {
+    let enabledStatusMatches = true;
+
+    if (this.state.filterStatus !== 'All') {
+      enabledStatusMatches = (contents.split(':')[1] === this.state.filterStatus);
+    }
+
+    return enabledStatusMatches && contents.toLowerCase().indexOf(this.state.searchText.toLowerCase()) > -1;
+  }
+
+  formatFilterValue(recipe, property) {
+    let status = (recipe.enabled === true ? 'Enabled' : 'Disabled');
+    return `${recipe[property]}:${status}`;
+  }
+
   render() {
+    const { dispatch, recipes } = this.props;
+
     return (
-      <div className="fluid-8">
-        <table id="recipe-list">
-          <thead>
-            <tr>
-              <td>Name</td>
-              <td>Action</td>
-              <td>Enabled</td>
-              <td>Approved</td>
-              <td>Last Updated</td>
-            </tr>
-          </thead>
-          <tbody>
-            {
-              this.props.recipes.map(recipe =>
-                <RecipeDataRow recipe={recipe} dispatch={this.props.dispatch} key={recipe.id} />
+      <div>
+        <div id="secondary-header" className="fluid-8">
+          <div className="fluid-2">
+            <div className="search input-with-icon">
+              <input type="text" placeholder="Search" value={this.state.searchText} onChange={::this.updateSearch} />
+            </div>
+          </div>
+          <div id="filters-container" className="fluid-6">
+            <h4>Filter By:</h4>
+            <SwitchFilter options={['All', 'Enabled', 'Disabled']} selectedFilter={this.state.filterStatus} updateFilter={::this.updateFilter} />
+          </div>
+        </div>
+
+        <div className="fluid-8">
+          <Table id="recipe-list" sortable={true} hideFilterInput
+            filterable={[
+              { column: 'name', filterFunction: ::this.parseFilter },
+              { column: 'action', filterFunction: ::this.parseFilter }
+            ]}
+            filterBy={this.state.searchQuery}>
+            <Thead>
+              <Th column="name">Name <i className="fa fa-sort post">&nbsp;</i></Th>
+              <Th column="action">Action Name <i className="fa fa-sort post">&nbsp;</i></Th>
+              <Th column="enabled">Enabled <i className="fa fa-sort post">&nbsp;</i></Th>
+              <Th column="is_approved">Approved <i className="fa fa-sort post">&nbsp;</i></Th>
+              <Th column="last_updated">Last Updated <i className="fa fa-sort post">&nbsp;</i></Th>
+            </Thead>
+            { recipes.map(recipe =>
+              <Tr key={recipe.id} onClick={(e) => { ::this.viewRecipe(recipe); }}>
+                <Td column="name" value={this.formatFilterValue(recipe, 'name')}>{recipe.name}</Td>
+                <Td column="action" value={this.formatFilterValue(recipe, 'action')}>{recipe.action}</Td>
+                <Td column="enabled" value={recipe.enabled ? 'Enabled' : 'Disabled'}><BooleanIcon value={recipe.enabled} /></Td>
+                <Td column="is_approved" value={recipe.is_approved}><BooleanIcon value={recipe.is_approved} /></Td>
+                <Td column="last_updated" value={recipe.last_updated}>{moment(recipe.last_updated).fromNow()}</Td>
+              </Tr>
               )
             }
-          </tbody>
-        </table>
+          </Table>
+        </div>
       </div>
     )
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-redux": "^4.4.5",
     "react-router": "^2.4.0",
     "react-router-redux": "^4.0.4",
+    "reactable": "^0.13.2",
     "redux": "^3.5.2",
     "redux-form": "^5.2.3",
     "redux-thunk": "^2.0.1",


### PR DESCRIPTION
Added a nifty package called [reactable](https://github.com/glittershark/reactable) that lets you sort and filter tables of data. 

All the columns are asc/desc sortable by clicking on the column headers
The search input filters based on the recipe `name` and `action_name` properties
Switch filter does an AND to limit to all/enabled/disabled recipes with the current search text. (We could also do this for `is_approved` if we want)

There is some not-so-pretty code around filtering the list. Reactable currently only supports filtering by a single string (there are PRs in to fix that in the near future). In order to filter by multiple columns with different conditions, I added `searchQuery` to the component state which combines both the search text & current enabled/disabled filter (i.e. "lorem ipsum dolor:enabled" will return only enabled recipes that contain "lorem ipsum dolor" in either `name` or `action_name`.

Fixes bug 1266490 r?