### PR TITLE
Add storage check before running shield study action

### DIFF
--- a/client/actions/shield-study/index.js
+++ b/client/actions/shield-study/index.js
@@ -1,13 +1,34 @@
 import { Action, registerAction } from '../utils';
 
 export default class ShieldStudyAction extends Action {
-  constructor(normandy, recipe) {
-    super(normandy, recipe);
-    this.storage = normandy.createStorage(recipe.id);
+  setHasBeenShown() {
+    this.storage.setItem('studyHasBeenShown', true);
+  }
+
+  async getHasBeenShown() {
+    const hasBeenShown = await this.storage.getItem('studyHasBeenShown');
+    return hasBeenShown;
   }
 
   async execute() {
+    try {
+      this.storage = await this.normandy.createStorage(this.recipe.id);
+    } catch (error) {
+      throw new Error(error);
+    }
+
+    const hasBeenShown = await this.getHasBeenShown();
+    const shouldShowStudyPrompt = (
+      this.normandy.testing
+      || hasBeenShown === null
+    );
+
+    if (!shouldShowStudyPrompt) {
+      return;
+    }
+
     this.normandy.showStudyConsentPage(this.recipe.arguments);
+    this.setHasBeenShown();
   }
 }
 

--- a/client/actions/shield-study/index.js
+++ b/client/actions/shield-study/index.js
@@ -10,9 +10,8 @@ export default class ShieldStudyAction extends Action {
     this.storage.setItem('studyHasBeenShown', true);
   }
 
-  async getHasBeenShown() {
-    const hasBeenShown = await this.storage.getItem('studyHasBeenShown');
-    return hasBeenShown;
+  getHasBeenShown() {
+    return this.storage.getItem('studyHasBeenShown');
   }
 
   async execute() {

--- a/client/actions/shield-study/index.js
+++ b/client/actions/shield-study/index.js
@@ -1,6 +1,11 @@
 import { Action, registerAction } from '../utils';
 
 export default class ShieldStudyAction extends Action {
+  constructor(normandy, recipe) {
+    super(normandy, recipe);
+    this.storage = normandy.createStorage(recipe.id);
+  }
+
   setHasBeenShown() {
     this.storage.setItem('studyHasBeenShown', true);
   }
@@ -11,10 +16,10 @@ export default class ShieldStudyAction extends Action {
   }
 
   async execute() {
-    try {
-      this.storage = await this.normandy.createStorage(this.recipe.id);
-    } catch (error) {
-      throw new Error(error);
+    const storageIsDurable = await this.storage.isDurable();
+
+    if (!storageIsDurable && !this.normandy.testing) {
+      throw new Error('Storage durability unconfirmed');
     }
 
     const hasBeenShown = await this.getHasBeenShown();

--- a/client/actions/shield-study/index.js
+++ b/client/actions/shield-study/index.js
@@ -15,12 +15,6 @@ export default class ShieldStudyAction extends Action {
   }
 
   async execute() {
-    const storageIsDurable = await this.storage.isDurable();
-
-    if (!storageIsDurable && !this.normandy.testing) {
-      throw new Error('Storage durability unconfirmed');
-    }
-
     const hasBeenShown = await this.getHasBeenShown();
     const shouldShowStudyPrompt = (
       this.normandy.testing

--- a/client/actions/tests/test_shield-study.js
+++ b/client/actions/tests/test_shield-study.js
@@ -14,4 +14,31 @@ describe('ShieldStudyAction', () => {
     await action.execute();
     expect(normandy.showStudyConsentPage).toHaveBeenCalledWith({ studyName: 'lorem ipsum' });
   });
+
+  it('should not run if it has already been shown', async () => {
+    const action = new ShieldStudyAction(normandy, { arguments: { studyName: 'lorem ipsum' } });
+
+    normandy.mock.storage.data.studyHasBeenShown = true;
+
+    await action.execute();
+    expect(normandy.showStudyConsentPage).not.toHaveBeenCalled();
+  });
+
+  it('should not run if localStorage is unavailable', async () => {
+    const action = new ShieldStudyAction(normandy, { arguments: { studyName: 'lorem ipsum' } });
+
+    normandy.testing = true;
+    spyOn(normandy, 'createStorage').and.returnValue(Promise.reject('err'));
+
+    expect(await action.execute()).toThrowError('err');
+  });
+
+  it('should always run in testing mode', async () => {
+    const action = new ShieldStudyAction(normandy, { arguments: { studyName: 'lorem ipsum' } });
+
+    normandy.testing = true;
+    normandy.mock.storage.data.studyHasBeenShown = true;
+    await action.execute();
+    expect(normandy.showStudyConsentPage).toHaveBeenCalled();
+  });
 });

--- a/client/actions/tests/test_shield-study.js
+++ b/client/actions/tests/test_shield-study.js
@@ -11,6 +11,9 @@ describe('ShieldStudyAction', () => {
 
   it('should log a message to the console', async () => {
     const action = new ShieldStudyAction(normandy, { arguments: { studyName: 'lorem ipsum' } });
+
+    normandy.mock.storage.data.storageDurability = 2;
+
     await action.execute();
     expect(normandy.showStudyConsentPage).toHaveBeenCalledWith({ studyName: 'lorem ipsum' });
   });
@@ -18,17 +21,17 @@ describe('ShieldStudyAction', () => {
   it('should not run if it has already been shown', async () => {
     const action = new ShieldStudyAction(normandy, { arguments: { studyName: 'lorem ipsum' } });
 
+    normandy.mock.storage.data.storageDurability = 2;
     normandy.mock.storage.data.studyHasBeenShown = true;
 
     await action.execute();
     expect(normandy.showStudyConsentPage).not.toHaveBeenCalled();
   });
 
-  it('should not run if localStorage is unavailable', async () => {
+  it('should not run if storage durability is unconfirmed', async () => {
     const action = new ShieldStudyAction(normandy, { arguments: { studyName: 'lorem ipsum' } });
 
-    normandy.testing = true;
-    spyOn(normandy, 'createStorage').and.returnValue(Promise.reject('err'));
+    normandy.mock.storage.data.storageDurability = 1;
 
     expect(await action.execute()).toThrowError('err');
   });

--- a/client/actions/tests/test_shield-study.js
+++ b/client/actions/tests/test_shield-study.js
@@ -33,7 +33,11 @@ describe('ShieldStudyAction', () => {
 
     normandy.mock.storage.data.storageDurability = 1;
 
-    expect(await action.execute()).toThrowError('err');
+    action.execute()
+      .then(() => fail())
+      .catch(error => {
+        expect(error.message).toEqual('Storage durability unconfirmed');
+      });
   });
 
   it('should always run in testing mode', async () => {

--- a/client/actions/tests/utils.js
+++ b/client/actions/tests/utils.js
@@ -82,7 +82,6 @@ export function mockNormandy() {
   const toSpy = [
     'location',
     'log',
-    'createStorage',
     'showHeartbeat',
     'client',
     'uuid',

--- a/client/actions/tests/utils.js
+++ b/client/actions/tests/utils.js
@@ -7,8 +7,8 @@ export class MockStorage {
   }
 
   async isDurable() {
-    const durability = this.data['storageDurability'];
-    return (durability === 2 ? true : false);
+    const durability = this.data.storageDurability;
+    return durability === 2;
   }
 
   getItem(key) {

--- a/client/actions/tests/utils.js
+++ b/client/actions/tests/utils.js
@@ -6,6 +6,11 @@ export class MockStorage {
     this.data = {};
   }
 
+  async isDurable() {
+    const durability = this.data['storageDurability'];
+    return (durability === 2 ? true : false);
+  }
+
   getItem(key) {
     const value = this.data[key];
     return Promise.resolve(value !== undefined ? value : null);
@@ -82,6 +87,7 @@ export function mockNormandy() {
   const toSpy = [
     'location',
     'log',
+    'createStorage',
     'showHeartbeat',
     'client',
     'uuid',

--- a/client/selfrepair/normandy_driver.js
+++ b/client/selfrepair/normandy_driver.js
@@ -12,6 +12,16 @@ class LocalStorage {
    */
   constructor(prefix) {
     this.prefix = prefix;
+
+    return new Promise((resolve, reject) => {
+      try {
+        localStorage.setItem('normandy-test', true);
+        localStorage.removeItem('normandy-test');
+        return resolve(this);
+      } catch (error) {
+        return reject('localStorage unavailable');
+      }
+    });
   }
 
   _makeKey(key) {

--- a/client/selfrepair/normandy_driver.js
+++ b/client/selfrepair/normandy_driver.js
@@ -16,9 +16,9 @@ class LocalStorage {
   }
 
   async _setDurabilityStatus() {
-    let durabilityStatus = await this.getItem('storageDurability');
+    const durabilityStatus = await this.getItem('storageDurability');
 
-    if (durabilityStatus && parseInt(durabilityStatus) < 2) {
+    if (durabilityStatus && parseInt(durabilityStatus, 10) < 2) {
       this.setItem('storageDurability', 2);
     } else {
       this.setItem('storageDurability', 1);
@@ -26,12 +26,8 @@ class LocalStorage {
   }
 
   async isDurable() {
-    let durabilityStatus = await this.getItem('storageDurability');
-    if (parseInt(durabilityStatus) === 2) {
-      return true;
-    } else {
-      return false;
-    }
+    const durabilityStatus = await this.getItem('storageDurability');
+    return (parseInt(durabilityStatus, 10) === 2);
   }
 
   _makeKey(key) {

--- a/client/selfrepair/normandy_driver.js
+++ b/client/selfrepair/normandy_driver.js
@@ -12,16 +12,26 @@ class LocalStorage {
    */
   constructor(prefix) {
     this.prefix = prefix;
+    this._setDurabilityStatus();
+  }
 
-    return new Promise((resolve, reject) => {
-      try {
-        localStorage.setItem('normandy-test', true);
-        localStorage.removeItem('normandy-test');
-        return resolve(this);
-      } catch (error) {
-        return reject('localStorage unavailable');
-      }
-    });
+  async _setDurabilityStatus() {
+    let durabilityStatus = await this.getItem('storageDurability');
+
+    if (durabilityStatus && parseInt(durabilityStatus) < 2) {
+      this.setItem('storageDurability', 2);
+    } else {
+      this.setItem('storageDurability', 1);
+    }
+  }
+
+  async isDurable() {
+    let durabilityStatus = await this.getItem('storageDurability');
+    if (parseInt(durabilityStatus) === 2) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   _makeKey(key) {


### PR DESCRIPTION
We don't want the shield study action to run if it's already been previously displayed to a user. I used a similar approach as the heartbeat action, saving a value to localStorage that denotes it's been shown.

I took a tiny stab at validating the localstorage with the strategy @Osmose mentioned [here](https://github.com/mozilla/normandy/issues/279#issuecomment-250794727) (I didnt quite understand the counter option, maybe someone can clarify it for me a little further and it's something I can take care of.) 

If you toggle the `dom.storage.enabled` pref in firefox you'll see the action execution stops if localstorage is unavailable. I tried to write a test for this but I'm having trouble writing a jasmine test that is _expected_ to fail. [My attempt](https://github.com/brittanystoroz/normandy/blob/82266f2030c81ce6cb804a638f516d60a3aa08bd/client/actions/tests/test_shield-study.js#L27-L34) seems to run the action execution and err out (as it should), but before it actually gets a chance to run the assertion.

Thoughts??
