### PR TITLE
Clarify origin of normandy.userId in filter expression docs

### DIFF
--- a/docs/user/filter_expressions.rst
+++ b/docs/user/filter_expressions.rst
@@ -97,8 +97,8 @@ filter expressions.
 
 .. js:attribute:: normandy.userId
 
-   A `v4 UUID`_ uniquely identifying the user. This is not necessarily
-   correlated with any other unique IDs, such as Telemetry IDs.
+   A `v4 UUID`_ uniquely identifying the user. This is uncorrelated with any
+   other unique IDs, such as Telemetry IDs.
 
    .. _v4 UUID: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29
 


### PR DESCRIPTION
Because of the changing usage of normandy.userId, it is important that it *not* be related to the Telemetry IDs. This clarifies the documentation for that.