### PR TITLE
Add 404 handler and refactor root component.

### DIFF
--- a/normandy/control/static/control/admin/sass/control.scss
+++ b/normandy/control/static/control/admin/sass/control.scss
@@ -115,6 +115,20 @@
 }
 
 
+/* 404 NoMatch Page */
+.no-match {
+  padding: 30px 45px;
+
+  h2 {
+    margin-bottom: 15px;
+  }
+
+  p {
+    margin-bottom: 10px;
+  }
+}
+
+
 /* Add & Edit Forms */
 .crud-form {
   padding: 30px 45px;

--- a/normandy/control/static/control/js/app.js
+++ b/normandy/control/static/control/js/app.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import controlStore from './stores/ControlStore.js';
+import ControlAppRoutes from './routes.js';
+
+import { Router, browserHistory } from 'react-router';
+import { syncHistoryWithStore } from 'react-router-redux'
+
+/**
+ * Root Component for the entire app.
+ */
+class Root extends React.Component {
+  render() {
+    const {store, history} = this.props;
+    return (
+      <Provider store={store}>
+        <Router history={history}>
+          {ControlAppRoutes}
+        </Router>
+      </Provider>
+    );
+  }
+}
+
+/**
+ * Initialize Redux store, history, and root component.
+ */
+export function createApp() {
+  const store = controlStore();
+  const history = syncHistoryWithStore(browserHistory, store);
+
+  return {
+    store,
+    history,
+    rootComponent: (<Root store={store} history={history} />),
+  };
+}

--- a/normandy/control/static/control/js/components/NoMatch.jsx
+++ b/normandy/control/static/control/js/components/NoMatch.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+/**
+ * 404-ish view shown for routes that don't match any valid route.
+ */
+export default class NoMatch extends React.Component {
+  render() {
+    return (
+      <div className="no-match fluid-8">
+        <h2>Page Not Found</h2>
+        <p>Sorry, we could not find the page you're looking for.</p>
+        <p><Link to="/control/">Click here to return to the control index.</Link></p>
+      </div>
+    );
+  }
+}

--- a/normandy/control/static/control/js/index.js
+++ b/normandy/control/static/control/js/index.js
@@ -1,34 +1,9 @@
-import React from 'react';
 import ReactDOM from 'react-dom';
-import { Provider } from 'react-redux';
-import controlStore from './stores/ControlStore.js';
-import ControlAppRoutes from './routes.js';
+import { createApp } from './app.js';
 
-import { Router, browserHistory } from 'react-router';
-import { syncHistoryWithStore } from 'react-router-redux'
-
-const store = controlStore({
-  controlApp: {
-    recipes: null,
-    isFetching: false,
-    selectedRecipe: null,
-    recipeListNeedsFetch: true,
-    notification: null
-  }
-});
-
-const history = syncHistoryWithStore(browserHistory, store);
-
-class Root extends React.Component {
-  render() {
-    return (
-      <Provider store={store}>
-        <Router history={history}>
-          {ControlAppRoutes}
-        </Router>
-      </Provider>
-    );
-  }
-}
-
-ReactDOM.render(<Root />, document.querySelector('#page-container'));
+// Initialize the control app and render it.
+const app = createApp();
+ReactDOM.render(
+  app.rootComponent,
+  document.querySelector('#page-container')
+);

--- a/normandy/control/static/control/js/routes.js
+++ b/normandy/control/static/control/js/routes.js
@@ -6,6 +6,7 @@ import RecipeForm from './components/RecipeForm.jsx';
 import RecipeHistory from './components/RecipeHistory.jsx';
 import RecipePreview from './components/RecipePreview.jsx';
 import DeleteRecipe from './components/DeleteRecipe.jsx';
+import NoMatch from './components/NoMatch.jsx';
 
 export default (
   <Route path="/control/" component={ControlApp}>
@@ -47,5 +48,6 @@ export default (
         />
       </Route>
     </Route>
+    <Route path="*" component={NoMatch}/>
   </Route>
 );

--- a/normandy/control/static/control/js/stores/ControlStore.js
+++ b/normandy/control/static/control/js/stores/ControlStore.js
@@ -7,14 +7,22 @@ import { reducer as formReducer } from 'redux-form';
 
 const reduxRouterMiddleware = routerMiddleware(browserHistory);
 
-export default function controlStore(initialState) {
+export default function controlStore() {
   return createStore(
     combineReducers({
       controlApp: controlAppReducer,
       form: formReducer,
       routing: routerReducer,
     }),
-    initialState,
+    {
+      controlApp: {
+        recipes: null,
+        isFetching: false,
+        selectedRecipe: null,
+        recipeListNeedsFetch: true,
+        notification: null
+      }
+    },
     applyMiddleware(
       reduxRouterMiddleware,
       thunk

--- a/normandy/control/tests/routes.js
+++ b/normandy/control/tests/routes.js
@@ -1,0 +1,22 @@
+import { push } from 'react-router-redux'
+
+import TestUtils from 'react/lib/ReactTestUtils';
+
+import { createApp } from '../static/control/js/app.js';
+import NoMatch from '../static/control/js/components/NoMatch.jsx';
+
+describe('Control routes', () => {
+  let app;
+
+  beforeEach(() => {
+    app = createApp();
+  });
+
+  it('renders the NoMatch component for unmatched routes', () => {
+    let element = TestUtils.renderIntoDocument(app.rootComponent);
+    app.store.dispatch(push('/control/does/not/exist'));
+
+    let noMatch = TestUtils.findRenderedComponentWithType(element, NoMatch);
+    expect(noMatch).toBeTruthy();
+  });
+});

--- a/normandy/selfrepair/static/js/self_repair.js
+++ b/normandy/selfrepair/static/js/self_repair.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import Normandy from './normandy_driver.js';
 import {fetchRecipes, filterContext, doesRecipeMatch, runRecipe} from './self_repair_runner.js';
 

--- a/normandy/selfrepair/static/js/self_repair.js
+++ b/normandy/selfrepair/static/js/self_repair.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill'
 import Normandy from './normandy_driver.js';
 import {fetchRecipes, filterContext, doesRecipeMatch, runRecipe} from './self_repair_runner.js';
 

--- a/normandy/selfrepair/static/js/self_repair_runner.js
+++ b/normandy/selfrepair/static/js/self_repair_runner.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill'
 import Mozilla from './uitour.js'
 import Normandy from './normandy_driver.js'
 import uuid from 'node-uuid'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,10 @@ module.exports = [
     context: __dirname,
 
     entry: {
-      selfrepair: './normandy/selfrepair/static/js/self_repair',
+      selfrepair: [
+        'babel-polyfill',
+        './normandy/selfrepair/static/js/self_repair',
+      ],
       control: [
         './normandy/control/static/control/js/index',
         './normandy/control/static/control/admin/sass/control.scss',


### PR DESCRIPTION
Phew. Okay. So, this took way longer than I anticipated.

The initial change was easy; add a NoMatch component, display it when other routes don't match. Sure, whatever. The problem was that I wanted to test my route matching.

I eventually got it working, with the following changes:
- Moved the `babel-runtime` import from `self_repair_runner.js` to `self_repair.js`. The former is imported by the tests, which already have a runtime injected into them. The latter is an entry point that isn't in the tests, and without this change, the tests fail due to multiple runtimes being loaded on the same page.
- Removed the `initialState` argument from `controlStore`. This isn't strictly necessary but it was convenient in the middle of my refactoring and I don't see a whole lot of value in passing the initial state in; we're never going to pass another value besides what we always do.
- Moved the root component into a standalone component and moved creation of the store, history, and root component instance into a helper method. This makes setting up tests a lot easier since we can reuse `createApp` there as well.

@brittanystoroz r? Although I feel like we might be flooding you with review requests. Maybe @mythmon instead?