### PR TITLE
Delete babel dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "wolfy87-eventemitter": "4.3.0"
   },
   "devDependencies": {
-    "babel": "6.5.2",
     "babel-core": "6.11.4",
     "babel-eslint": "6.1.2",
     "babel-loader": "6.2.4",


### PR DESCRIPTION
Hello, while it doesn't really hurt anything by being there, you should be able to delete the `babel` dep as babel@6 doesn't really do anything. (FYI I haven't run the tests though.)