### PR TITLE
Add prompt field for UI bar in shield study

### DIFF
--- a/client/actions/shield-study/package.json
+++ b/client/actions/shield-study/package.json
@@ -34,6 +34,11 @@
                     "description": "URL to study addon XPI",
                     "propertyOrder": 400
                 },
+                "promptMessage": {
+                    "type": "string",
+                    "description": "Message to show in the UI bar prompt to learn more about the study",
+                    "propertyOrder": 500
+                },
                 "buttonText": {
                     "type": "string",
                     "description": "Text for opt-in button",

--- a/client/control/components/action_forms/ShieldStudyForm.js
+++ b/client/control/components/action_forms/ShieldStudyForm.js
@@ -5,6 +5,7 @@ export const ShieldStudyFormFields = [
   'studyName',
   'addonName',
   'addonUrl',
+  'promptMessage',
   'buttonText',
   'thankYouText',
   'duration',
@@ -23,6 +24,7 @@ export default function ShieldStudyForm({ fields }) {
         <FormField type="text" label="Authors" field={fields.authors} />
         <FormField type="text" label="Addon Name" field={fields.addonName} />
         <FormField type="text" label="Addon URL" field={fields.addonUrl} />
+        <FormField type="text" label="Prompt Message" field={fields.promptMessage} />
         <FormField type="text" label="Button Text" field={fields.buttonText} />
         <FormField type="text" label="Thank You Text" field={fields.thankYouText} />
       </div>


### PR DESCRIPTION
Adds a `promptMessage` field to the shield study action so we can define what message is shown in the UI bar that appears before showing the consent page.  (e.g. "Help us make Firefox more efficient")
