### PR TITLE
Set HSTS to 6 months in prod

### DIFF
--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -286,6 +286,7 @@ class Production(Base):
     USE_X_FORWARDED_HOST = values.BooleanValue(True)
     SECURE_PROXY_SSL_HEADER = values.TupleValue(('HTTP_X_FORWARDED_PROTO', 'https'))
     LOGGING_USE_JSON = values.Value(True)
+    SECURE_HSTS_SECONDS = values.IntegerValue(15768000)  # Six months
 
 
 class ProductionReadOnly(Production):


### PR DESCRIPTION
We set HSTS to a silly small number at first, since we dind't have a good idea of how HTTPS would work out. By now we've built a lot of confidence in running on HTTPS and haven't seen any problems from it. [As recommended by Observatory](https://observatory.mozilla.org/analyze.html?host=self-repair.mozilla.org), this sets the HSTS time to 6 months.

This means that a client, after connecting to us once, should always use HTTPS for every interaction for 6 months. Since we redirect all HTTP traffic to HTTPS anyways, this is what we want. The risk is that if we decide that we want to stop all HTTPS for some reason, it would take up to 6 months for clients to stop trying to use HTTPS. I don't think we'll do that.

@rehandalal r?