### PR TITLE
Fix prop values in ControlApp

### DIFF
--- a/normandy/control/static/control/js/components/ControlApp.js
+++ b/normandy/control/static/control/js/components/ControlApp.js
@@ -1,22 +1,28 @@
-import React from 'react';
+import React, { PropTypes as pt } from 'react';
 import Header from './Header.js';
 import Notifications from './Notifications.js';
 
-export default function ControlApp() {
+export default function ControlApp({ children, location, routes, params }) {
   return (
     <div>
       <Notifications />
       <Header
-        pageType={this.props.children.props.route}
-        currentLocation={this.props.location.pathname}
-        routes={this.props.routes}
-        params={this.props.params}
+        pageType={children.props.route}
+        currentLocation={location.pathname}
+        routes={routes}
+        params={params}
       />
       <div id="content" className="wrapper">
         {
-          React.Children.map(this.props.children, child => React.cloneElement(child))
+          React.Children.map(children, child => React.cloneElement(child))
         }
       </div>
     </div>
   );
 }
+ControlApp.propTypes = {
+  children: pt.object.isRequired,
+  location: pt.object.isRequired,
+  routes: pt.object.isRequired,
+  params: pt.object.isRequired,
+};


### PR DESCRIPTION
`this` context is undefined in the `ControlApp` function the way it's been refactored. We have to explicitly pass in the objects we want to use otherwise `this.props` is always undefined.