### PR TITLE
Sigs on new recipes

### DIFF
--- a/normandy/conftest.py
+++ b/normandy/conftest.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from django.core.cache import caches
 from django.conf import settings
 
@@ -33,3 +35,19 @@ def geolocation():
         skip_except_in_ci()
     else:
         return geolocation_module
+
+
+@pytest.fixture
+def mocked_autograph(mocker):
+    mocked = mocker.patch('normandy.recipes.models.Autographer')
+
+    def fake_sign(datas):
+        sigs = []
+        for d in datas:
+            sigs.append({
+                'signature': hashlib.sha256(d).hexdigest()
+            })
+        return sigs
+
+    mocked.return_value.sign_data.side_effect = fake_sign
+    return mocked

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -118,6 +118,7 @@ class Recipe(DirtyFieldsMixin, models.Model):
     def __str__(self):
         return self.name
 
+    @transaction.atomic
     def save(self, *args, skip_last_updated=False, **kwargs):
         if self.is_dirty(check_relationship=True):
             dirty_fields = self.get_dirty_fields(check_relationship=True)

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -122,9 +122,13 @@ class Recipe(DirtyFieldsMixin, models.Model):
         if self.is_dirty(check_relationship=True):
             dirty_fields = self.get_dirty_fields(check_relationship=True)
 
-            # If only the signature changed, skip the rest of the updates here, to avoid
-            # invalidating that signature. If anything else changed, remove the signature,
-            # since it is now invalid.
+            # If only the signature changed, skip the rest of the updates here,
+            # to avoid invalidating that signature. If the signature changed
+            # along with something else, raise an error, since the signature
+            # will probably be invalid. Otherwise, try and generate a new
+            # signature for the object. If that fails, remove the signature,
+            # because it is invalid now.
+
             dirty_field_names = list(dirty_fields.keys())
             should_sign = False
 

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -154,6 +154,11 @@ class Recipe(DirtyFieldsMixin, models.Model):
 
             if should_sign:
                 try:
+                    if self.id is None:
+                        # Save now, to get an ID for the signature.
+                        super().save(*args, **kwargs)
+                        # Change from insert to update, so the save() call at the end doesn't fail
+                        kwargs['force_insert'] = False
                     self.update_signature()
                 except ImproperlyConfigured:
                     self.signature = None

--- a/normandy/recipes/tests/__init__.py
+++ b/normandy/recipes/tests/__init__.py
@@ -41,6 +41,10 @@ class RecipeFactory(factory.DjangoModelFactory):
     enabled = True
     approval = factory.SubFactory(ApprovalFactory)
 
+    # It is important that the signature be based on the actual data, and not
+    # some static value so that tests can make assertions against what data was
+    # signed.
+
     @factory.post_generation
     def signed(self, create, extracted=False, **kwargs):
         if extracted:

--- a/normandy/recipes/tests/__init__.py
+++ b/normandy/recipes/tests/__init__.py
@@ -44,7 +44,7 @@ class RecipeFactory(factory.DjangoModelFactory):
     @factory.post_generation
     def signed(self, create, extracted=False, **kwargs):
         if extracted:
-            self.signature = SignatureFactory()
+            self.signature = SignatureFactory(data=self.canonical_json())
             self.signature.save()
             self.save()
         else:
@@ -97,8 +97,10 @@ class ApprovalRequestCommentFactory(factory.DjangoModelFactory):
 class SignatureFactory(factory.DjangoModelFactory):
     class Meta:
         model = Signature
+        exclude = ['data']
 
-    signature = 'a' * 128
+    data = b''
+    signature = factory.LazyAttribute(lambda o: hashlib.sha256(o.data).hexdigest())
     public_key = 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh+JqU60off8jnvWkQAnP/P4vdKjP0aFiK4rrDne5rsqNd4A4A/z5P2foRFltlS6skODDIUu4X/C2pwROMgSXpkRFZxXk9IwATCRCVQ7YnffR8f1Jw5fWzCerDmf5fAj5'  # noqa
     x5u = 'https://example.com/fake.x5u'
 

--- a/normandy/recipes/tests/test_factories.py
+++ b/normandy/recipes/tests/test_factories.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import datetime
 
 import pytest
@@ -23,5 +24,5 @@ class TestRecipeFactory:
     def test_signed_true(self):
         r = RecipeFactory(signed=True)
         assert r.signature is not None
-        assert len(r.signature.signature) == 128
+        assert r.signature.signature == hashlib.sha256(r.canonical_json()).hexdigest()
         assert isinstance(r.signature.timestamp, datetime)

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -111,6 +111,11 @@ class TestRecipe(object):
         expected = expected.encode()
         assert recipe.canonical_json() == expected
 
+    def test_signature_is_correct_on_creation_if_autograph_available(self, mocked_autograph):
+        recipe = RecipeFactory()
+        expected_sig = hashlib.sha256(recipe.canonical_json()).hexdigest()
+        assert recipe.signature.signature == expected_sig
+
     def test_signature_is_updated_if_autograph_available(self, mocked_autograph):
         recipe = RecipeFactory(name='unchanged')
         original_signature = recipe.signature


### PR DESCRIPTION
This fixes an issue where newly created recipes had the wrong signature. The signature was generated based on data that did not include an ID, since Django hadn't generated one yet.

r?