### PR TITLE
Add ProductionReadOnly environment to settings.

### DIFF
--- a/normandy/base/middleware.py
+++ b/normandy/base/middleware.py
@@ -1,23 +1,4 @@
-from django.core.urlresolvers import Resolver404, resolve
 from django.utils import timezone
-
-
-class ShortCircuitMiddleware(object):
-    """
-    Middleware that skips remaining middleware when a view is marked with
-    normandy.base.decorators.short_circuit_middlewares
-    """
-
-    def process_request(self, request):
-        try:
-            result = resolve(request.path)
-        except Resolver404:
-            return
-
-        if getattr(result.func, 'short_circuit_middlewares', False):
-            return result.func(request, *result.args, **result.kwargs)
-        else:
-            return None
 
 
 class RequestReceivedAtMiddleware(object):


### PR DESCRIPTION
This environment will be used on public webheads that shouldn't
make changes to the database. Mainly we want to disable things that
modify cookies (like SessionMiddleware) on these nodes.

@mythmon r?