### PR TITLE
Temporarily no-op durability checks

### DIFF
--- a/client/selfrepair/normandy_driver.js
+++ b/client/selfrepair/normandy_driver.js
@@ -176,7 +176,9 @@ export default class NormandyDriver {
   }
 
   createStorage(prefix) {
-    return new LocalStorage(prefix, this.testing);
+    // TODO: Stop skipping durabilit checks after durability checking has
+    // been deployed for 2+days to avoid interupting surveys.
+    return new LocalStorage(prefix, { skipDurability: true });
   }
 
   client() {

--- a/client/selfrepair/tests/test_normandy_driver.js
+++ b/client/selfrepair/tests/test_normandy_driver.js
@@ -156,9 +156,19 @@ describe('Normandy Driver', () => {
   });
 
   describe('userId', () => {
+    const originalLocalStorage = window.localStorage;
+
     beforeEach(() => {
       Object.defineProperty(window, 'localStorage', {
         value: new MockStorage(),
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'localStorage', {
+        value: originalLocalStorage,
         configurable: true,
         writable: true,
       });
@@ -169,7 +179,7 @@ describe('Normandy Driver', () => {
       spyOn(window.localStorage, 'setItem');
 
       const driver = new NormandyDriver();
-      let userId = driver.userId;
+      const userId = driver.userId;
 
       expect(window.localStorage.getItem).toHaveBeenCalledWith('userId');
       expect(window.localStorage.setItem).toHaveBeenCalledWith('userId', userId);


### PR DESCRIPTION
If we turn this on, we will stop all surveys for a while, which is no bueno. This makes durability checking only count durability, without blocking anything. We can make durability count have teeth next deploy.