### PR TITLE
Switch to babel stage 0

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -32,7 +32,7 @@ module.exports = function(config) {
                         exclude: /node_modules/,
                         loader: 'babel',
                         'query': {
-                          presets: ['react', 'es2015', 'stage-2']
+                          presets: ['react', 'es2015', 'stage-0']
                         }
                     },
                 ],

--- a/package.json
+++ b/package.json
@@ -13,9 +13,8 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "babel-plugin-transform-function-bind": "^6.8.0",
     "babel-polyfill": "^6.7.2",
-    "babel-preset-stage-2": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0",
     "babel-runtime": "^6.6.1",
     "classnames": "^2.2.5",
     "cssmin": "^0.4.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,8 +44,7 @@ module.exports = [
           exclude: /node_modules/,
           loader: 'babel',
           'query': {
-            presets: ['es2015', 'react', 'stage-2'],
-            plugins: ['transform-function-bind']
+            presets: ['es2015', 'react', 'stage-0'],
           }
         },
         {
@@ -103,7 +102,7 @@ module.exports = [
             exclude: /node_modules/,
             loader: 'babel-loader',
             query: {
-              presets: ['es2015', 'stage-2'],
+              presets: ['es2015', 'stage-0'],
               plugins: [
                 ['transform-runtime', {
                   polyfill: false,


### PR DESCRIPTION
We were already pulling in  `transform-function-bind`, which is literally half of `stage-0`. Lets just be simple about it.

@brittanystoroz r?