### PR TITLE
Fix heartbeat event stuff.

### DIFF
--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -154,6 +154,11 @@ export default class ShowHeartbeatAction extends Action {
       flow.save();
     });
 
+    heartbeat.on('Engaged', data => {
+      flow.setPhaseTimestamp('engaged', data.timestamp);
+      flow.save();
+    });
+
     this.setLastShownDate();
   }
 

--- a/client/actions/tests/test_show-heartbeat.js
+++ b/client/actions/tests/test_show-heartbeat.js
@@ -216,7 +216,7 @@ describe('ShowHeartbeatAction', () => {
   });
 
   it('should choose a random survey based on the weights', async () => {
-        // This test relies on the order of surveys passed in, which sucks.
+    // This test relies on the order of surveys passed in, which sucks.
     const survey20 = surveyFactory({ message: 'survey20', weight: 20 });
     const survey30 = surveyFactory({ message: 'survey30', weight: 30 });
     const survey50 = surveyFactory({ message: 'survey50', weight: 50 });
@@ -230,7 +230,7 @@ describe('ShowHeartbeatAction', () => {
       message: survey20.message,
     }));
 
-        // If the random number changes, return a different survey.
+    // If the random number changes, return a different survey.
     normandy = mockNormandy();
     action = new ShowHeartbeatAction(normandy, recipe);
     await action.execute();
@@ -264,9 +264,10 @@ describe('ShowHeartbeatAction', () => {
     emitter.emit('NotificationOffered', { timestamp: 20 });
     emitter.emit('LearnMore', { timestamp: 30 });
     emitter.emit('Voted', { timestamp: 40, score: 3 });
+    emitter.emit('Engaged', { timestamp: 50 });
 
-        // Checking per field makes recognizing which field failed
-        // _much_ easier.
+    // Checking per field makes recognizing which field failed
+    // _much_ easier.
     const flowData = normandy.saveHeartbeatFlow.calls.mostRecent().args[0];
     expect(flowData.response_version).toEqual(2);
     expect(flowData.survey_id).toEqual(recipe.arguments.surveyId);
@@ -278,6 +279,7 @@ describe('ShowHeartbeatAction', () => {
     expect(flowData.flow_began_ts).toEqual(10);
     expect(flowData.flow_offered_ts).toEqual(20);
     expect(flowData.flow_voted_ts).toEqual(40);
+    expect(flowData.flow_engaged_ts).toEqual(50);
     expect(flowData.channel).toEqual(client.channel);
     expect(flowData.version).toEqual(client.version);
     expect(flowData.locale).toEqual(normandy.locale);
@@ -312,8 +314,8 @@ describe('ShowHeartbeatAction', () => {
 
     await action.execute();
 
-        // Checking per field makes recognizing which field failed
-        // _much_ easier.
+    // Checking per field makes recognizing which field failed
+    // _much_ easier.
     const flowData = normandy.saveHeartbeatFlow.calls.mostRecent().args[0];
     expect(flowData.question_id).toEqual(longString);
     expect(flowData.locale).toEqual(longString);

--- a/client/actions/tests/utils.js
+++ b/client/actions/tests/utils.js
@@ -1,5 +1,4 @@
-import EventEmitter from 'wolfy87-eventemitter';
-
+import { HeartbeatEmitter } from '../../selfrepair/normandy_driver.js';
 
 export class MockStorage {
   constructor() {
@@ -37,7 +36,7 @@ export function mockNormandy() {
   const normandy = {
     mock: {
       storage: new MockStorage(),
-      heartbeatEmitter: new EventEmitter(),
+      heartbeatEmitter: new HeartbeatEmitter(),
       location: {
         countryCode: 'us',
       },

--- a/client/control/components/RecipePreview.js
+++ b/client/control/components/RecipePreview.js
@@ -19,6 +19,9 @@ export class UnwrappedRecipePreview extends React.Component {
       error: null,
       errorHelp: null,
     };
+
+    this.driver = new NormandyDriver();
+    this.driver.registerCallbacks();
   }
 
   componentWillMount() {
@@ -32,8 +35,6 @@ export class UnwrappedRecipePreview extends React.Component {
   attemptPreview() {
     const { recipe } = this.props;
     const { status } = this.state;
-    const driver = new NormandyDriver();
-    driver.registerCallbacks();
 
     if (recipe && status === 'start') {
       this.pingUITour();
@@ -42,7 +43,8 @@ export class UnwrappedRecipePreview extends React.Component {
         status: 'attempting',
       });
 
-      runRecipe(recipe, driver, { testing: true }).then(() => {
+      runRecipe(recipe, this.driver, { testing: true })
+      .then(() => {
         this.setState({
           status: 'executed',
         });

--- a/docs/dev/driver.rst
+++ b/docs/dev/driver.rst
@@ -55,7 +55,8 @@ The driver object contains the following attributes:
    :param learnMoreUrl: URL to open when the "Learn More" button is clicked.
    :param surveyId: Extra data to be stored in telemetry.
    :param surveyVersion: Extra data to be stored in telemetry.
-   :param testing: Extra data to be stored in telemetry when Normandy is in testing mode.
+   :param testing: Extra data to be stored in telemetry when Normandy is in
+      testing mode.
    :returns: A Promise that resolves with an event emitter.
 
    The emitter returned by this function can be subscribed to using ``on``
@@ -89,6 +90,10 @@ The driver object contains the following attributes:
       Emitted when the user clicks the star rating bar and submits a rating.
       An extra ``score`` attribute is included on the data object for this
       event containing the rating the user submitted.
+   Engaged
+      Emitted when the user clicks the engagement button. Only occurs if the
+      ``engagementButtonLabel`` parameter was given when ``showHeartbeat`` was
+      called.
    TelemetrySent
       Emitted after Heartbeat has sent flow data to the Telemetry servers. Only
       available on Firefox 46 and higher.

--- a/docs/dev/driver.rst
+++ b/docs/dev/driver.rst
@@ -98,6 +98,10 @@ The driver object contains the following attributes:
       Emitted after Heartbeat has sent flow data to the Telemetry servers. Only
       available on Firefox 46 and higher.
 
+   .. note:: Individual events are only emitted once; if `on` is called after an
+      event has already been emitted, the given callback will be called
+      immediately.
+
 .. js:function:: uuid()
 
    Generates a v4 UUID. The UUID is randomly generated.

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "redux-thunk": "2.1.0",
     "sha.js": "2.4.5",
     "uglifyjs": "2.4.10",
-    "underscore": "1.8.3",
-    "wolfy87-eventemitter": "5.1.0"
+    "underscore": "1.8.3"
   },
   "devDependencies": {
     "babel-core": "6.14.0",


### PR DESCRIPTION
There's a potential race condition in Heartbeat's event emitter, where we might not register events before the heartbeat prompt is shown. This fixes that by using a special event emitter for heartbeat that dispatches each event once, and will run callbacks immediately if the event they're hooked to has already run.

Also includes a fix for [bug 1302791](https://bugzilla.mozilla.org/show_bug.cgi?id=1302791) because I discovered it while originally writing this patch.

This is marked WIP because it lacks tests and should probably be split into two commits, but some feedback on the chosen solution would be appreciated.

@mythmon f?