### PR TITLE
Change `routeParams` to `params` when accessing URL data

### DIFF
--- a/normandy/control/static/control/js/components/RecipeContainer.jsx
+++ b/normandy/control/static/control/js/components/RecipeContainer.jsx
@@ -43,7 +43,7 @@ export default function composeRecipeContainer(Component) {
     }
 
     return {
-      recipeId: state.controlApp.selectedRecipe || parseInt(props.routeParams.id) || null,
+      recipeId: state.controlApp.selectedRecipe || parseInt(props.params.id) || null,
       recipe: recipeData,
       dispatch: props.dispatch
     };


### PR DESCRIPTION
Refactoring the routes in #175 broke the ability to fetch recipe data from the URL if you're doing a hard refresh. For some reason we lose `this.props.routeParams` with the new way routes are nested. Wrapping the `recipeContainer` component in `withRouter` fixes it, though I'm not convinced it's the best solution. Just wanted to put up a quick fix for now.