### PR TITLE
Update docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5.1-slim
+FROM python:3.5.2-slim
 WORKDIR /app
 RUN groupadd --gid 1001 app && useradd -g app --uid 1001 --shell /usr/sbin/nologin app
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
python:3.5.1-slim has been removed from Dockerhub.

@relud r?