### PR TITLE
#304 GA post-answer URL query params

### DIFF
--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -1,6 +1,6 @@
 import { Action, registerAction } from '../utils';
 
-const VERSION = 54; // Increase when changed.
+const VERSION = 55; // Increase when changed.
 const LAST_SHOWN_DELAY = 1000 * 60 * 60 * 24 * 7; // 7 days
 
 
@@ -149,7 +149,10 @@ export default class ShowHeartbeatAction extends Action {
       message,
       engagementButtonLabel,
       thanksMessage,
-      postAnswerUrl: this.annotatePostAnswerUrl({ url: postAnswerUrl, userId }),
+      postAnswerUrl: this.annotatePostAnswerUrl({
+        url: postAnswerUrl,
+        userId,
+      }),
       learnMoreMessage,
       learnMoreUrl,
       flowId: flow.id,
@@ -196,6 +199,20 @@ export default class ShowHeartbeatAction extends Action {
     return Number.isNaN(lastShown) ? null : lastShown;
   }
 
+  getGAParams() {
+    let message = this.recipe.arguments.message || '';
+    // remove spaces
+    message = message.replace(/\s+/g, '');
+    // url-ify
+    message = encodeURIComponent(message);
+
+    return {
+      utm_source: 'firefox',
+      utm_medium: this.recipe.action, // action name
+      utm_campaign: message, // 'shortenedmesssagetext'
+    };
+  }
+
   annotatePostAnswerUrl({ url, userId }) {
     // Don't bother with empty URLs.
     if (!url) {
@@ -210,6 +227,8 @@ export default class ShowHeartbeatAction extends Action {
       isDefaultBrowser: this.client.isDefaultBrowser ? 1 : 0,
       searchEngine: this.client.searchEngine,
       syncSetup: this.client.syncSetup ? 1 : 0,
+      // Google Analytics parameters
+      ...this.getGAParams(),
     };
 
     // if a userId is given,

--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -203,8 +203,14 @@ export default class ShowHeartbeatAction extends Action {
     let message = this.recipe.arguments.message || '';
     // remove spaces
     message = message.replace(/\s+/g, '');
-    // url-ify
+    // escape what we can
     message = encodeURIComponent(message);
+
+    // use a fake URL object to get a legit URL-ified URL
+    const fakeUrl = new URL('http://mozilla.com');
+    fakeUrl.searchParams.set('message', message);
+    // pluck the (now encoded) message
+    message = fakeUrl.search.replace('?message=', '');
 
     return {
       utm_source: 'firefox',

--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -199,6 +199,13 @@ export default class ShowHeartbeatAction extends Action {
     return Number.isNaN(lastShown) ? null : lastShown;
   }
 
+  /**
+   * Gathers recipe action/message information, and formats the content into
+   * URL-safe query params. This is used by this.annotatePostAnswerUrl to
+   * inject Google Analytics params into the post-answer URL.
+   *
+   * @return {Object} Hash containing utm_ queries to append to post-answer URL
+   */
   getGAParams() {
     let message = this.recipe.arguments.message || '';
     // remove spaces

--- a/client/actions/tests/test_show-heartbeat.js
+++ b/client/actions/tests/test_show-heartbeat.js
@@ -121,7 +121,7 @@ describe('ShowHeartbeatAction', () => {
     const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
     const params = new URL(postAnswerUrl).searchParams;
     expect(params.get('source')).toEqual('heartbeat');
-    expect(params.get('surveyversion')).toEqual('54');
+    expect(params.get('surveyversion')).toEqual('55');
     expect(params.get('updateChannel')).toEqual('nightly');
     expect(params.get('fxVersion')).toEqual('42.0.1');
     expect(params.get('isDefaultBrowser')).toEqual('1');
@@ -130,6 +130,32 @@ describe('ShowHeartbeatAction', () => {
 
     // telemetry data is turned off, so no userId should be passed into params
     expect(params.get('userId')).toBeNull();
+  });
+
+
+  it('should annotate the post-answer URL with google analytics params', async () => {
+    const url = 'https://example.com';
+    const recipe = recipeFactory({
+      action: 'show-heartbeat',
+      arguments: {
+        postAnswerUrl: url,
+        message: 'This is a test message!!',
+      },
+    });
+    const action = new ShowHeartbeatAction(normandy, recipe);
+
+    normandy.mock.client.version = '42.0.1';
+    normandy.mock.client.channel = 'nightly';
+    normandy.mock.client.isDefaultBrowser = true;
+    normandy.mock.client.searchEngine = 'shady-tims';
+    normandy.mock.client.syncSetup = true;
+
+    await action.execute();
+    const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
+    const params = new URL(postAnswerUrl).searchParams;
+    expect(params.get('utm_source')).toEqual('firefox');
+    expect(params.get('utm_medium')).toEqual('show-heartbeat');
+    expect(params.get('utm_campaign')).toEqual('Thisisatestmessage%21%21');
   });
 
 


### PR DESCRIPTION
Fixes #304 

Adds `getGAParams` function to `show-heartbeat`. Gathers relevant recipe info and then creates a hash of `utm_` params to append to the post-answer URL.