### PR TITLE
Add stable sampling to jexl filters

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react", "es2015", "stage-0"]
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,9 +31,6 @@ module.exports = function(config) {
                         test: /(\.|\/)(jsx|js)$/,
                         exclude: /node_modules/,
                         loader: 'babel',
-                        'query': {
-                          presets: ['react', 'es2015', 'stage-0']
-                        }
                     },
                 ],
             },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,7 @@ module.exports = function(config) {
             'node_modules/jasmine-promises/dist/jasmine-promises.js',
             'normandy/control/tests/index.js',
             'normandy/recipes/tests/actions/index.js',
+            'normandy/selfrepair/tests/index.js',
         ],
 
         // preprocess matching files before serving them to the browser
@@ -21,6 +22,7 @@ module.exports = function(config) {
         preprocessors: {
             'normandy/control/tests/index.js': ['webpack', 'sourcemap'],
             'normandy/recipes/tests/actions/index.js': ['webpack', 'sourcemap'],
+            'normandy/selfrepair/tests/index.js': ['webpack', 'sourcemap'],
             'normandy/control/static/control/js/components/*.jsx': ['react-jsx'],
         },
 

--- a/normandy/selfrepair/static/js/utils.js
+++ b/normandy/selfrepair/static/js/utils.js
@@ -1,0 +1,47 @@
+import Sha256 from 'sha.js/sha256';
+
+export function stableSample(input, rate) {
+    const hasher = new Sha256();
+    hasher.update(JSON.stringify(input));
+
+    const samplePoint = fractionToKey(rate);
+    const inputHash = hasher.digest('hex')
+
+    if (samplePoint.length !== 64 || inputHash.length !== 64) {
+        throw new Error('Unexpected hash length');
+    }
+
+    return inputHash < samplePoint;
+}
+
+/**
+ * Map from the range [0, 1] to [0, max(sha256)].
+ * @param  {number} frac A float from 0.0 to 1.0.
+ * @return {string} A string in the sha256 hash space. Will be zero padded to 64
+ *   characters.
+ */
+export function fractionToKey(frac) {
+    // SHA 256 hashes are 64-digit hexadecimal numbers. The largest possible SHA
+    // 256 hash is 2^256 - 1.
+
+    if (frac < 0 || frac > 1) {
+        throw new Error(`frac must be between 0 and 1 inclusive (got ${frac})`);
+    }
+
+    const mult = 2 ** 256 - 1;
+    const inDecimal = Math.floor(frac * mult);
+    let hexDigits = inDecimal.toString(16);
+    if (hexDigits.length < 64) {
+        // Left pad with zeroes
+        // If N zeroes are needed, generate an array of nulls N+1 elements long,
+        // and inserts zeroes between each null.
+        hexDigits = Array(64 - hexDigits.length + 1).join('0') + hexDigits;
+    }
+
+    // Saturate at 2**256 - 1
+    if (hexDigits.length > 64) {
+        hexDigits = Array(65).join('f');
+    }
+
+    return hexDigits;
+}

--- a/normandy/selfrepair/tests/index.js
+++ b/normandy/selfrepair/tests/index.js
@@ -1,0 +1,2 @@
+var testsContext = require.context("./", true, /^\.\/.*\.js$/);
+testsContext.keys().forEach(testsContext);

--- a/normandy/selfrepair/tests/test_utils.js
+++ b/normandy/selfrepair/tests/test_utils.js
@@ -1,0 +1,71 @@
+import {fractionToKey, stableSample} from '../static/js/utils';
+
+function repeatString(char, times) {
+    let acc = '';
+    for (let i = 0; i < times; i++) {
+        acc += char;
+    }
+    return acc;
+}
+
+describe('fractionToKey', () => {
+    it('should match some known values', () => {
+        // quick range check
+        expect(fractionToKey(0 / 4)).toEqual(repeatString('0', 64));
+        expect(fractionToKey(1 / 4)).toEqual('4' + repeatString('0', 63));
+        expect(fractionToKey(2 / 4)).toEqual('8' + repeatString('0', 63));
+        expect(fractionToKey(3 / 4)).toEqual('c' + repeatString('0', 63));
+        expect(fractionToKey(4 / 4)).toEqual(repeatString('f', 64));
+
+        // Tests leading zeroes
+        expect(fractionToKey(1 / 32)).toEqual('08' + repeatString('0', 62));
+
+        // The expected output here is 0.00001 * 2^256, in hex.
+        expect(fractionToKey(0.00001))
+        .toEqual('0000a7c5ac471b47880000000000000000000000000000000000000000000000');
+    });
+
+    it('handles error cases', () => {
+        const cases = [-1, -0.5, 1.5, 2];
+        for (let val of cases) {
+            expect(() => fractionToKey(val))
+            .toThrowError(`frac must be between 0 and 1 inclusive (got ${val})`);
+        }
+    });
+
+    it('should be 64 characters long', () => {
+        for (let i = 0; i < 1000; i++) {
+            let r = Math.random();
+            let key = fractionToKey(r);
+            expect(key.length).toEqual(64);
+        }
+    });
+});
+
+describe('stableSample', () => {
+    it('should match at about the right rate', () => {
+        // This test could in theory fail randomly, but I think the probability is pretty good.
+        let trials = 1000;
+        let hits = 0;
+        let rate = Math.random();
+        for (let i = 0; i < trials; i++) {
+            if (stableSample(Math.random(), rate)) {
+                hits += 1;
+            }
+        }
+        // 95% accurate
+        expect(Math.abs((hits / trials) - rate) < 0.05).toEqual(true);
+    });
+
+    it('should be stable', () => {
+        // Make sure that the stable sample returns the same value repeatedly.
+        for (var i = 0; i < 100; i++) {
+            let rate = Math.random();
+            let val = Math.random();
+            let hit = stableSample(val, rate);
+            for (var j = 0; j < 10; j++) {
+                expect(stableSample(val, rate)).toEqual(hit);
+            }
+        }
+    });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,9 +43,6 @@ module.exports = [
           test: /(\.|\/)(jsx|js)$/,
           exclude: /node_modules/,
           loader: 'babel',
-          'query': {
-            presets: ['es2015', 'react', 'stage-0'],
-          }
         },
         {
           test: /\.scss$/,
@@ -102,7 +99,6 @@ module.exports = [
             exclude: /node_modules/,
             loader: 'babel-loader',
             query: {
-              presets: ['es2015', 'stage-0'],
               plugins: [
                 ['transform-runtime', {
                   polyfill: false,


### PR DESCRIPTION
Also refactor babel configuration a bit, which makes reasoning about it a lot easier.

The Python version of the code is at [`normandy/recipes/utils.py`](https://github.com/mozilla/normandy/blob/b99cc7134330aa584d51ecab4fa8615ab0e8d071/normandy/recipes/utils.py#L27). The tests are ported from the Python versions. The changed from `7fff...` to `8000...` (etc) because of rounding errors.

@rehandalal r?