### PR TITLE
Test server heartbeat

### DIFF
--- a/bin/ci/contract-tests.sh
+++ b/bin/ci/contract-tests.sh
@@ -14,6 +14,7 @@ SERVER_ID=$(./docker-run.sh -e DJANGO_CONFIGURATION=ProductionInsecure -d)
 docker run --net host -e CHECK_PORT=8000 -e CHECK_HOST=localhost giorgos/takis
 echo "Running acceptance tests"
 ./docker-run.sh py.test contract-tests/ \
+  -vv \
   --server http://localhost:8000 \
   --junitxml=/test_artifacts/pytest.xml
 STATUS=$?

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ test:
     # Run lint checks
     - bin/ci/docker-run.sh therapist run --use-tracked-files
     # Run Python tests
-    - bin/ci/docker-run.sh py.test --junitxml=/test_artifacts/pytest.xml normandy/
+    - bin/ci/docker-run.sh py.test -vv --junitxml=/test_artifacts/pytest.xml normandy/
     # Start Karma test server, and run them in Firefox
     - |
       (

--- a/contract-tests/test_heartbeat.py
+++ b/contract-tests/test_heartbeat.py
@@ -1,0 +1,11 @@
+def test_heartbeat_is_ok(conf, requests_session):
+    r = requests_session.get(conf.getoption('server') + '/__heartbeat__')
+    # No r.raise_for_status() so we can check other things first
+    response = r.json()
+
+    # Verify there is at least one check being made
+    assert len(response['checks'].keys()) > 0
+    # This will give nice-ish errors if there are failing tests
+    assert response['details'] == {}
+    assert response['status'] == 'ok'
+    assert r.status_code == 200

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -312,9 +312,14 @@ class ProductionInsecure(Production):
     CSRF_COOKIE_SECURE = values.BooleanValue(False)
     SECURE_HSTS_SECONDS = values.IntegerValue(0)
     SESSION_COOKIE_SECURE = values.BooleanValue(False)
+
+    # These checks aren't useful for a purposefully insecure environment
     SILENCED_SYSTEM_CHECKS = values.ListValue([
+        'security.W004',  # check hsts seconds
         'security.W008',  # Secure SSL redirect
         'security.W009',  # Secret key length
+        'security.W012',  # Check session cookie secure
+        'security.W016',  # Check CSRF cookie secure
     ])
 
 


### PR DESCRIPTION
Recently, @relud added support for running the contract tests during deploys. Failures in the contract tests will mark a deploy as failed, and are generally much nicer than finding the same problems after the deploy.

This PR adds a test that checks the `/__heartbeat__` endpoint of the server, which contains several internal checks.

@chartjes r?