### PR TITLE
Remove navigator.oscpu logging

### DIFF
--- a/client/selfrepair/self_repair_runner.js
+++ b/client/selfrepair/self_repair_runner.js
@@ -94,7 +94,6 @@ export function classifyClient() {
   const headers = { Accept: 'application/json' };
 
   classifyUrl = new URL(classifyUrl, window.location.href);
-  classifyUrl.searchParams.set('oscpu', classifyClient.getOscpu() || 'unknown');
 
   return fetch(classifyUrl.href, { headers })
   .then(response => response.json())
@@ -104,7 +103,6 @@ export function classifyClient() {
     return classification;
   });
 }
-classifyClient.getOscpu = () => navigator.oscpu;
 
 
 /**

--- a/client/selfrepair/tests/test_self_repair_runner.js
+++ b/client/selfrepair/tests/test_self_repair_runner.js
@@ -38,23 +38,6 @@ describe('Self-Repair Runner', () => {
       }));
       expect(new URL(fetchMock.lastUrl()).pathname).toEqual(url);
     });
-
-    it('should include navigator.oscpu in the query arguments', async () => {
-      const oscpu = 'fake oscpu';
-      spyOn(classifyClient, 'getOscpu').and.returnValue(oscpu);
-
-      await classifyClient();
-      const fetchUrl = new URL(fetchMock.lastUrl());
-      expect(fetchUrl.searchParams.get('oscpu')).toEqual(oscpu);
-    });
-
-    it('should indicate when it could not find navigator.oscpu', async () => {
-      spyOn(classifyClient, 'getOscpu').and.returnValue(undefined);
-
-      await classifyClient();
-      const fetchUrl = new URL(fetchMock.lastUrl());
-      expect(fetchUrl.searchParams.get('oscpu')).toEqual('unknown');
-    });
   });
 
   describe('filterContext', () => {

--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -179,12 +179,6 @@ in other Django projects.
 
     .. _mozlog: https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md
 
-.. envvar:: DJANGO_LOG_OSCPU_RATE
-
-    :default: ``0.001``
-
-    Rate to log ``navigator.oscpu`` values sent by clients.
-
 Gunicorn settings
 -----------------
 These settings control how Gunicorn starts, when the default command of the

--- a/normandy/recipes/api/views.py
+++ b/normandy/recipes/api/views.py
@@ -1,6 +1,3 @@
-import logging
-import random
-
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.views.decorators.cache import cache_control
@@ -28,9 +25,6 @@ from normandy.recipes.api.serializers import (
     RecipeVersionSerializer,
     SignedRecipeSerializer,
 )
-
-
-logger = logging.getLogger(__name__)
 
 
 class ActionViewSet(CachingViewsetMixin, viewsets.ReadOnlyModelViewSet):
@@ -220,13 +214,6 @@ class ClassifyClient(views.APIView):
     serializer_class = ClientSerializer
 
     def get(self, request, format=None):
-        # Temporary: Log navigator.oscpu as sent by users.
-        if 'oscpu' in request.GET and random.random() <= settings.LOG_OSCPU_RATE:
-            oscpu = request.GET['oscpu']
-            logger.debug('navigator.oscpu={}'.format(oscpu), extra={
-                'navigator.oscpu': oscpu
-            })
-
         client = Client(request)
         serializer = self.serializer_class(client, context={'request': request})
         return Response(serializer.data)

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -599,19 +599,3 @@ class TestClassifyClient(object):
         res = api_client.get('/api/v1/classify_client/')
         assert res.status_code == 200
         assert res.client.cookies == {}
-
-    def test_it_logs_oscpu(self, api_client, settings, mocker):
-        settings.LOG_OSCPU_RATE = 1
-        logger = mocker.patch('normandy.recipes.api.views.logger')
-
-        api_client.get('/api/v1/classify_client/', {'oscpu': 'test_oscpu'})
-        logger.debug.assert_called_with('navigator.oscpu=test_oscpu', extra={
-            'navigator.oscpu': 'test_oscpu'
-        })
-
-    def test_it_doesnt_log_missing_oscpu(self, api_client, settings, mocker):
-        settings.LOG_OSCPU_RATE = 1
-        logger = mocker.patch('normandy.recipes.api.views.logger')
-
-        api_client.get('/api/v1/classify_client/')
-        assert not logger.debug.called

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -255,7 +255,6 @@ class Base(Core):
     ACTION_IMPLEMENTATION_CACHE_TIME = values.IntegerValue(60 * 60 * 24 * 365)
     NUM_PROXIES = values.IntegerValue(0)
     API_CACHE_TIME = values.IntegerValue(30)
-    LOG_OSCPU_RATE = values.FloatValue(0.001)
     # Autograph settings
     AUTOGRAPH_URL = values.Value()
     AUTOGRAPH_HAWK_ID = values.Value()
@@ -278,7 +277,6 @@ class Development(Base):
 
     CAN_EDIT_ACTIONS_IN_USE = values.BooleanValue(True)
     API_CACHE_TIME = values.IntegerValue(0)
-    LOG_OSCPU_RATE = values.FloatValue(1)
 
 
 class Production(Base):


### PR DESCRIPTION
This has been in prod about a week now. We can nix it.

I didn't just revert the original commit because I think there was some useful changes to the JS tests in it, which I left in place.