### PR TITLE
Do not render the control app on the login page.

### DIFF
--- a/normandy/control/templates/control/admin/base.html
+++ b/normandy/control/templates/control/admin/base.html
@@ -26,11 +26,14 @@
       </div>
 
       {% block page-header %}{% endblock %}
-      {% block content %}{% endblock %}
-      <div id="page-container"></div>
+      {% block content %}
+        <div id="page-container"></div>
+      {% endblock %}
 
     </div>
     <!-- END Container -->
-    {% render_bundle 'control' 'js' %}
+    {% block javascript %}
+      {% render_bundle 'control' 'js' %}
+    {% endblock %}
   </body>
 </html>

--- a/normandy/control/templates/control/admin/login.html
+++ b/normandy/control/templates/control/admin/login.html
@@ -8,6 +8,9 @@
   </div>
 {% endblock %}
 
+{# Do not render the frontend app on the login page. #}
+{% block javascript %}{% endblock %}
+
 {% block content %}
   <div id="content" class="wrapper">
     {% if form.errors and not form.non_field_errors %}

--- a/normandy/control/urls.py
+++ b/normandy/control/urls.py
@@ -1,17 +1,30 @@
 from django.conf import settings
 from django.conf.urls import url, include
-
-from normandy.control import views as control_views
 from django.contrib.auth.views import login, logout_then_login
+from django.core.urlresolvers import reverse_lazy
+
+from normandy.control import views
+
 
 app_name = 'control'
 urlpatterns = []
 
+
 if settings.ADMIN_ENABLED:
     urlpatterns += [
         url(r'^control/', include([
-            url('login', login, {'template_name': 'control/admin/login.html'}, name='login'),
-            url('logout', logout_then_login, {'login_url': '/control/login.html'}, name='logout'),
-            url(r'^.*$', control_views.IndexView, name='index'),
+            url(
+                'login',
+                login,
+                {'template_name': 'control/admin/login.html'},
+                name='login'
+            ),
+            url(
+                'logout',
+                logout_then_login,
+                {'login_url': reverse_lazy('control:login')},
+                name='logout'
+            ),
+            url(r'^.*$', views.IndexView, name='index'),
         ]))
     ]


### PR DESCRIPTION
This fixes a bug where the login page showed the 404 page of the
control app since the login page is separate from the frontend app.

I couldn't think of any good unit tests that we'd want to keep around for this. Someday I think we'll just allow login via the API and have frontend-based login views, but that day is not today.

@rehandalal r?