### PR TITLE
Update contract-tests to expect raw signatures from api

### DIFF
--- a/contract-tests/test_api.py
+++ b/contract-tests/test_api.py
@@ -98,8 +98,6 @@ def test_recipe_signatures(conf, requests_session):
 
     for item in data:
         canonical_recipe = canonicaljson.encode_canonical_json(item['recipe'])
-        signature_pairs = item['signature']['signature'].split(';')
-        signature_parts = dict(part.split('=') for part in signature_pairs)
-        signature = signature_parts['p384ecdsa']
+        signature = item['signature']['signature']
         pubkey = item['signature']['public_key']
         assert verify_signature(canonical_recipe, signature, pubkey)


### PR DESCRIPTION
The tests were not updated to deal with the changes in #264. We didn't see this breakage until we got to prod because nothing outside of prod had signatures. This showed up as a failed test in prod.

In the future we may want to add "destructive" tests that create signed recipes and verifies them, instead of relying on data on the server.