### PR TITLE
Fix propType errors

### DIFF
--- a/client/control/components/RecipeList.js
+++ b/client/control/components/RecipeList.js
@@ -58,7 +58,7 @@ function SwitchFilter({ options, selectedFilter, updateFilter }) {
   );
 }
 SwitchFilter.propTypes = {
-  options: pt.object.isRequired,
+  options: pt.array.isRequired,
   selectedFilter: pt.any.isRequired,
   updateFilter: pt.func.isRequired,
 };

--- a/client/selfrepair/tests/test_JexlEnvironment.js
+++ b/client/selfrepair/tests/test_JexlEnvironment.js
@@ -79,7 +79,7 @@ describe('JexlEnvironment', () => {
 
       return Promise.all(promises)
       .then(results => {
-        let count = results.filter(x => x).length;
+        const count = results.filter(x => x).length;
         expect(count).toBeGreaterThan(sample * rate / (1 + accuracy));
         expect(count).toBeLessThan(sample * rate * (1 + accuracy));
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ if (production) {
 module.exports = [
   {
     context: __dirname,
-    devtool: production ? undefined : 'eval-source-map',
+    devtool: production ? undefined : 'eval',
 
     entry: {
       selfrepair: [
@@ -95,7 +95,7 @@ module.exports = [
     },
   },
   {
-    devtool: production ? undefined : 'eval-source-map',
+    devtool: production ? undefined : 'eval',
 
     entry: {
       'console-log': './client/actions/console-log/index',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ if (production) {
 module.exports = [
   {
     context: __dirname,
-    devtool: production ? undefined : 'eval',
+    devtool: production ? undefined : 'cheap-module-eval-source-map',
 
     entry: {
       selfrepair: [
@@ -95,7 +95,7 @@ module.exports = [
     },
   },
   {
-    devtool: production ? undefined : 'eval',
+    devtool: production ? undefined : 'cheap-module-eval-source-map',
 
     entry: {
       'console-log': './client/actions/console-log/index',


### PR DESCRIPTION
- Fixes 'wrong propType' error for SwitchFilter
- Fixes slow/crashy startup behavior (on my machine)

**NOTE**: `Warning: Unknown prop 'props' on <td> tag. Remove this prop from the element.` still exists in console - this is due to the `reactable` package and should be resolved soon. Relevant issue: https://github.com/glittershark/reactable/issues/311