### PR TITLE
Log navigator.oscpu via the client classification endpoint.

### DIFF
--- a/client/selfrepair/self_repair_runner.js
+++ b/client/selfrepair/self_repair_runner.js
@@ -90,10 +90,13 @@ export function fetchRecipes() {
  * @promise Resolves with an object containing client info.
  */
 export function classifyClient() {
-  const { classifyUrl } = document.documentElement.dataset;
+  let { classifyUrl } = document.documentElement.dataset;
   const headers = { Accept: 'application/json' };
 
-  return fetch(classifyUrl, { headers })
+  classifyUrl = new URL(classifyUrl, window.location.href);
+  classifyUrl.searchParams.set('oscpu', classifyClient.getOscpu() || 'unknown');
+
+  return fetch(classifyUrl.href, { headers })
   .then(response => response.json())
   .then(classification => {
     // Parse request time
@@ -101,6 +104,7 @@ export function classifyClient() {
     return classification;
   });
 }
+classifyClient.getOscpu = () => navigator.oscpu;
 
 
 /**

--- a/client/tests/utils.js
+++ b/client/tests/utils.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * Create a fetch-mock matcher that matches URLs based on their path
+ * alone.
+ * @param  {String} urlToMatch URL path to match against (including leading /)
+ * @return {Function}          Function for use as a fetch-mock matcher.
+ */
+export function urlPathMatcher(path) {
+  return url => {
+    const parsedUrl = new URL(url);
+    return parsedUrl.pathname === path;
+  };
+}

--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -179,6 +179,12 @@ in other Django projects.
 
     .. _mozlog: https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md
 
+.. envvar:: DJANGO_LOG_OSCPU_RATE
+
+    :default: ``0.001``
+
+    Rate to log ``navigator.oscpu`` values sent by clients.
+
 Gunicorn settings
 -----------------
 These settings control how Gunicorn starts, when the default command of the

--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -1,3 +1,6 @@
+import logging
+import random
+
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.views.decorators.cache import cache_control
@@ -25,6 +28,9 @@ from normandy.recipes.api.serializers import (
     RecipeVersionSerializer,
     SignedRecipeSerializer,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class ActionViewSet(CachingViewsetMixin, viewsets.ReadOnlyModelViewSet):
@@ -214,6 +220,13 @@ class ClassifyClient(views.APIView):
     serializer_class = ClientSerializer
 
     def get(self, request, format=None):
+        # Temporary: Log navigator.oscpu as sent by users.
+        if 'oscpu' in request.GET and random.random() <= settings.LOG_OSCPU_RATE:
+            oscpu = request.GET['oscpu']
+            logger.debug('navigator.oscpu={}'.format(oscpu), extra={
+                'navigator.oscpu': oscpu
+            })
+
         client = Client(request)
         serializer = self.serializer_class(client, context={'request': request})
         return Response(serializer.data)

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -599,3 +599,19 @@ class TestClassifyClient(object):
         res = api_client.get('/api/v1/classify_client/')
         assert res.status_code == 200
         assert res.client.cookies == {}
+
+    def test_it_logs_oscpu(self, api_client, settings, mocker):
+        settings.LOG_OSCPU_RATE = 1
+        logger = mocker.patch('normandy.recipes.api.views.logger')
+
+        api_client.get('/api/v1/classify_client/', {'oscpu': 'test_oscpu'})
+        logger.debug.assert_called_with('navigator.oscpu=test_oscpu', extra={
+            'navigator.oscpu': 'test_oscpu'
+        })
+
+    def test_it_doesnt_log_missing_oscpu(self, api_client, settings, mocker):
+        settings.LOG_OSCPU_RATE = 1
+        logger = mocker.patch('normandy.recipes.api.views.logger')
+
+        api_client.get('/api/v1/classify_client/')
+        assert not logger.debug.called

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -255,6 +255,7 @@ class Base(Core):
     ACTION_IMPLEMENTATION_CACHE_TIME = values.IntegerValue(60 * 60 * 24 * 365)
     NUM_PROXIES = values.IntegerValue(0)
     API_CACHE_TIME = values.IntegerValue(30)
+    LOG_OSCPU_RATE = values.FloatValue(0.001)
     # Autograph settings
     AUTOGRAPH_URL = values.Value()
     AUTOGRAPH_HAWK_ID = values.Value()
@@ -277,6 +278,7 @@ class Development(Base):
 
     CAN_EDIT_ACTIONS_IN_USE = values.BooleanValue(True)
     API_CACHE_TIME = values.IntegerValue(0)
+    LOG_OSCPU_RATE = values.FloatValue(1)
 
 
 class Production(Base):


### PR DESCRIPTION
Prior to implementing operating system filtering, I'd like to collect some data from users about what the value of `navigator.oscpu` is, since we'll be using that value to filter by OS.

This is marked as Do Not Merge because I'd like a data review from @rjweiss first, which happens via Bugzilla flags AFAICT. I (or anyone, really) can remove that tag once the data review on Bugzilla is approved.

Fixes [bug 1296028](https://bugzilla.mozilla.org/show_bug.cgi?id=1296028).

@mythmon r? Since you're probably most familiar with how logging should be done.