### PR TITLE
Test that Vary: Cookie isn't sent on the hot path

### DIFF
--- a/contract-tests/conftest.py
+++ b/contract-tests/conftest.py
@@ -29,3 +29,14 @@ def requests_session(conf):
     session = requests.Session()
     session.verify = conf.getoption('verify')
     return session
+
+
+@pytest.fixture
+def only_readonly(requests_session, conf):
+    """Check if the current server is a readonly server, skip if it is not"""
+    r = requests_session.get(conf.getoption('server') + '/__version__')
+    r.raise_for_status()
+    data = r.json()
+
+    if not data.get('configuration') == 'ProductionReadOnly':
+        pytest.skip('Server config is not ProductionReadOnly')

--- a/contract-tests/test_performance.py
+++ b/contract-tests/test_performance.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+"""These are paths hit by self repair that need to be very fast"""
+HOT_PATHS = [
+    '/en-US/repair',
+    '/en-US/repair/',
+    '/api/v1/recipe/',
+    '/api/v1/action/',
+]
+
+
+@pytest.mark.parametrize('path', HOT_PATHS)
+class TestHotPaths(object):
+    """
+    Test for performance-enhancing properties of the site.
+
+    This file does not test performance by measuring runtimes and throughput.
+    Instead it tests for markers of features that would speed up or slow down the
+    site, such as cache headers.
+    """
+
+    def test_no_redirects(self, conf, requests_session, path):
+        r = requests_session.get(conf.getoption('server') + path)
+        r.raise_for_status()
+        assert 200 <= r.status_code < 300
+
+    def test_no_vary_cookie(self, conf, requests_session, path, only_readonly):
+        r = requests_session.get(conf.getoption('server') + path)
+        r.raise_for_status()
+        assert 'cookie' not in r.headers.get('vary', '').lower()

--- a/normandy/health/api/views.py
+++ b/normandy/health/api/views.py
@@ -37,6 +37,7 @@ def version(request):
         'source': repo_url,
         'commit': commit,
         'commit_link': '{0}/commit/{1}'.format(repo_url, commit) if commit else None,
+        'configuration': os.environ.get('DJANGO_CONFIGURATION'),
     })
 
 

--- a/normandy/health/tests/test_api.py
+++ b/normandy/health/tests/test_api.py
@@ -14,6 +14,7 @@ def test_version(client, mocker):
         'source': 'https://github.com/mozilla/normandy',
         'commit': '<git hash>',
         'commit_link': 'https://github.com/mozilla/normandy/commit/<git hash>',
+        'configuration': 'Test',
     }
 
 


### PR DESCRIPTION
Having a `Vary` header with a value that includes "Cookie" will destroy any performance we might hope to have. This PR adds an external test to verify we don't send this kind of header on performance sensitive servers.

@chartjes r? (please use the new Github review feature, since merging PRs is now gated on having a approved review)