### PR TITLE
signing: Store bare signature from autograph, not content-signature

### DIFF
--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -19,7 +19,7 @@ from normandy.recipes.utils import Autographer
 from normandy.recipes.validators import validate_json
 
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class Approval(models.Model):
@@ -42,6 +42,13 @@ class RecipeQuerySet(models.QuerySet):
         autographer = Autographer()
         # Convert to a list because order must be preserved
         recipes = list(self)
+
+        recipe_ids = [r.id for r in recipes]
+        logger.info(
+            'Requesting signatures for recipes with ids [%s] from Autograph',
+            (recipe_ids, ),
+            extra={'recipe_ids': recipe_ids})
+
         canonical_jsons = [r.canonical_json() for r in recipes]
         signatures_data = autographer.sign_data(canonical_jsons)
 
@@ -156,7 +163,11 @@ class Recipe(DirtyFieldsMixin, models.Model):
 
     def update_signature(self):
         autographer = Autographer()
-        # Convert to a list because order must be preserved
+
+        logger.info(
+            'Requesting signatures for recipes with ids [%s] from Autograph',
+            self.id,
+            extra={'recipe_ids': [self.id]})
 
         signature_data = autographer.sign_data([self.canonical_json()])[0]
         signature = Signature(**signature_data)

--- a/normandy/recipes/utils.py
+++ b/normandy/recipes/utils.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import logging
 
 import ecdsa
 import requests
@@ -9,6 +10,9 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
 from django.utils.functional import cached_property
+
+
+logger = logging.getLogger(__name__)
 
 
 def fraction_to_key(frac):
@@ -107,11 +111,14 @@ class Autographer:
         res.raise_for_status()
         signing_responses = res.json()
 
+        logger.info('Got %s signatures from Autograph', len(signing_responses))
+
         signatures = []
         for res in signing_responses:
+
             signatures.append({
                 'timestamp': ts,
-                'signature': res['content-signature'],
+                'signature': res['signature'],
                 'x5u': res.get('x5u'),
                 'public_key': res['public_key'],
             })


### PR DESCRIPTION
This changes the signatures stored in the database from `x5u=URL;ecdsa384=SIG` to just `SIG`. The rest of the data is already stored in the DB.

This will require changes to the system addon, since it was built against the longer version.