### PR TITLE
Add cache headers to "hot-path" APIs

### DIFF
--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -131,6 +131,14 @@ in other Django projects.
     environments, setting this value too low can be a denial-of-service risk.
     Defaults to 5 minutes.
 
+.. envvar:: DJANGO_API_CACHE_TIME
+
+    :default: ``30``
+
+    The time in seconds to set in cache headers for cacheable APIs. This may be
+    set to 0 in non-production environments to ease testing. In production
+    environments, setting this value too low can be a denial-of-service risk.
+
 Gunicorn settings
 -----------------
 These settings control how Gunicorn starts, when the default command of the

--- a/normandy/base/api/mixins.py
+++ b/normandy/base/api/mixins.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.views.decorators.cache import cache_control
 
 
-class CachingMixin:
+class CachingViewsetMixin(object):
     """Modify a ModelViewSet to add caching to read methods"""
 
     @cache_control(public=True, max_age=settings.API_CACHE_TIME)

--- a/normandy/base/api/mixins.py
+++ b/normandy/base/api/mixins.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django.views.decorators.cache import cache_control
+
+
+class CachingMixin:
+    """Modify a ModelViewSet to add caching to read methods"""
+
+    @cache_control(public=True, max_age=settings.API_CACHE_TIME)
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
+
+    @cache_control(public=True, max_age=settings.API_CACHE_TIME)
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -11,6 +11,7 @@ from reversion.models import Version
 
 from normandy.base.api import UpdateOrCreateModelViewSet
 from normandy.base.api.filters import CaseInsensitiveBooleanFilter
+from normandy.base.api.mixins import CachingMixin
 from normandy.base.api.permissions import AdminEnabledOrReadOnly
 from normandy.base.api.renderers import JavaScriptRenderer
 from normandy.base.decorators import reversion_transaction
@@ -25,7 +26,7 @@ from normandy.recipes.api.serializers import (
 )
 
 
-class ActionViewSet(viewsets.ReadOnlyModelViewSet):
+class ActionViewSet(CachingMixin, viewsets.ReadOnlyModelViewSet):
     """Viewset for viewing recipe actions."""
     queryset = Action.objects.all()
     serializer_class = ActionSerializer
@@ -62,7 +63,7 @@ class RecipeFilters(django_filters.FilterSet):
         fields = ['action', 'enabled']
 
 
-class RecipeViewSet(UpdateOrCreateModelViewSet):
+class RecipeViewSet(CachingMixin, UpdateOrCreateModelViewSet):
     """Viewset for viewing and uploading recipes."""
     queryset = Recipe.objects.all()
     serializer_class = RecipeSerializer

--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -11,7 +11,7 @@ from reversion.models import Version
 
 from normandy.base.api import UpdateOrCreateModelViewSet
 from normandy.base.api.filters import CaseInsensitiveBooleanFilter
-from normandy.base.api.mixins import CachingMixin
+from normandy.base.api.mixins import CachingViewsetMixin
 from normandy.base.api.permissions import AdminEnabledOrReadOnly
 from normandy.base.api.renderers import JavaScriptRenderer
 from normandy.base.decorators import reversion_transaction
@@ -26,7 +26,7 @@ from normandy.recipes.api.serializers import (
 )
 
 
-class ActionViewSet(CachingMixin, viewsets.ReadOnlyModelViewSet):
+class ActionViewSet(CachingViewsetMixin, viewsets.ReadOnlyModelViewSet):
     """Viewset for viewing recipe actions."""
     queryset = Action.objects.all()
     serializer_class = ActionSerializer
@@ -63,7 +63,7 @@ class RecipeFilters(django_filters.FilterSet):
         fields = ['action', 'enabled']
 
 
-class RecipeViewSet(CachingMixin, UpdateOrCreateModelViewSet):
+class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
     """Viewset for viewing and uploading recipes."""
     queryset = Recipe.objects.all()
     serializer_class = RecipeSerializer

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -58,6 +58,21 @@ class TestActionAPI(object):
         assert res.status_code == 200
         assert res.data['name'] == action.name
 
+    def test_list_view_includes_cache_headers(self, api_client):
+        res = api_client.get('/api/v1/action/')
+        assert res.status_code == 200
+        # It isn't important to assert a particular value for max-age
+        assert 'max-age=' in res['Cache-Control']
+        assert 'public' in res['Cache-Control']
+
+    def test_detail_view_includes_cache_headers(self, api_client):
+        action = ActionFactory()
+        res = api_client.get('/api/v1/action/{name}/'.format(name=action))
+        assert res.status_code == 200
+        # It isn't important to assert a particular value for max-age
+        assert 'max-age=' in res['Cache-Control']
+        assert 'public' in res['Cache-Control']
+
 
 @pytest.mark.django_db
 class TestImplementationAPI(object):
@@ -254,6 +269,21 @@ class TestRecipeAPI(object):
         res = api_client.get('/api/v1/recipe/?enabled=true')
         assert res.status_code == 200
         assert [r['id'] for r in res.data] == [r1.id]
+
+    def test_list_view_includes_cache_headers(self, api_client):
+        res = api_client.get('/api/v1/recipe/')
+        assert res.status_code == 200
+        # It isn't important to assert a particular value for max_age
+        assert 'max-age=' in res['Cache-Control']
+        assert 'public' in res['Cache-Control']
+
+    def test_detail_view_includes_cache_headers(self, api_client):
+        recipe = RecipeFactory()
+        res = api_client.get('/api/v1/recipe/{id}/'.format(id=recipe.id))
+        assert res.status_code == 200
+        # It isn't important to assert a particular value for max-age
+        assert 'max-age=' in res['Cache-Control']
+        assert 'public' in res['Cache-Control']
 
 
 @pytest.mark.django_db

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -204,6 +204,7 @@ class Base(Core):
     ADMIN_ENABLED = values.BooleanValue(True)
     ACTION_IMPLEMENTATION_CACHE_TIME = values.IntegerValue(60 * 60 * 24 * 365)
     NUM_PROXIES = values.IntegerValue(0)
+    API_CACHE_TIME = values.IntegerValue(30)
 
 
 class Development(Base):
@@ -220,6 +221,7 @@ class Development(Base):
     REQUIRE_RECIPE_AUTH = values.BooleanValue(False)
 
     CAN_EDIT_ACTIONS_IN_USE = values.BooleanValue(True)
+    API_CACHE_TIME = values.IntegerValue(0)
 
 
 class Production(Base):


### PR DESCRIPTION
Fixes bug 1277994.

I changed normandy-compose's Nginx proxy to have caching behavior similar to what our production servers will have. I tested this change with that caching behavior, and it resulted in cache hits that lasted 30 seconds.

r? @Osmose