### PR TITLE
Minify webpack code in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install -U 'pip>=8' && \
     npm install
 
 COPY . /app
-RUN ./node_modules/.bin/webpack && \
+RUN NODE_ENV=production ./node_modules/.bin/webpack && \
     DJANGO_CONFIGURATION=Build ./manage.py collectstatic --no-input && \
     mkdir -p media && chown app:app media && \
     mkdir -p __version__ && \

--- a/circle.yml
+++ b/circle.yml
@@ -46,7 +46,7 @@ test:
         echo Starting Firefox
         firefox localhost:9876
       ) &
-      bin/ci/docker-run.sh -p 9876:9876 node bin/ci/karma-ci.js
+      bin/ci/docker-run.sh -e NODE_ENV=production -p 9876:9876 node bin/ci/karma-ci.js
     # Start the app, and run acceptance tests
     - bin/ci/contract-tests.sh
 


### PR DESCRIPTION
In my testing, this takes the control bundle from 2.29MB to 727KB in production. It should also silence all the prop types in production. They are still there, just quieter.

@Osmose r?