### PR TITLE
Fix fetchRecipes test.

### DIFF
--- a/client/selfrepair/tests/test_self_repair_runner.js
+++ b/client/selfrepair/tests/test_self_repair_runner.js
@@ -46,9 +46,9 @@ describe('Self-Repair Runner', () => {
   describe('fetchRecipes', () => {
     it('should request recipes from server', async () => {
       document.documentElement.dataset.recipeUrl = '/api/v1/recipe/';
-      fetchMock.get('/api/v1/recipe/?enabled=true', 200);
+      fetchMock.get('/api/v1/recipe/?enabled=true', []);
 
-      fetchRecipes();
+      await fetchRecipes();
 
       expect(fetchMock.lastOptions()).toEqual({
         headers: {


### PR DESCRIPTION
The test wasn't properly awaiting on a promise, and was passing while logging an unhandled promise rejection.

Separately, we should probably make unhandled promise rejects actually fail tests instead of simply logging them.

r?