### PR TITLE
Do not include hashes in client assets in development.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ const production = process.env.NODE_ENV === 'production';
 var plugins = [
   new BundleTracker({ filename: './webpack-stats.json' }),
   new webpack.optimize.OccurrenceOrderPlugin(true),
-  new ExtractTextPlugin('[name]-[hash].css'),
+  new ExtractTextPlugin(production ? '[name]-[hash].css' : '[name].css'),
   new webpack.DefinePlugin({
     PRODUCTION: production,
     DEVELOPMENT: !production,
@@ -61,7 +61,7 @@ module.exports = [
 
     output: {
       path: path.resolve('./assets/bundles/'),
-      filename: '[name]-[hash].js',
+      filename: production ? '[name]-[hash].js' : '[name].js',
       chunkFilename: '[id].bundle.js',
     },
     externals: {
@@ -129,7 +129,7 @@ module.exports = [
 
     output: {
       path: path.resolve('./assets/bundles/'),
-      filename: '[name]-[hash].js',
+      filename: production ? '[name]-[hash].js' : '[name].js',
     },
 
     module: {


### PR DESCRIPTION
Currently, built assets have hashes in their filenames by default.
When working locally and using the watch command, this has the side
effect of generating a bunch of nearly-identical assets with different
filenames, and over time can take up a lot of space.

In a development environment there's no reason to use unique hashes in
asset filenames, so disabling this behavior will help avoid the buildup
of assets.