### PR TITLE
#303 Add metaData and searchData to recipes

### DIFF
--- a/client/control/components/RecipeList.js
+++ b/client/control/components/RecipeList.js
@@ -99,21 +99,21 @@ class DisconnectedRecipeList extends React.Component {
     // check if there are specific properties/labels we want to display
     const requestedMetaProps = DisconnectedRecipeList.ActionMetaData[recipeAction];
 
-    // if we have a metadata definition to fill..
+    // if we have a metaData definition to fill...
     if (requestedMetaProps) {
+      // ...get the data we want to display
       const foundData = requestedMetaProps(newRecipe);
 
-      // add the data to the metaData collection
+      // ...and add it to the existing metaData collection
+      // (the data comes back as an array of objects,
+      // so we can just concat it to our existing array)
       newRecipe.metaData = newRecipe.metaData.concat(foundData);
     }
 
     // update the searchdata string with whatever the values are
     // (this is used for sorting/filtering/searching)
-    newRecipe.metaData.map(data => {
-      newRecipe.searchData += data.value;
-
-      // lint complains if we dont return
-      return data;
+    newRecipe.metaData.forEach(data => {
+      newRecipe.searchData = `${newRecipe.searchData} ${data.value}`;
     });
 
     return newRecipe;

--- a/client/control/components/RecipeList.js
+++ b/client/control/components/RecipeList.js
@@ -64,18 +64,17 @@ SwitchFilter.propTypes = {
 };
 
 class DisconnectedRecipeList extends React.Component {
-
   /**
    * Given a recipe object, determines what type of recipe it is (based on its `action`),
    * and then compiles a hash of 'displayed metadata props' and their values. This hash
-   * is saved on the recipe as `metaData`.
+   * is saved on the recipe as `metaData`, and displayed in the 'Metadata'
    *
    * Beyond that, a string of metaData values is created, and attached to the
    * recipe as the `searchData` property. This is used by the `Table` component
-   * in to search/filter over the metaData.
+   * to search/filter/sort the metaData.
    *
-   * @param  {Object} Original recipe received/passed into reducer
-   * @return {Object} Original recipe, but with `metaData` and `searchData` properties added
+   * @param  {Object} Original recipe object
+   * @return {Object} Original recipe but with `metaData` and `searchData` properties added
    */
   static applyUniqueRecipeID(recipe) {
     const newRecipe = { ...recipe };

--- a/client/control/components/RecipeList.js
+++ b/client/control/components/RecipeList.js
@@ -91,7 +91,7 @@ class DisconnectedRecipeList extends React.Component {
    * @param  {Object} Original recipe object
    * @return {Object} Original recipe but with `metaData` and `searchData` properties added
    */
-  static applyUniqueRecipeID(recipe) {
+  static applyRecipeMetadata(recipe) {
     const { action: recipeAction } = recipe;
     const newRecipe = { ...recipe };
 
@@ -179,7 +179,7 @@ class DisconnectedRecipeList extends React.Component {
   render() {
     const { recipes } = this.props;
     let filteredRecipes = this.state.filteredRecipes || recipes;
-    filteredRecipes = filteredRecipes.map(DisconnectedRecipeList.applyUniqueRecipeID);
+    filteredRecipes = filteredRecipes.map(DisconnectedRecipeList.applyRecipeMetadata);
 
     return (
       <div>

--- a/client/control/components/RecipeList.js
+++ b/client/control/components/RecipeList.js
@@ -72,10 +72,6 @@ class DisconnectedRecipeList extends React.Component {
     'show-heartbeat': {
       // prop name : displayed label
       surveyId: 'Survey ID',
-      thanksMessage: 'Thanks Message',
-    },
-    'console-log': {
-      message: 'Message',
     },
   };
 

--- a/client/control/components/RecipeList.js
+++ b/client/control/components/RecipeList.js
@@ -217,7 +217,8 @@ class DisconnectedRecipeList extends React.Component {
                       recipe.metaData
                         .map((metaProp, index) => (
                           <li key={index}>
-                            <span>{metaProp.label}:</span> {metaProp.value}
+                            <span className="metadata-label">{metaProp.label}:</span>
+                            {metaProp.value}
                           </li>
                         ))
                     }

--- a/client/control/components/RecipeList.js
+++ b/client/control/components/RecipeList.js
@@ -86,7 +86,7 @@ class DisconnectedRecipeList extends React.Component {
    * @param  {Object} Original recipe object
    * @return {Object} Original recipe but with `metaData` and `searchData` properties added
    */
-  static applyRecipeMetadata(recipe) {
+  static applyRecipeMetaData(recipe) {
     const { action: recipeAction } = recipe;
     const newRecipe = {
       ...recipe,
@@ -176,7 +176,7 @@ class DisconnectedRecipeList extends React.Component {
   render() {
     const { recipes } = this.props;
     let filteredRecipes = this.state.filteredRecipes || recipes;
-    filteredRecipes = filteredRecipes.map(DisconnectedRecipeList.applyRecipeMetadata);
+    filteredRecipes = filteredRecipes.map(DisconnectedRecipeList.applyRecipeMetaData);
 
     return (
       <div>

--- a/client/control/sass/control.scss
+++ b/client/control/sass/control.scss
@@ -384,10 +384,8 @@
 }
 
 /* Recipe List */
-#recipe-list {
-  .metadata-list {
-    span {
-      font-weight: 800;
-    }
+.metadata-list {
+  .metadata-label {
+    font-weight: 800;
   }
 }

--- a/client/control/sass/control.scss
+++ b/client/control/sass/control.scss
@@ -382,3 +382,12 @@
       white-space: nowrap;
     }
 }
+
+/* Recipe List */
+#recipe-list {
+  .metadata-list {
+    span {
+      font-weight: 800;
+    }
+  }
+}


### PR DESCRIPTION
- Add `metaData` and `searchData` properties to received recipes.
- `metaData` is a hash of displayed labels/values
- `searchData` is a string of concat'd metadata values, which is used by the `Table` component for searching/sorting/filtering.
- Desired metadata properties are defined in `DisconnectedRecipeList#ActionMetaData` and collected/applied in `DisconnectedRecipeList#applyRecipeMetadata`