### PR TITLE
Add test for changing the action field

### DIFF
--- a/client/control/components/RecipeForm.js
+++ b/client/control/components/RecipeForm.js
@@ -47,7 +47,7 @@ export class DisconnectedRecipeForm extends React.Component {
 
   changeAction(event) {
     const { dispatch, fields } = this.props;
-    const selectedActionName = event.currentTarget.value;
+    const selectedActionName = event.target.value;
 
     dispatch(destroy('action'));
     fields.action.onChange(event);

--- a/client/control/tests/components/test_RecipeForm.js
+++ b/client/control/tests/components/test_RecipeForm.js
@@ -28,4 +28,22 @@ describe('<RecipeForm>', () => {
       <RecipeForm params={{}} location={{ query: '' }} />
     </Provider>);
   });
+
+  describe('changeAction', () => {
+    const store = controlStore();
+    const recipeFormWrapper = mount(<Provider store={store}>
+      <RecipeForm params={{}} recipe={{ action: 'show-heartbeat' }} location={{ query: '' }} />
+    </Provider>);
+
+    const disconnectedFormWrapper = recipeFormWrapper.find('DisconnectedRecipeForm').get(0);
+    disconnectedFormWrapper.changeAction({ target: { value: 'console-log' } });
+
+    it('should update the selectedAction in state', () => {
+      expect(disconnectedFormWrapper.state.selectedAction).toEqual({ name: 'console-log' });
+    });
+
+    it('should change the action form component', () => {
+      expect(recipeFormWrapper.find('ConsoleLogForm').length).toEqual(1);
+    });
+  });
 });

--- a/client/control/tests/components/test_RecipeForm.js
+++ b/client/control/tests/components/test_RecipeForm.js
@@ -30,19 +30,21 @@ describe('<RecipeForm>', () => {
   });
 
   describe('changeAction', () => {
-    const store = controlStore();
-    const recipeFormWrapper = mount(<Provider store={store}>
-      <RecipeForm params={{}} recipe={{ action: 'show-heartbeat' }} location={{ query: '' }} />
-    </Provider>);
+    let store;
+    let recipeFormWrapper;
+    let disconnectedFormWrapper;
 
-    const disconnectedFormWrapper = recipeFormWrapper.find('DisconnectedRecipeForm').get(0);
-    disconnectedFormWrapper.changeAction({ target: { value: 'console-log' } });
-
-    it('should update the selectedAction in state', () => {
-      expect(disconnectedFormWrapper.state.selectedAction).toEqual({ name: 'console-log' });
+    beforeEach(() => {
+      store = controlStore();
+      recipeFormWrapper = mount(<Provider store={store}>
+        <RecipeForm params={{}} recipe={{ action: 'show-heartbeat' }} location={{ query: '' }} />
+      </Provider>);
+      disconnectedFormWrapper = recipeFormWrapper.find('DisconnectedRecipeForm').get(0);
+      disconnectedFormWrapper.changeAction({ target: { value: 'console-log' } });
     });
 
-    it('should change the action form component', () => {
+    it('should change the action in state & update the form', () => {
+      expect(disconnectedFormWrapper.state.selectedAction).toEqual({ name: 'console-log' });
       expect(recipeFormWrapper.find('ConsoleLogForm').length).toEqual(1);
     });
   });


### PR DESCRIPTION
This adds a test for changing the action field in the recipe forms as brought up in https://github.com/mozilla/normandy/pull/239. This is more of an integration test, I just plopped it into our existing recipe form test file. Maybe we want to split our tests into `unit` and `integration` directories?