### PR TITLE
Reversion improvements

### DIFF
--- a/normandy/control/static/control/admin/sass/control.scss
+++ b/normandy/control/static/control/admin/sass/control.scss
@@ -330,33 +330,24 @@
 
 /* Recipe History */
 .recipe-history {
-  .history-item {
-    display: flex;
-    flex-direction: row;
+  td {
+    text-align: left;
+  }
 
-    .revision-number,
-    .revision-created {
-      line-height: 20px;
-      margin: 0 20px;
-    }
+  .revision-number {
+    font-weight: 600;
 
-    .revision-number {
-      flex: 0;
-      font-weight: 600;
-    }
+    /* Force table cell to smallest width */
+    white-space: nowrap;
+    width: 1px;
+  }
 
-    .revision-created {
-      flex: 1;
-    }
+  .status-indicator {
+    margin: 0 20px; /* Reset .status-indicator margin */
+  }
 
-    .revision-status {
-      flex: 1;
-      margin: 0 20px; /* Reset .status-indicator margin */
-    }
-
-    .label {
-      padding: 0px;
-    }
+  .label {
+    padding: 0px;
   }
 }
 

--- a/normandy/control/tests/components/RecipeHistory.js
+++ b/normandy/control/tests/components/RecipeHistory.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { HistoryItem, HistoryList } from '../../static/control/js/components/RecipeHistory.js';
+
+describe('Recipe history components', () => {
+  describe('<HistoryList>', () => {
+    it('should render a <HistoryItem> for each revision', () => {
+      const recipe = { revision_id: 2 };
+      const revision1 = { id: 1 };
+      const revision2 = { id: 2 };
+      const dispatch = () => null;
+      const wrapper = shallow(
+        <HistoryList dispatch={dispatch} recipe={recipe} revisions={[revision1, revision2]} />
+      );
+
+      const items = wrapper.find(HistoryItem);
+      expect(items.length).toEqual(2);
+      expect(items.get(0).props.revision).toEqual(revision1);
+      expect(items.get(1).props.revision).toEqual(revision2);
+    });
+  });
+
+  describe('<HistoryItem>', () => {
+    it('should render the revision info', () => {
+      const dispatch = () => null;
+      const recipe = { revision_id: 1 };
+      const revision = {
+        id: 2,
+        recipe,
+        date_created: '2016-08-10T04:16:58.440Z+00:00',
+        comment: 'test comment',
+      };
+
+      const wrapper = shallow(
+        <HistoryItem revision={revision} recipe={recipe} dispatch={dispatch} />
+      );
+      expect(wrapper.find('.revision-number').text()).toContain(revision.recipe.revision_id);
+      expect(wrapper.find('.revision-comment').text()).toContain(revision.comment);
+      expect(wrapper.find('.status-indicator').text()).toContain('Current Revision');
+    });
+
+    it('should not render the status indicator if the revision is not current', () => {
+      const dispatch = () => null;
+      const recipe = { revision_id: 2 };
+      const revision = {
+        id: 3,
+        recipe: { revision_id: 1 },
+        date_created: '2016-08-10T04:16:58.440Z+00:00',
+        comment: 'test comment',
+      };
+
+      const wrapper = shallow(
+        <HistoryItem revision={revision} recipe={recipe} dispatch={dispatch} />
+      );
+      expect(wrapper.find('.status-indicator').isEmpty()).toEqual(true);
+    });
+  });
+});

--- a/normandy/recipes/api/serializers.py
+++ b/normandy/recipes/api/serializers.py
@@ -152,6 +152,7 @@ class ClientSerializer(serializers.Serializer):
 
 class RecipeVersionSerializer(serializers.ModelSerializer):
     date_created = serializers.DateTimeField(source='revision.date_created', read_only=True)
+    comment = serializers.CharField(source='revision.comment', read_only=True)
     recipe = RecipeSerializer(source='_object_version.object', read_only=True)
 
     class Meta:
@@ -160,4 +161,5 @@ class RecipeVersionSerializer(serializers.ModelSerializer):
             'id',
             'date_created',
             'recipe',
+            'comment',
         ]

--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -198,8 +198,7 @@ class RecipeVersionViewSet(viewsets.ReadOnlyModelViewSet):
     ]
 
     def get_queryset(self):
-        content_type = ContentType.objects.get_for_model(Recipe)
-        return Version.objects.filter(content_type=content_type)
+        return Version.objects.get_for_model(Recipe)
 
 
 class ClassifyClient(views.APIView):

--- a/normandy/recipes/management/commands/update_actions.py
+++ b/normandy/recipes/management/commands/update_actions.py
@@ -33,6 +33,7 @@ class Command(BaseCommand):
     @reversion.create_revision()
     def handle(self, *args, **options):
         disabled_recipes = []
+        reversion.set_comment('Updating actions.')
 
         action_names = settings.ACTIONS.keys()
         if options['action_name']:


### PR DESCRIPTION
So like I was going to work on real bugs but got distracted thinking about how I couldn't tell which revisions were made during `update_actions` and which ones weren't. Thus, this PR!

1. Updates `update_actions` to set a comment on reversions it creates.
2. A tiny tweak to simplify a view by using a helper I found.
3. Adds comments to the history page. This got a bit out of control in terms of size, but whatever.

   Because the styling of the history page got difficult using flexbox, and because the data is tabular anyway, I converted the page to use a table. To make unit testing some of my changes easier, I also split the history component into a state container and a presentational component. The container should really be managing state in redux instead of on itself, but that tidbit can wait until a later refactoring. I couldn't think of good ways to test the container and it's mostly unchanged from the old code anyway, so I didn't test it, but I did test the presentational stuff.

@rehandalal r?