### PR TITLE
Remove signatures when splitting migrations for migration

### DIFF
--- a/normandy/recipes/migrations/0033_migrate_surveys.py
+++ b/normandy/recipes/migrations/0033_migrate_surveys.py
@@ -19,6 +19,7 @@ def split_recipes(apps, schema_editor):
         # Delete the original, and use it as a template for new recipes.
         recipe.delete()
         recipe.enabled = False
+        recipe.signature = None
 
         recipe_name = recipe.name
         arguments = json.loads(recipe.arguments_json)


### PR DESCRIPTION
I tested this by spinning up a normandy-compose cluster on v21 (old version), setting up a recipe with two surveys, and then migrating to v23. Without this fix, it fails in the way we saw in prod. With this change, it works.

r?