### PR TITLE
Allow editing actions, regardless of recipe usage

### DIFF
--- a/normandy/recipes/admin/model_admins.py
+++ b/normandy/recipes/admin/model_admins.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.template.loader import render_to_string
 
 from normandy.recipes import models
-from normandy.recipes.forms import ActionAdminForm, RecipeAdminForm
+from normandy.recipes.forms import RecipeAdminForm
 
 from reversion.admin import VersionAdmin
 
@@ -39,8 +39,7 @@ class RecipeAdmin(VersionAdmin):
 
 @admin.register(models.Action)
 class ActionAdmin(VersionAdmin):
-    form = ActionAdminForm
-    list_display = ['name', 'implementation_hash', 'in_use']
+    list_display = ['name', 'implementation_hash']
     fieldsets = [
         [None, {
             'fields': [
@@ -61,12 +60,3 @@ class ActionAdmin(VersionAdmin):
             'recipes': action.recipes_used_by.order_by('name'),
         })
     recipe_list.short_description = 'Used in Recipes'
-
-    def in_use(self, action):
-        """
-        Wrapper around the Action.in_use property so that we can set the
-        boolean attribute to display a nice checkmark for the field in
-        the admin.
-        """
-        return action.in_use
-    in_use.boolean = True

--- a/normandy/recipes/forms.py
+++ b/normandy/recipes/forms.py
@@ -7,20 +7,6 @@ import jsonschema
 from jsonschema import SchemaError, ValidationError as JSONValidationError
 
 
-class ActionAdminForm(forms.ModelForm):
-    def clean(self):
-        """
-        Validate that the action being edited isn't currently in use.
-        """
-        super().clean()
-
-        if self.instance.in_use:
-            self.add_error(
-                None,
-                ValidationError('Action is currently in use and cannot be edited.')
-            )
-
-
 class RecipeAdminForm(forms.ModelForm):
     def clean(self):
         """Validate the arguments against their schema."""

--- a/normandy/recipes/management/commands/update_actions.py
+++ b/normandy/recipes/management/commands/update_actions.py
@@ -21,13 +21,6 @@ class Command(BaseCommand):
             type=str,
             help='Only update the specified actions'
         )
-        parser.add_argument(
-            '--no-disable',
-            action='store_true',
-            dest='no-disable',
-            default=False,
-            help='Do not disable recipes using actions that are updated'
-        )
 
     @transaction.atomic
     @reversion.create_revision()

--- a/normandy/recipes/management/commands/update_actions.py
+++ b/normandy/recipes/management/commands/update_actions.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from reversion import revisions as reversion
 from webpack_loader.utils import get_loader
 
-from normandy.recipes.models import Action, Recipe
+from normandy.recipes.models import Action
 
 
 class Command(BaseCommand):
@@ -32,7 +32,6 @@ class Command(BaseCommand):
     @transaction.atomic
     @reversion.create_revision()
     def handle(self, *args, **options):
-        disabled_recipes = []
         reversion.set_comment('Updating actions.')
 
         action_names = settings.ACTIONS.keys()
@@ -57,12 +56,6 @@ class Command(BaseCommand):
                     action.arguments_schema = arguments_schema
                     action.save()
 
-                    # As a precaution, disable any recipes that are
-                    # being used by an action that was just updated.
-                    if not options['no-disable']:
-                        recipes = Recipe.objects.filter(action=action, enabled=True)
-                        disabled_recipes += list(recipes)
-                        recipes.update(enabled=False)
             except Action.DoesNotExist:
                 action = Action(
                     name=name,
@@ -72,11 +65,6 @@ class Command(BaseCommand):
                 action.save()
 
             self.stdout.write('Done')
-
-        if disabled_recipes:
-            self.stdout.write('\nThe following recipes were disabled while updating actions:')
-            for recipe in disabled_recipes:
-                self.stdout.write(recipe.name)
 
 
 def get_implementation(action_name):

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -177,11 +177,6 @@ class Action(models.Model):
         self.arguments_schema_json = json.dumps(value)
 
     @property
-    def in_use(self):
-        """True if this action is being used by any active recipes."""
-        return self.recipes_used_by.exists()
-
-    @property
     def recipes_used_by(self):
         """Set of enabled recipes that are using this action."""
         return self.recipe_set.filter(enabled=True)

--- a/normandy/recipes/tests/test_admin.py
+++ b/normandy/recipes/tests/test_admin.py
@@ -1,0 +1,15 @@
+import pytest
+
+from normandy.recipes.tests import ActionFactory
+
+
+@pytest.mark.django_db
+class TestActionAdmin(object):
+    def test_it_works(self, admin_client):
+        res = admin_client.get('/admin/recipes/action/')
+        assert res.status_code == 200
+
+    def test_it_works_with_actions(self, admin_client):
+        ActionFactory()
+        res = admin_client.get('/admin/recipes/action/')
+        assert res.status_code == 200

--- a/normandy/recipes/tests/test_commands.py
+++ b/normandy/recipes/tests/test_commands.py
@@ -67,7 +67,7 @@ class TestUpdateActions(object):
         assert action.implementation == 'new_impl'
         assert action.arguments_schema == {'type': 'int'}
 
-    def test_it_disables_recipes_when_updating(self, mock_action):
+    def test_it_doesnt_disable_recipes(self, mock_action):
         recipe = RecipeFactory(
             action__name='test-action',
             action__implementation='old',
@@ -75,20 +75,6 @@ class TestUpdateActions(object):
         )
         action = recipe.action
         mock_action(action.name, 'impl', action.arguments_schema)
-
-        call_command('update_actions')
-        recipe.refresh_from_db()
-        assert not recipe.enabled
-
-    def test_it_doesnt_disable_recipes_if_action_doesnt_change(self, mock_action):
-        recipe = RecipeFactory(
-            action__name='test-action',
-            action__implementation='impl',
-            action__arguments_schema={},
-            enabled=True,
-        )
-        action = recipe.action
-        mock_action(action.name, action.implementation, action.arguments_schema)
 
         call_command('update_actions')
         recipe.refresh_from_db()

--- a/normandy/recipes/tests/test_commands.py
+++ b/normandy/recipes/tests/test_commands.py
@@ -101,19 +101,6 @@ class TestUpdateActions(object):
         dont_update_action.refresh_from_db()
         assert dont_update_action.implementation == 'old'
 
-    def test_it_can_skip_disabling_recipes(self, mock_action):
-        recipe = RecipeFactory(
-            action__name='test-action',
-            action__implementation='old',
-            enabled=True
-        )
-        action = recipe.action
-        mock_action(action.name, 'impl', action.arguments_schema)
-
-        call_command('update_actions', '--no-disable')
-        recipe.refresh_from_db()
-        assert recipe.enabled
-
     def test_it_sets_the_revision_comment(self, mock_action):
         mock_action('test-action', 'console.log("foo");', {'type': 'int'})
 

--- a/normandy/recipes/tests/test_forms.py
+++ b/normandy/recipes/tests/test_forms.py
@@ -2,28 +2,17 @@ from django.forms import modelform_factory
 
 import pytest
 
-from normandy.recipes.forms import ActionAdminForm, RecipeAdminForm
+from normandy.recipes.forms import RecipeAdminForm
 from normandy.recipes.models import Action, Recipe
 from normandy.recipes.tests import ActionFactory, RecipeFactory
 
 
 @pytest.mark.django_db()
 def test_action_admin_form_in_use():
-    """Actions that are in-use cannot be edited."""
+    """Actions that are in-use can be edited."""
     action = RecipeFactory(enabled=True).action
 
-    FormClass = modelform_factory(Action, form=ActionAdminForm, fields=['name'])
-    form = FormClass({'name': 'foo'}, instance=action)
-    assert not form.is_valid()
-    assert len(form.non_field_errors()) == 1
-
-
-@pytest.mark.django_db()
-def test_action_admin_form_not_in_use():
-    """Actions that are not in-use can be edited."""
-    action = RecipeFactory(enabled=False).action
-
-    FormClass = modelform_factory(Action, form=ActionAdminForm, fields=['name'])
+    FormClass = modelform_factory(Action, fields=['name'])
     form = FormClass({'name': 'foo'}, instance=action)
     assert form.is_valid()
 

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -33,16 +33,6 @@ class TestAction(object):
         RecipeFactory.create_batch(2, action=action, enabled=False)
         assert list(action.recipes_used_by) == []
 
-    def test_in_use(self):
-        action = ActionFactory()
-        assert not action.in_use
-
-        RecipeFactory(action=action, enabled=False)
-        assert not action.in_use
-
-        RecipeFactory(action=action, enabled=True)
-        assert action.in_use
-
 
 @pytest.mark.django_db
 class TestRecipe(object):

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,7 +106,7 @@ module.exports = [
           var cmd;
           if (argv['update-actions']) {
             // Don't disable actions since this is mostly for development.
-            cmd = 'python manage.py update_actions --no-disable';
+            cmd = 'python manage.py update_actions';
 
             childProcess.exec(cmd, function (err, stdout, stderr) {
               console.log('\n' + BOLD + 'Updating Actions' + END_BOLD);


### PR DESCRIPTION
This just makes our lives harder, especially during deploys. Since the actions are part of this repo, I don't think the case we were protecting against is valid anymore.

@Osmose r?