### PR TITLE
Make signature verification more helpful and add tests

### DIFF
--- a/normandy/recipes/checks.py
+++ b/normandy/recipes/checks.py
@@ -41,9 +41,11 @@ def recipe_signatures_are_correct(app_configs, **kwargs):
             data = recipe.canonical_json()
             signature = recipe.signature.signature
             pubkey = recipe.signature.public_key
-            if not verify_signature(data, signature, pubkey):
-                msg = ("Recipe '{recipe}' (id={recipe.id}) has a bad signature"
-                       .format(recipe=recipe))
+            try:
+                verify_signature(data, signature, pubkey)
+            except verify_signature.BadSignature as e:
+                msg = ("Recipe '{recipe}' (id={recipe.id}) has a bad signature: {detail}"
+                       .format(recipe=recipe, detail=e.detail))
                 errors.append(Warning(msg, id=WARNING_INVALID_RECIPE_SIGNATURE))
 
     return errors

--- a/normandy/recipes/tests/__init__.py
+++ b/normandy/recipes/tests/__init__.py
@@ -98,7 +98,9 @@ class SignatureFactory(factory.DjangoModelFactory):
     class Meta:
         model = Signature
 
-    signature = 'fake signature'
+    signature = 'a' * 128
+    public_key = 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh+JqU60off8jnvWkQAnP/P4vdKjP0aFiK4rrDne5rsqNd4A4A/z5P2foRFltlS6skODDIUu4X/C2pwROMgSXpkRFZxXk9IwATCRCVQ7YnffR8f1Jw5fWzCerDmf5fAj5'  # noqa
+    x5u = 'https://example.com/fake.x5u'
 
 
 ARGUMENTS_SCHEMA = {

--- a/normandy/recipes/tests/test_factories.py
+++ b/normandy/recipes/tests/test_factories.py
@@ -23,5 +23,5 @@ class TestRecipeFactory:
     def test_signed_true(self):
         r = RecipeFactory(signed=True)
         assert r.signature is not None
-        assert r.signature.signature == 'fake signature'
+        assert len(r.signature.signature) == 128
         assert isinstance(r.signature.timestamp, datetime)

--- a/normandy/recipes/tests/test_serializers.py
+++ b/normandy/recipes/tests/test_serializers.py
@@ -127,9 +127,10 @@ class TestSignedRecipeSerializer:
         combined_serializer = SignedRecipeSerializer(instance=recipe, context=context)
         recipe_serializer = RecipeSerializer(instance=recipe, context=context)
 
+        # Testing for shape of data, not contents
         assert combined_serializer.data == {
             'signature': {
-                'signature': 'fake signature',
+                'signature': Whatever(),
                 'timestamp': Whatever(),
                 'x5u': Whatever(),
                 'public_key': Whatever(),

--- a/normandy/recipes/tests/test_utils.py
+++ b/normandy/recipes/tests/test_utils.py
@@ -106,10 +106,29 @@ class TestAutographer(object):
 
 class TestVerifySignature(object):
 
-    def test_known_good_signature(self):
-        # known good data
-        data = '{"action":"console-log","approval":null,"arguments":{"message":"telemetry available"},"current_approval_request":null,"enabled":true,"filter_expression":"telemetry != undefined","id":22,"is_approved":false,"last_updated":"2016-09-01T23:03:17.360536Z","name":"mythmon\'s system addon test","revision_id":2}'  # noqa
-        signature = 'sSyFLu0fY7mcrMwueJlvV9JV7XCrBUyEJCx08awzhPhGcUXEO7gC0gA15GLMbkHEfC1ekOoK0WGhQwMZgEMbT_QOQf4BqquG8C1zsjOpUEf7d38D4nyFA7Ow7gPNzYLQ'  # noqa
-        pubkey = 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh+JqU60off8jnvWkQAnP/P4vdKjP0aFiK4rrDne5rsqNd4A4A/z5P2foRFltlS6skODDIUu4X/C2pwROMgSXpkRFZxXk9IwATCRCVQ7YnffR8f1Jw5fWzCerDmf5fAj5'  # noqa
+    # known good data
+    data = '{"action":"console-log","approval":null,"arguments":{"message":"telemetry available"},"current_approval_request":null,"enabled":true,"filter_expression":"telemetry != undefined","id":22,"is_approved":false,"last_updated":"2016-09-01T23:03:17.360536Z","name":"mythmon\'s system addon test","revision_id":2}'  # noqa
+    signature = 'sSyFLu0fY7mcrMwueJlvV9JV7XCrBUyEJCx08awzhPhGcUXEO7gC0gA15GLMbkHEfC1ekOoK0WGhQwMZgEMbT_QOQf4BqquG8C1zsjOpUEf7d38D4nyFA7Ow7gPNzYLQ'  # noqa
+    pubkey = 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh+JqU60off8jnvWkQAnP/P4vdKjP0aFiK4rrDne5rsqNd4A4A/z5P2foRFltlS6skODDIUu4X/C2pwROMgSXpkRFZxXk9IwATCRCVQ7YnffR8f1Jw5fWzCerDmf5fAj5'  # noqa
 
-        assert verify_signature(data, signature, pubkey)
+    def test_known_good_signature(self):
+        assert verify_signature(self.data, self.signature, self.pubkey)
+
+    def test_raises_nice_error_for_too_short_signatures_bad_padding(self):
+        signature = 'a_too_short_signature'
+
+        with pytest.raises(verify_signature.WrongSignatureSize):
+            verify_signature(self.data, signature, self.pubkey)
+
+    def test_raises_nice_error_for_too_short_signatures_good_base64(self):
+        signature = 'aa=='
+
+        with pytest.raises(verify_signature.WrongSignatureSize):
+            verify_signature(self.data, signature, self.pubkey)
+
+    def test_raises_nice_error_for_wrong_signature(self):
+        # change the signature, but keep it a valid signature
+        signature = self.signature.replace('s', 'S')
+
+        with pytest.raises(verify_signature.SignatureDoesNotMatch):
+            verify_signature(self.data, signature, self.pubkey)


### PR DESCRIPTION
This make signature verification give useful errors when something goes wrong, and makes the heartbeat page catch those errors and print them nicely.