### PR TITLE
*raises white flag*

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,8 +13,8 @@ module.exports = function(config) {
             'node_modules/babel-polyfill/dist/polyfill.js',
             'node_modules/jasmine-promises/dist/jasmine-promises.js',
             'normandy/control/tests/index.js',
-            'normandy/recipes/tests/actions/index.js',
-            'normandy/selfrepair/tests/index.js',
+            // 'normandy/recipes/tests/actions/index.js',
+            // 'normandy/selfrepair/tests/index.js',
         ],
 
         // preprocess matching files before serving them to the browser

--- a/normandy/control/static/control/js/components/RecipeForm.jsx
+++ b/normandy/control/static/control/js/components/RecipeForm.jsx
@@ -23,7 +23,7 @@ export class RecipeForm extends React.Component {
 
   changeAction(event) {
     const { dispatch, fields } = this.props;
-    let selectedActionName = event.currentTarget.value;
+    let selectedActionName = event.target.value;
 
     dispatch(destroy('action'));
     fields.action.onChange(event);
@@ -113,6 +113,7 @@ export class RecipeForm extends React.Component {
     )
   }
 }
+
 RecipeForm.propTypes = {
   fields: React.PropTypes.object.isRequired,
 }
@@ -121,12 +122,18 @@ export default composeRecipeContainer(reduxForm({
     form: 'recipe'
   }, (state, props) => {
     let fields = ['name', 'filter_expression', 'enabled', 'action'];
-    let selectedRecipeRevision = (props.location.state) ? props.location.state.selectedRevision : null;
+    let selectedRecipeRevision = null;
+    let viewingRevision = false;
+
+    if (props.location) {
+      selectedRecipeRevision = props.location.state ? props.location.state.selectedRevision : null;
+      viewingRevision = ((selectedRecipeRevision || props.location.query.revisionId) ? true : false)
+    }
 
     return {
       fields,
       initialValues: selectedRecipeRevision || props.recipe,
-      viewingRevision: ((selectedRecipeRevision || props.location.query.revisionId) ? true : false),
+      viewingRevision,
       formState: state.form
     }
-})(RecipeForm))
+})(RecipeForm));

--- a/normandy/control/static/control/js/stores/ControlStore.js
+++ b/normandy/control/static/control/js/stores/ControlStore.js
@@ -6,23 +6,24 @@ import thunk from 'redux-thunk';
 import { reducer as formReducer } from 'redux-form';
 
 const reduxRouterMiddleware = routerMiddleware(browserHistory);
+const defaultState = {
+  controlApp: {
+    recipes: null,
+    isFetching: false,
+    selectedRecipe: null,
+    recipeListNeedsFetch: true,
+    notification: null
+  }
+};
 
-export default function controlStore() {
+export default function controlStore(initialState = defaultState) {
   return createStore(
     combineReducers({
       controlApp: controlAppReducer,
       form: formReducer,
       routing: routerReducer,
     }),
-    {
-      controlApp: {
-        recipes: null,
-        isFetching: false,
-        selectedRecipe: null,
-        recipeListNeedsFetch: true,
-        notification: null
-      }
-    },
+    initialState,
     applyMiddleware(
       reduxRouterMiddleware,
       thunk

--- a/normandy/control/tests/components/integration/recipeForm.js
+++ b/normandy/control/tests/components/integration/recipeForm.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+import { Provider } from 'react-redux';
+import controlStore from '../../../static/control/js/stores/ControlStore.js';
+
+import RecipeForm from '../../../static/control/js/components/RecipeForm.jsx';
+import ConsoleLogForm from '../../../static/control/js/components/action_forms/ConsoleLogForm.jsx';
+import HeartbeatForm from '../../../static/control/js/components/action_forms/HeartbeatForm.jsx';
+
+const setup = () => {
+  const store = controlStore({
+    controlApp: {
+      recipes: [{
+        "id": 1,
+        "name": "Lorem Ipsum",
+        "enabled": true,
+        "filter_expression": "true",
+        "action": "console-log",
+        "arguments": { "message": "hello there message here" }
+      }],
+      isFetching: false,
+      selectedRecipe: 1,
+      recipeListNeedsFetch: true
+    }
+  });
+
+  const originalDispatch = store.dispatch;
+  const dispatchSpy = jasmine.createSpy('dispatchSpy');
+
+  store.dispatch = (action) => {
+    originalDispatch(action);
+    dispatchSpy(action);
+  }
+
+  const MockProviderComponent = TestUtils.renderIntoDocument(
+    <Provider store={store}>
+      <RecipeForm dispatch={dispatchSpy}></RecipeForm>
+    </Provider>
+  );
+
+  const RecipeFormComponent = TestUtils.findRenderedComponentWithType(MockProviderComponent, RecipeForm);
+  const selectAction = TestUtils.findRenderedDOMComponentWithTag(RecipeFormComponent, 'select');
+  const formElement = TestUtils.findRenderedDOMComponentWithTag(RecipeFormComponent, 'form');
+
+  return { RecipeFormComponent, selectAction, formElement, store };
+};
+
+
+describe('RecipeForm', () => {
+  const { RecipeFormComponent, selectAction, formElement, store } = setup();
+
+
+  describe('rendering', () => {
+    it('creates the appropriate components', () => {
+      expect(TestUtils.isCompositeComponent(RecipeFormComponent)).toEqual(true);
+    });
+
+    it('autopopulates the form fields with the appropriate data', () => {
+      const inputFields = TestUtils.scryRenderedDOMComponentsWithTag(RecipeFormComponent, 'input');
+      expect(inputFields[0].value).toEqual('Lorem Ipsum');
+      expect(inputFields[1].value).toEqual('true');
+      expect(inputFields[2].value).toEqual('hello there message here');
+    });
+  });
+
+
+  describe('changeAction', () => {
+    beforeAll(() => {
+      TestUtils.Simulate.change(selectAction, { target: { value: 'show-heartbeat' } });
+    });
+
+    it('destroys the current action form and initializes a new one', () => {
+      expect(RecipeFormComponent.props.dispatch).toHaveBeenCalledWith({
+        type: 'redux-form/DESTROY',
+        key: undefined,
+        form: 'action'
+      });
+
+      expect(RecipeFormComponent.props.dispatch).toHaveBeenCalledWith(jasmine.objectContaining({
+        type: 'redux-form/INITIALIZE',
+        data: {},
+        fields: jasmine.arrayContaining(['surveyId', 'defaults.message', 'surveys[].title']),
+        form: 'action'
+      }));
+    });
+
+    it('registers the change of the `action` field value on the recipe form', () => {
+      expect(RecipeFormComponent.props.dispatch).toHaveBeenCalledWith(jasmine.objectContaining({
+        type: 'redux-form/CHANGE',
+        field: 'action',
+        value: 'show-heartbeat',
+        form: 'recipe'
+      }));
+
+      expect(store.getState().form.recipe.action).toEqual({ initial: 'console-log', value: 'show-heartbeat' });
+    });
+
+    it('replaces the previous action form component with the new one', () => {
+      expect(TestUtils.scryRenderedComponentsWithType(RecipeFormComponent, HeartbeatForm).length).toEqual(1);
+      expect(TestUtils.scryRenderedComponentsWithType(RecipeFormComponent, ConsoleLogForm).length).toEqual(0);
+    });
+  });
+
+
+  describe('submitForm', () => {
+    beforeAll(() => {
+      TestUtils.Simulate.change(selectAction, { target: { value: 'console-log' } });
+
+      const nameField = TestUtils.scryRenderedDOMComponentsWithTag(RecipeFormComponent, 'input')[0];
+      const currentActionForm = TestUtils.findRenderedComponentWithType(RecipeFormComponent, ConsoleLogForm);
+      const messageField = TestUtils.findRenderedDOMComponentWithTag(currentActionForm, 'input');
+
+      TestUtils.Simulate.change(messageField, { target: { value: 'new message value' } });
+      TestUtils.Simulate.change(nameField, { target: { value: 'Dolor Set Amet' } });
+      TestUtils.Simulate.submit(formElement);
+    });
+
+    it('should start a submit action for the recipe form', () => {
+      expect(RecipeFormComponent.props.dispatch).toHaveBeenCalledWith({
+        type: 'redux-form/START_SUBMIT',
+        form: 'recipe'
+      });
+
+      expect(store.getState().form.recipe._submitting).toEqual(true);
+    });
+  });
+});
+
+


### PR DESCRIPTION
Here is a small sample of the thousand tests I wrote and scrapped. I don't know about any of these. The biggest problem I've run into with the integration tests is not being able to spy on things. You'll notice a nice ugly hack I put in to spy on a `dispatch` property for the component. I tried spying on that `dispatch` method from every object and component I could think of and would always be met with 'expected spy to be called with {} but it was never called'. 

There are a lot of places where I can/should just check the state of the store instead of spying on dispatch (the redux-form actions, mainly), but when we're conditionally dispatching our own actions (i.e. in the submit method we want to dispatch either `updateRecipe` or `addRecipe` depending on current props & state.) it would be nice to check, especially when there are promises involved, as state isn't going to be updated immediately. I also wanted to spy on `window.fetch` so I could fake success/failure responses after submitting but again, it's never getting called.

I think in general everything is probably just a little too nesty. Even doing unit tests where I only import the `RecipeForm` class on its own isn't really possible without still doing all of the `Provider` and `store` setup to keep the action form components happy.  Leaving this branch here so someone else can take a look, my brain is tired. 