### PR TITLE
Do not save recipe revisions with no changes.

### DIFF
--- a/normandy/base/decorators.py
+++ b/normandy/base/decorators.py
@@ -22,6 +22,6 @@ def short_circuit_middlewares(view_func):
 
 def reversion_transaction(view_func):
     def wrapped_view(*args, **kwargs):
-        with transaction.atomic(), revisions.create_revision():
+        with transaction.atomic(), revisions.create_revision(manage_manually=True):
             return view_func(*args, **kwargs)
     return wraps(view_func)(wrapped_view)

--- a/normandy/control/static/control/js/components/RecipeHistory.jsx
+++ b/normandy/control/static/control/js/components/RecipeHistory.jsx
@@ -16,7 +16,7 @@ class RecipeHistory extends React.Component {
     apiFetch(`/api/v1/recipe/${recipeId}/history/`)
       .then(response => {
         this.setState({
-          revisionLog: response.reverse()
+          revisionLog: response
         })
       });
   }

--- a/normandy/recipes/api/serializers.py
+++ b/normandy/recipes/api/serializers.py
@@ -110,7 +110,7 @@ class ClientSerializer(serializers.Serializer):
 
 class RecipeVersionSerializer(serializers.ModelSerializer):
     date_created = serializers.DateTimeField(source='revision.date_created', read_only=True)
-    recipe = RecipeSerializer(source='object_version.object', read_only=True)
+    recipe = RecipeSerializer(source='_object_version.object', read_only=True)
 
     class Meta:
         model = Version

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -122,9 +122,12 @@ class Recipe(DirtyFieldsMixin, models.Model):
         return self.name
 
     def save(self, *args, **kwargs):
-        # Increment the revision ID if we've changed
+        # Increment the revision ID and save the reversion if we've
+        # changed
         if self.is_dirty(check_relationship=True):
             self.revision_id += 1
+            if reversion.is_active():
+                reversion.add_to_revision(self)
 
         super().save(*args, **kwargs)
 

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -51,6 +51,19 @@ class TestRecipe(object):
         recipe.save()
         assert recipe.revision_id == revision_id + 1
 
+    def test_revision_id_doesnt_increment_if_no_changes(self):
+        """
+        revision_id should not increment if a recipe is saved with no
+        changes.
+        """
+        recipe = RecipeFactory()
+
+        # The factory saves a couple times so revision id is not 0
+        revision_id = recipe.revision_id
+
+        recipe.save()
+        assert recipe.revision_id == revision_id
+
 
 @pytest.mark.django_db
 class TestApprovalRequest(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@ django-dirtyfields==0.8.2 \
 django-mozilla-product-details==0.10 \
     --hash=sha256:400e59be3c163aebfc8c078879e87a895dad249589d8bc332bb76dc9c9b63efb \
     --hash=sha256:33add704683a5d7f9ff49c03e40a4d8c500882589aee970d5ed81ad11c7ae75c
-django-reversion==1.10.0 \
-    --hash=sha256:a7df6a438bb7f2135bd6c9f5a7bf2879d700e381c0e1336bb8606c1275168395
+django-reversion==2.0.4 \
+    --hash=sha256:a95624e28e72ef0b07231e601abe6fc790cd5e9e54791a1e57ff5eb2b1c0bc32
 django-sslserver==0.18 \
     --hash=sha256:e7180255546c6e1e1652de032d212aa63b19a26b2c817b5f7babca24711f03ad
 django-storages-redux==1.3.2 \


### PR DESCRIPTION
Revisions are only saved and the revision number is incremented only
when a recipe actually changes. Includes an update to django-reversion
2.0.4.

@mythmon r?