### PR TITLE
Remove custom update/create methods from Recipe serializer.

### DIFF
--- a/normandy/control/static/control/js/components/ActionForm.jsx
+++ b/normandy/control/static/control/js/components/ActionForm.jsx
@@ -34,7 +34,7 @@ export default reduxForm({
         break;
     }
 
-    if (props.recipe && props.recipe.action_name === props.name) {
+    if (props.recipe && props.recipe.action === props.name) {
       initialValues = props.recipe['arguments'];
     }
 

--- a/normandy/control/static/control/js/components/RecipeForm.jsx
+++ b/normandy/control/static/control/js/components/RecipeForm.jsx
@@ -25,7 +25,7 @@ export class RecipeForm extends React.Component {
     let selectedActionName = event.currentTarget.value;
 
     dispatch(destroy('action'));
-    fields.action_name.onChange(event);
+    fields.action.onChange(event);
     this.setState({
       selectedAction: { name: selectedActionName }
     });
@@ -61,7 +61,7 @@ export class RecipeForm extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (!this.state.selectedAction && nextProps.recipe) {
-      let selectedActionName = nextProps.recipe.action_name;
+      let selectedActionName = nextProps.recipe.action;
       this.setState({
         selectedAction: { name: selectedActionName }
       });
@@ -69,7 +69,7 @@ export class RecipeForm extends React.Component {
   }
 
   render() {
-    const { fields: { name, filter_expression, enabled, action_name }, recipe, recipeId, handleSubmit, viewingRevision } = this.props;
+    const { fields: { name, filter_expression, enabled, action }, recipe, recipeId, handleSubmit, viewingRevision } = this.props;
     const { availableActions, selectedAction } = this.state;
 
     return (
@@ -83,7 +83,7 @@ export class RecipeForm extends React.Component {
 
         <FormField type="text" label="Name" field={name} containerClass="fluid-3" />
         <FormField type="textarea" label="Filter Expression" field={filter_expression} containerClass="fluid-3" />
-        <FormField type="select" label="Action" field={action_name} containerClass="fluid-3"
+        <FormField type="select" label="Action" field={action} containerClass="fluid-3"
           options={availableActions}
           onChange={::this.changeAction}
         />
@@ -110,7 +110,7 @@ RecipeForm.propTypes = {
 export default composeRecipeContainer(reduxForm({
     form: 'recipe'
   }, (state, props) => {
-    let fields = ['name', 'filter_expression', 'enabled', 'action_name'];
+    let fields = ['name', 'filter_expression', 'enabled', 'action'];
     let selectedRecipeRevision = (props.location.state) ? props.location.state.selectedRevision : null;
 
     return {

--- a/normandy/control/static/control/js/components/RecipeList.jsx
+++ b/normandy/control/static/control/js/components/RecipeList.jsx
@@ -23,7 +23,7 @@ class RecipeDataRow extends React.Component {
         dispatch(push(`/control/recipe/${recipe.id}/`))
       }}>
         <td>{recipe.name}</td>
-        <td>{recipe.action_name}</td>
+        <td>{recipe.action}</td>
         <td><BooleanIcon value={recipe.enabled} /></td>
         <td><BooleanIcon value={recipe.is_approved} /></td>
         <td>{ moment(recipe.last_updated).fromNow() }</td>

--- a/normandy/control/static/control/js/components/RecipePreview.jsx
+++ b/normandy/control/static/control/js/components/RecipePreview.jsx
@@ -55,7 +55,7 @@ class RecipePreview extends React.Component {
         <div className="fluid-7">
           <div className="fluid-3">
             <h3>Previewing {recipe.name}...</h3>
-            <p><b>Action Type:</b> {recipe.action_name}</p>
+            <p><b>Action Type:</b> {recipe.action}</p>
           </div>
           <div className="fluid-3 float-right">
             <div className={statusClasses}>

--- a/normandy/control/tests/actions/controlActions.js
+++ b/normandy/control/tests/actions/controlActions.js
@@ -20,7 +20,7 @@ const fixtureRevisions = [
         "name": "Consequestar",
         "enabled": true,
         "revision_id": 22,
-        "action_name": "console-log",
+        "action": "console-log",
         "arguments": {
             "message": "hi there message here"
         },

--- a/normandy/recipes/api/serializers.py
+++ b/normandy/recipes/api/serializers.py
@@ -79,7 +79,7 @@ class ApprovalRequestCommentSerializer(serializers.ModelSerializer):
 
 
 class RecipeSerializer(serializers.ModelSerializer):
-    action_name = serializers.CharField(source='action.name')
+    action = serializers.SlugRelatedField(slug_field='name', queryset=Action.objects.all())
     arguments = serializers.JSONField()
     current_approval_request = ApprovalRequestSerializer(read_only=True)
     approval = ApprovalSerializer(read_only=True)
@@ -94,37 +94,13 @@ class RecipeSerializer(serializers.ModelSerializer):
             'name',
             'enabled',
             'revision_id',
-            'action_name',
+            'action',
             'arguments',
             'filter_expression',
             'current_approval_request',
             'approval',
             'is_approved',
         ]
-
-    def validate_action_name(self, attr):
-        try:
-            Action.objects.get(name=attr)
-        except Action.DoesNotExist:
-            raise serializers.ValidationError('Action does not exist.')
-        return attr
-
-    def create(self, validated_data):
-        action_name = validated_data.pop('action')['name']
-        action = Action.objects.get(name=action_name)
-        recipe = Recipe.objects.create(action=action, **validated_data)
-        return recipe
-
-    def update(self, instance, validated_data):
-        instance.name = validated_data.get('name', instance.name)
-        instance.arguments = validated_data.get('arguments', instance.arguments)
-
-        if 'action' in validated_data:
-            action_name = validated_data.pop('action')['name']
-            instance.action = Action.objects.get(name=action_name)
-
-        instance.save()
-        return instance
 
 
 class ClientSerializer(serializers.Serializer):

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -116,7 +116,7 @@ class TestRecipeAPI(object):
         action = ActionFactory()
 
         res = api_client.post('/api/v1/recipe/', {'name': 'Test Recipe',
-                                                  'action_name': action.name,
+                                                  'action': action.name,
                                                   'arguments': {},
                                                   'filter_expression': 'whatever'})
         assert res.status_code == 201
@@ -125,19 +125,23 @@ class TestRecipeAPI(object):
         assert recipes.count() == 1
 
     def test_it_can_edit_recipes(self, api_client):
-        recipe = RecipeFactory(name='unchanged')
+        recipe = RecipeFactory(name='unchanged', filter_expression='true')
         old_revision_id = recipe.revision_id
 
-        res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {'name': 'changed'})
+        res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {
+            'name': 'changed',
+            'filter_expression': 'false',
+        })
         assert res.status_code == 200
 
         recipe = Recipe.objects.all()[0]
         assert recipe.name == 'changed'
+        assert recipe.filter_expression == 'false'
         assert recipe.revision_id == old_revision_id + 1
 
     def test_creation_when_action_does_not_exist(self, api_client):
         res = api_client.post('/api/v1/recipe/', {'name': 'Test Recipe',
-                                                  'action_name': 'fake-action',
+                                                  'action': 'fake-action',
                                                   'arguments': '{}'})
         assert res.status_code == 400
 
@@ -148,7 +152,7 @@ class TestRecipeAPI(object):
         recipe = RecipeFactory()
         action = ActionFactory()
 
-        res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {'action_name': action.name})
+        res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {'action': action.name})
         assert res.status_code == 200
 
         recipe = Recipe.objects.get(pk=recipe.id)

--- a/normandy/recipes/tests/test_serializers.py
+++ b/normandy/recipes/tests/test_serializers.py
@@ -19,7 +19,7 @@ class TestRecipeSerializer:
             'enabled': recipe.enabled,
             'filter_expression': recipe.filter_expression,
             'revision_id': recipe.revision_id,
-            'action_name': action.name,
+            'action': action.name,
             'arguments': {
                 'foo': 'bar',
             },

--- a/normandy/selfrepair/static/js/self_repair_runner.js
+++ b/normandy/selfrepair/static/js/self_repair_runner.js
@@ -24,7 +24,7 @@ window.registerAction = function(name, ActionClass) {
  */
 function loadAction(recipe) {
     return new Promise((resolve, reject) => {
-        let action_name = recipe.action_name;
+        let action_name = recipe.action;
         if (!registeredActions[action_name]) {
             fetch(`/api/v1/action/${action_name}/`)
             .then(response => response.json())


### PR DESCRIPTION
Due to our custom update/create methods on the recipe serializer, we can't edit filter expressions via the control interface, as the custom methods don't alter the field at all. The whole reason we have them is to support using the `name` field on actions as the value on serialized Recipes, but this is provided by DRF already, so we don't need them.

This changes the API; the action_name field is now simply called action. Most of the changeset is renaming things from action_name to action.

@mythmon r?