### PR TITLE
#309 Add UUID to surveyId

### DIFF
--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -1,6 +1,6 @@
 import { Action, registerAction } from '../utils';
 
-const VERSION = 52; // Increase when changed.
+const VERSION = 53; // Increase when changed.
 const LAST_SHOWN_DELAY = 1000 * 60 * 60 * 24 * 7; // 7 days
 
 
@@ -128,11 +128,11 @@ export default class ShowHeartbeatAction extends Action {
     // A bit redundant but the action argument names shouldn't necessarily rely
     // on the argument names showHeartbeat takes.
     const heartbeatData = {
-      surveyId,
+      surveyId: `${surveyId}::${flow.id}`,
       message,
       engagementButtonLabel,
       thanksMessage,
-      postAnswerUrl: this.annotatePostAnswerUrl(postAnswerUrl),
+      postAnswerUrl: this.annotatePostAnswerUrl({ url: postAnswerUrl, userId: flow.id }),
       learnMoreMessage,
       learnMoreUrl,
       flowId: flow.id,
@@ -179,7 +179,7 @@ export default class ShowHeartbeatAction extends Action {
     return Number.isNaN(lastShown) ? null : lastShown;
   }
 
-  annotatePostAnswerUrl(url) {
+  annotatePostAnswerUrl({ url, userId }) {
     // Don't bother with empty URLs.
     if (!url) {
       return url;
@@ -193,6 +193,7 @@ export default class ShowHeartbeatAction extends Action {
       isDefaultBrowser: this.client.isDefaultBrowser ? 1 : 0,
       searchEngine: this.client.searchEngine,
       syncSetup: this.client.syncSetup ? 1 : 0,
+      userId,
     };
 
     // Append testing parameter if in testing mode.

--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -1,6 +1,6 @@
 import { Action, registerAction } from '../utils';
 
-const VERSION = 53; // Increase when changed.
+const VERSION = 54; // Increase when changed.
 const LAST_SHOWN_DELAY = 1000 * 60 * 60 * 24 * 7; // 7 days
 
 
@@ -125,14 +125,33 @@ export default class ShowHeartbeatAction extends Action {
     const flow = new HeartbeatFlow(this);
     flow.save();
 
+    let userId;
+    let heartbeatSurveyId = surveyId;
+
+    // should user ID stuff be sent to telemetry?
+    const { includeTelemetryUUID } = this.recipe.arguments;
+
+    if (includeTelemetryUUID) {
+      // get the already-defined UUID from normandy
+      // #todo normandy.userId is undefined
+      userId = this.normandy.userId;
+
+      // if a userId exists,
+      if (userId) {
+        // alter the survey ID to include that UUID
+        heartbeatSurveyId = `${surveyId}::${userId}`;
+      }
+    }
+
+
     // A bit redundant but the action argument names shouldn't necessarily rely
     // on the argument names showHeartbeat takes.
     const heartbeatData = {
-      surveyId: `${surveyId}::${flow.id}`,
+      surveyId: heartbeatSurveyId,
       message,
       engagementButtonLabel,
       thanksMessage,
-      postAnswerUrl: this.annotatePostAnswerUrl({ url: postAnswerUrl, userId: flow.id }),
+      postAnswerUrl: this.annotatePostAnswerUrl({ url: postAnswerUrl, userId }),
       learnMoreMessage,
       learnMoreUrl,
       flowId: flow.id,
@@ -193,8 +212,14 @@ export default class ShowHeartbeatAction extends Action {
       isDefaultBrowser: this.client.isDefaultBrowser ? 1 : 0,
       searchEngine: this.client.searchEngine,
       syncSetup: this.client.syncSetup ? 1 : 0,
-      userId,
     };
+
+    // if a userId is given,
+    // we'll include it with the data passed through
+    // to SurveyGizmo (via query params)
+    if (userId) {
+      args.userId = userId;
+    }
 
     // Append testing parameter if in testing mode.
     if (this.normandy.testing) {

--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -133,7 +133,6 @@ export default class ShowHeartbeatAction extends Action {
 
     if (includeTelemetryUUID) {
       // get the already-defined UUID from normandy
-      // #todo normandy.userId is undefined
       userId = this.normandy.userId;
 
       // if a userId exists,
@@ -142,7 +141,6 @@ export default class ShowHeartbeatAction extends Action {
         heartbeatSurveyId = `${surveyId}::${userId}`;
       }
     }
-
 
     // A bit redundant but the action argument names shouldn't necessarily rely
     // on the argument names showHeartbeat takes.

--- a/client/actions/show-heartbeat/package.json
+++ b/client/actions/show-heartbeat/package.json
@@ -17,6 +17,11 @@
         "thanksMessage"
       ],
       "properties": {
+        "includeTelemetryUUID": {
+          "type": "boolean",
+          "description": "Include unique user ID in post-answer-url and Telemetry",
+          "default": false
+        },
         "surveyId": {
           "type": "string",
           "description": "Slug uniquely identifying this survey in telemetry"

--- a/client/actions/tests/test_show-heartbeat.js
+++ b/client/actions/tests/test_show-heartbeat.js
@@ -141,17 +141,19 @@ describe('ShowHeartbeatAction', () => {
     normandy.mock.client.isDefaultBrowser = true;
     normandy.mock.client.searchEngine = 'shady-tims';
     normandy.mock.client.syncSetup = true;
+    normandy.uuid.and.returnValue('fake-uuid');
 
     await action.execute();
     const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
     const params = new URL(postAnswerUrl).searchParams;
     expect(params.get('source')).toEqual('heartbeat');
-    expect(params.get('surveyversion')).toEqual('52');
+    expect(params.get('surveyversion')).toEqual('53');
     expect(params.get('updateChannel')).toEqual('nightly');
     expect(params.get('fxVersion')).toEqual('42.0.1');
     expect(params.get('isDefaultBrowser')).toEqual('1');
     expect(params.get('searchEngine')).toEqual('shady-tims');
     expect(params.get('syncSetup')).toEqual('1');
+    expect(params.get('userId')).toEqual('fake-uuid');
   });
 
   it('should annotate the post-answer URL if it has an existing query string', async () => {
@@ -200,8 +202,13 @@ describe('ShowHeartbeatAction', () => {
     const action = new ShowHeartbeatAction(normandy, recipe);
 
     await action.execute();
+
+    // stub a fake UUID
+    normandy.uuid.and.returnValue('fake-uuid');
+
     expect(normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
-      surveyId: 'my-survey',
+      // returned surveyId should be `name::uuid`
+      surveyId: `my-survey::${normandy.uuid()}`,
       surveyVersion: 42,
     }));
   });

--- a/client/actions/tests/test_show-heartbeat.js
+++ b/client/actions/tests/test_show-heartbeat.js
@@ -197,6 +197,23 @@ describe('ShowHeartbeatAction', () => {
       revision_id: 42,
       arguments: {
         surveyId: 'my-survey',
+      },
+    });
+    const action = new ShowHeartbeatAction(normandy, recipe);
+
+    await action.execute();
+
+    expect(normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
+      surveyId: 'my-survey',
+      surveyVersion: 42,
+    }));
+  });
+
+  it('should pass a UUID telemetry argument when the recipe calls for it', async () => {
+    const recipe = recipeFactory({
+      revision_id: 42,
+      arguments: {
+        surveyId: 'my-survey',
         includeTelemetryUUID: true,
       },
     });

--- a/client/actions/tests/test_show-heartbeat.js
+++ b/client/actions/tests/test_show-heartbeat.js
@@ -226,7 +226,7 @@ describe('ShowHeartbeatAction', () => {
 
     // userId should be uuid4
     const UUID_ISH_REGEX = /^[a-f0-9-]{36}$/;
-    expect(UUID_ISH_REGEX.test(normandy.userId)).toBe(true);
+    expect(normandy.userId).toMatch(UUID_ISH_REGEX);
 
     expect(normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
       // returned surveyId should be `name::uuid`

--- a/client/actions/tests/utils.js
+++ b/client/actions/tests/utils.js
@@ -1,3 +1,5 @@
+import uuid from 'node-uuid';
+
 import { HeartbeatEmitter } from '../../selfrepair/normandy_driver.js';
 
 export class MockStorage {
@@ -70,6 +72,8 @@ export function mockNormandy() {
     uuid() {
       return 'fake-uuid';
     },
+    // this needs to be a valid UUID4 to pass regex tests later
+    userId: uuid(),
     saveHeartbeatFlow() {
       return Promise.resolve();
     },

--- a/client/control/components/action_forms/HeartbeatForm.js
+++ b/client/control/components/action_forms/HeartbeatForm.js
@@ -2,6 +2,7 @@ import React, { PropTypes as pt } from 'react';
 import FormField from '../form_fields/FormFieldWrapper.js';
 
 export const HeartbeatFormFields = [
+  'includeTelemetryUUID',
   'surveyId',
   'message',
   'engagementButtonLabel',
@@ -18,6 +19,11 @@ export default function HeartbeatForm({ fields }) {
         This action shows a single message or survey prompt to the user.
       </p>
       <div className="fluid-4">
+        <FormField
+          type="checkbox"
+          label="Include unique user ID in post-answer-url and Telemetry"
+          field={fields.includeTelemetryUUID}
+        />
         <FormField type="text" label="Survey ID" field={fields.surveyId} />
         <FormField label="Message" field={fields.message} />
         <FormField label="Engagement Button Label" field={fields.engagementButtonLabel} />

--- a/client/control/components/form_fields/FormFieldWrapper.js
+++ b/client/control/components/form_fields/FormFieldWrapper.js
@@ -19,6 +19,9 @@ SelectMenu.propTypes = {
 const FormField = props => {
   const { label, type, field, containerClass } = props;
   let fieldType;
+  // in some instances (checkbox) we want to nest the label
+  // so that the input and the text appear inline
+  let nestInputInLabel = false;
 
   switch (type) {
     case 'select':
@@ -35,6 +38,7 @@ const FormField = props => {
       break;
     case 'checkbox':
       fieldType = (<input type="checkbox" {...field} />);
+      nestInputInLabel = true;
       break;
     default:
       throw new Error(`Unexpected field type: "${type}"`);
@@ -44,10 +48,11 @@ const FormField = props => {
     <div className="row">
       <div className={containerClass}>
         <label htmlFor={field.name}>
+          {nestInputInLabel && fieldType}
           {label}
           <span className="validation-error">{field.error}</span>
         </label>
-        {fieldType}
+        {!nestInputInLabel && fieldType}
       </div>
     </div>
   );

--- a/client/control/components/form_fields/FormFieldWrapper.js
+++ b/client/control/components/form_fields/FormFieldWrapper.js
@@ -33,6 +33,9 @@ const FormField = props => {
     case 'textarea':
       fieldType = (<textarea field={field} {...field} />);
       break;
+    case 'checkbox':
+      fieldType = (<input type="checkbox" {...field} />);
+      break;
     default:
       throw new Error(`Unexpected field type: "${type}"`);
   }

--- a/client/selfrepair/normandy_driver.js
+++ b/client/selfrepair/normandy_driver.js
@@ -128,8 +128,25 @@ export default class NormandyDriver {
     }
   }
 
+  /**
+   * Generate a fresh UUID
+   * @return {String} Generated UUID
+   */
   uuid() {
     return uuid.v4();
+  }
+
+  /**
+   * Get a user id. If one doesn't exist yet, make one up and store it in local storage.
+   * @return {String} A stored or generated UUID
+   */
+  get userId() {
+    let userId = localStorage.getItem('userId');
+    if (userId === null) {
+      userId = uuid.v4();
+      localStorage.setItem('userId', userId);
+    }
+    return userId;
   }
 
   createStorage(prefix) {

--- a/client/selfrepair/self_repair_runner.js
+++ b/client/selfrepair/self_repair_runner.js
@@ -1,5 +1,3 @@
-import uuid from 'node-uuid';
-
 import JexlEnvironment from './JexlEnvironment.js';
 
 const registeredActions = {};
@@ -57,21 +55,6 @@ export function fetchAction(recipe) {
   return cache[recipe.action];
 }
 fetchAction._cache = {};
-
-
-/**
- * Get a user id. If one doesn't exist yet, make one up and store it in local storage.
- * @return {String} A stored or generated UUID
- */
-export function getUserId() {
-  let userId = localStorage.getItem('userId');
-  if (userId === null) {
-    userId = uuid.v4();
-    localStorage.setItem('userId', userId);
-  }
-  return userId;
-}
-
 
 /**
  * Fetch all enabled recipes from the server.
@@ -134,7 +117,7 @@ export async function filterContext(driver) {
   return {
     normandy: {
       locale: driver.locale,
-      userId: getUserId(),
+      userId: driver.userId,
       ...client,
       ...classification,
     },

--- a/client/selfrepair/tests/test_normandy_driver.js
+++ b/client/selfrepair/tests/test_normandy_driver.js
@@ -2,6 +2,7 @@ import fetchMock from 'fetch-mock';
 
 import NormandyDriver, { HeartbeatEmitter } from '../normandy_driver.js';
 import { urlPathMatcher } from '../../tests/utils.js';
+import { MockStorage } from '../../actions/tests/utils.js';
 
 describe('Normandy Driver', () => {
   describe('showHeartbeat', () => {
@@ -147,6 +148,27 @@ describe('Normandy Driver', () => {
       const driver = new NormandyDriver();
       const uuid = driver.uuid();
       expect(UUID_ISH_REGEX.test(uuid)).toBe(true);
+    });
+  });
+
+  describe('userId', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'localStorage', {
+        value: new MockStorage(),
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('should return the userId from localStorage', () => {
+      spyOn(window.localStorage, 'getItem').and.returnValue(null);
+      spyOn(window.localStorage, 'setItem');
+
+      const driver = new NormandyDriver();
+      let userId = driver.userId;
+
+      expect(window.localStorage.getItem).toHaveBeenCalledWith('userId');
+      expect(window.localStorage.setItem).toHaveBeenCalledWith('userId', userId);
     });
   });
 

--- a/client/selfrepair/tests/test_normandy_driver.js
+++ b/client/selfrepair/tests/test_normandy_driver.js
@@ -147,7 +147,7 @@ describe('Normandy Driver', () => {
       const UUID_ISH_REGEX = /^[a-f0-9-]{36}$/;
       const driver = new NormandyDriver();
       const uuid = driver.uuid();
-      expect(UUID_ISH_REGEX.test(uuid)).toBe(true);
+      expect(uuid).toMatch(UUID_ISH_REGEX);
     });
   });
 

--- a/client/selfrepair/tests/test_self_repair_runner.js
+++ b/client/selfrepair/tests/test_self_repair_runner.js
@@ -68,7 +68,7 @@ describe('Self-Repair Runner', () => {
       const driver = mockNormandy();
       const context = await filterContext(driver);
       expect(context.normandy.userId).toBeDefined();
-      expect(UUID_ISH_REGEX.test(context.normandy.userId)).toBe(true);
+      expect(context.normandy.userId).toMatch(UUID_ISH_REGEX);
     });
   });
 

--- a/client/selfrepair/tests/test_self_repair_runner.js
+++ b/client/selfrepair/tests/test_self_repair_runner.js
@@ -1,6 +1,6 @@
 import fetchMock from 'fetch-mock';
 
-import { mockNormandy, MockStorage } from '../../actions/tests/utils.js';
+import { mockNormandy } from '../../actions/tests/utils.js';
 import {
   classifyClient,
   doesRecipeMatch,
@@ -8,7 +8,6 @@ import {
   fetchRecipes,
   filterContext,
   loadActionImplementation,
-  getUserId,
 } from '../self_repair_runner.js';
 import { urlPathMatcher } from '../../tests/utils.js';
 
@@ -136,25 +135,6 @@ describe('Self-Repair Runner', () => {
       const impl1 = await impl1Promise;
       const impl2 = await impl2Promise;
       expect(impl1).toEqual(impl2);
-    });
-  });
-
-  describe('getUserId', () => {
-    beforeEach(() => {
-      Object.defineProperty(window, 'localStorage', {
-        value: new MockStorage(),
-        configurable: true,
-        writable: true,
-      });
-    });
-
-    it('should return the userId from localStorage', () => {
-      spyOn(window.localStorage, 'getItem').and.returnValue(null);
-      spyOn(window.localStorage, 'setItem');
-
-      getUserId();
-      expect(window.localStorage.getItem).toHaveBeenCalledWith('userId');
-      expect(window.localStorage.setItem).toHaveBeenCalledWith('userId', jasmine.any(String));
     });
   });
 });

--- a/docs/dev/driver.rst
+++ b/docs/dev/driver.rst
@@ -108,6 +108,10 @@ The driver object contains the following attributes:
 
    :returns: String containing the UUID.
 
+.. js:data:: userId
+
+   The v4 UUID currently assigned to the user, loaded from the client's localStorage. If no UUID exists, a new one is generated, and saved to localStorage.
+
 .. js:function:: createStorage(keyPrefix)
 
    Creates a storage object that can be used to store data on the client.


### PR DESCRIPTION
- Add UUID to surveyId (e.g. `my-survey::USERS-UUID`)
- Add `userId` to query param for the `postAnswerUrl` (for SurveyGizmo)

*Note: I had to run `npm run watch -- --update-actions` to update the heartbeat action with new code - you may have to as well!*