### PR TITLE
#341 'enabled' Form Validation

### DIFF
--- a/normandy/recipes/api/serializers.py
+++ b/normandy/recipes/api/serializers.py
@@ -85,7 +85,7 @@ class RecipeSerializer(serializers.ModelSerializer):
     current_approval_request = ApprovalRequestSerializer(read_only=True)
     approval = ApprovalSerializer(read_only=True)
     is_approved = serializers.BooleanField(read_only=True)
-    enabled = serializers.BooleanField()
+    enabled = serializers.BooleanField(required=False)
 
     class Meta:
         model = Recipe

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -151,6 +151,7 @@ class TestRecipeAPI(object):
     def test_it_can_create_recipes(self, api_client):
         action = ActionFactory()
 
+        # Enabled recipe
         res = api_client.post('/api/v1/recipe/', {
             'name': 'Test Recipe',
             'action': action.name,
@@ -160,8 +161,18 @@ class TestRecipeAPI(object):
         })
         assert res.status_code == 201
 
+        # Disabled recipe
+        res = api_client.post('/api/v1/recipe/', {
+            'name': 'Test Recipe 2',
+            'action': action.name,
+            'arguments': {},
+            'filter_expression': 'whatever',
+            'enabled': False
+        })
+        assert res.status_code == 201
+
         recipes = Recipe.objects.all()
-        assert recipes.count() == 1
+        assert recipes.count() == 2
 
     def test_it_can_edit_recipes(self, api_client):
         recipe = RecipeFactory(name='unchanged', filter_expression='true')

--- a/normandy/recipes/tests/test_api.py
+++ b/normandy/recipes/tests/test_api.py
@@ -161,9 +161,15 @@ class TestRecipeAPI(object):
         })
         assert res.status_code == 201
 
+        recipes = Recipe.objects.all()
+        assert recipes.count() == 1
+
+    def test_it_can_create_disabled_recipes(self, api_client):
+        action = ActionFactory()
+
         # Disabled recipe
         res = api_client.post('/api/v1/recipe/', {
-            'name': 'Test Recipe 2',
+            'name': 'Test Recipe',
             'action': action.name,
             'arguments': {},
             'filter_expression': 'whatever',
@@ -172,7 +178,7 @@ class TestRecipeAPI(object):
         assert res.status_code == 201
 
         recipes = Recipe.objects.all()
-        assert recipes.count() == 2
+        assert recipes.count() == 1
 
     def test_it_can_edit_recipes(self, api_client):
         recipe = RecipeFactory(name='unchanged', filter_expression='true')


### PR DESCRIPTION
Fixes #341 

- 'enabled' field is no longer required to be checked when creating a recipe
- Adds additional API test where 'enabled' is False

I'm not sure if the test I put in is appropriate - if anyone has suggestions on how to test this better, I'd be happy to improve it.

@Osmose @mythmon r?