### PR TITLE
Add cache headers to self-repair page

### DIFF
--- a/normandy/selfrepair/views.py
+++ b/normandy/selfrepair/views.py
@@ -1,9 +1,12 @@
+from django.conf import settings
 from django.shortcuts import render
+from django.views.decorators.cache import cache_control
 
 from normandy.base.decorators import short_circuit_middlewares
 
 
 @short_circuit_middlewares
+@cache_control(public=True, max_age=settings.API_CACHE_TIME)
 def repair(request, locale):
     return render(request, 'selfrepair/repair.html', {
         'locale': locale,


### PR DESCRIPTION
This is very similar to #172. We might be able to more aggressively cache this page (read: longer cache times), but that would probably make our deploys go funny. Even 30 seconds of caching (the default value for `API_CACHE_TIME`) should drastically help our scalibility.

@Osmose r?