### PR TITLE
Use pretty JSON for browsable API

### DIFF
--- a/normandy/base/api/renderers.py
+++ b/normandy/base/api/renderers.py
@@ -32,3 +32,8 @@ class CanonicalJSONRenderer(renderers.BaseRenderer):
 
     def render(self, data, media_type=None, renderer_context=None):
         return canonicaljson.encode_canonical_json(data)
+
+
+class CustomBrowsableAPIRenderer(renderers.BrowsableAPIRenderer):
+    def get_default_renderer(self, view):
+        return renderers.JSONRenderer()

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -94,7 +94,7 @@ class Core(Configuration):
         'TEST_REQUEST_DEFAULT_FORMAT': 'json',
         'DEFAULT_RENDERER_CLASSES': (
             'normandy.base.api.renderers.CanonicalJSONRenderer',
-            'rest_framework.renderers.BrowsableAPIRenderer',
+            'normandy.base.api.renderers.CustomBrowsableAPIRenderer',
         )
     }
 


### PR DESCRIPTION
# Before

![shot_771](https://cloud.githubusercontent.com/assets/305049/18725901/f3580c94-7ff6-11e6-9e92-58db0426d295.png)

# After

![shot_907](https://cloud.githubusercontent.com/assets/305049/18725903/f72f459e-7ff6-11e6-9b93-545c3aea9a73.png)

