### PR TITLE
Fix display issues for preview error message

### DIFF
--- a/client/control/components/RecipePreview.js
+++ b/client/control/components/RecipePreview.js
@@ -1,11 +1,12 @@
 import React, { PropTypes as pt } from 'react';
 import classNames from 'classnames';
+
 import composeRecipeContainer from './RecipeContainer.js';
 import { runRecipe } from '../../selfrepair/self_repair_runner.js';
 import NormandyDriver from '../../selfrepair/normandy_driver.js';
 import Mozilla from '../../selfrepair/uitour.js';
 
-class RecipePreview extends React.Component {
+export class UnwrappedRecipePreview extends React.Component {
   static propTypes = {
     recipe: pt.object.isRequired,
   }
@@ -55,16 +56,22 @@ class RecipePreview extends React.Component {
     }
   }
 
+  currentURL() {
+    // This is for mocking out in tests
+    return new URL(window.location);
+  }
+
   pingUITour() {
     const timeout = setTimeout(() => {
-      const url = new URL(window.location);
+      const url = this.currentURL();
       const prefName = 'browser.uitour.testingOrigins';
-      const prefValue = `${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ':'}`;
+      const prefValue = `${url.protocol}//${url.hostname}${url.port ? `:${url.port}` : ''}`;
+
       this.setState({
         status: 'error',
         error: 'UITour unavailable',
         errorHelp: (
-          <span>
+          <span className="uitour-error-help">
             Make sure the pref <code>{prefName}</code> includes <code>{prefValue}</code>.
           </span>
         ),
@@ -146,5 +153,4 @@ ExecuteStatus.propTypes = {
   errorHelp: pt.node,
 };
 
-
-export default composeRecipeContainer(RecipePreview);
+export default composeRecipeContainer(UnwrappedRecipePreview);

--- a/client/control/sass/control.scss
+++ b/client/control/sass/control.scss
@@ -376,4 +376,9 @@
       margin: 0 0 10px 20px;
       text-transform: none;
     }
+
+    code {
+      font-weight: 600;
+      white-space: nowrap;
+    }
 }

--- a/client/control/tests/components/test_RecipePreview.js
+++ b/client/control/tests/components/test_RecipePreview.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { UnwrappedRecipePreview } from '../../components/RecipePreview.js';
+
+describe('Recipe preview components', () => {
+  describe('<UnwrappedRecipePreview>', () => {
+    beforeEach(() => {
+      jasmine.clock().install();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    it('should not include a colon in the error when there is no port number', () => {
+      const preview = mount(<UnwrappedRecipePreview recipe={{}} />);
+      preview.instance().currentURL = () => new URL('http://example.com/control/');
+      jasmine.clock().tick(1000);
+      const errorHelp = preview.find('.uitour-error-help');
+      expect(errorHelp.text()).not.toContain('http://example.com:');
+    });
+
+    it('should include a colon in the error when there is a port number', () => {
+      const preview = mount(<UnwrappedRecipePreview recipe={{}} />);
+      preview.instance().currentURL = () => new URL('http://example.com:8000/control/');
+      jasmine.clock().tick(1000);
+      const errorHelp = preview.find('.uitour-error-help');
+      expect(errorHelp.text()).toContain('http://example.com:8000');
+    });
+  });
+});


### PR DESCRIPTION
This makes the error message a little easier to visually parse, and also removes the erroneous colon when there is no port in the URL.

### Before:

<img width="552" src="https://cloud.githubusercontent.com/assets/305049/19498372/4e054bc6-9545-11e6-8ef4-2ede55a6db64.png">

### After:

<img width="552" src="https://cloud.githubusercontent.com/assets/305049/19498378/52a9bea0-9545-11e6-9bff-1f96c7b37692.png">