### PR TITLE
Remove Heartbeat 'last show delay'

### DIFF
--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -1,8 +1,6 @@
 import { Action, registerAction } from '../utils';
 
-const VERSION = 54; // Increase when changed.
-const LAST_SHOWN_DELAY = 1000 * 60 * 60 * 24 * 7; // 7 days
-
+const VERSION = 55; // Increase when changed.
 
 export class HeartbeatFlow {
   constructor(action) {
@@ -113,7 +111,6 @@ export default class ShowHeartbeatAction extends Action {
     const shouldShowSurvey = (
       this.normandy.testing
       || lastShown === null
-      || Date.now() - lastShown > LAST_SHOWN_DELAY
     );
     if (!shouldShowSurvey) {
       return;

--- a/client/actions/tests/test_show-heartbeat.js
+++ b/client/actions/tests/test_show-heartbeat.js
@@ -14,14 +14,29 @@ describe('ShowHeartbeatAction', () => {
     await action.execute();
   });
 
-  it('should not show heartbeat if it has shown within the past 7 days', async () => {
+  it('should show heartbeat if it has not been shown yet', async () => {
     const recipe = recipeFactory();
     const action = new ShowHeartbeatAction(normandy, recipe);
 
-    normandy.mock.storage.data.lastShown = '100';
-    spyOn(Date, 'now').and.returnValue(10);
+    normandy.mock.storage.data.lastShown = null;
+    spyOn(Date, 'now').and.returnValue(99999999);
 
     await action.execute();
+    expect(normandy.showHeartbeat).toHaveBeenCalled();
+  });
+
+  it('should NOT show heartbeat if it has been shown already', async () => {
+    const recipe = recipeFactory();
+    const action = new ShowHeartbeatAction(normandy, recipe);
+
+    // set the lastShown value in storage,
+    // so heartbeat thinks it's run already before
+    normandy.mock.storage.data.lastShown = '100';
+
+    // attempt to run it again
+    await action.execute();
+
+    // it should NOT run since it's already 'run' once before
     expect(normandy.showHeartbeat).not.toHaveBeenCalled();
   });
 
@@ -31,28 +46,6 @@ describe('ShowHeartbeatAction', () => {
 
     normandy.testing = true;
     normandy.mock.storage.data.lastShown = '100';
-    spyOn(Date, 'now').and.returnValue(10);
-
-    await action.execute();
-    expect(normandy.showHeartbeat).toHaveBeenCalled();
-  });
-
-  it("should show heartbeat if it hasn't shown within the past 7 days", async () => {
-    const recipe = recipeFactory();
-    const action = new ShowHeartbeatAction(normandy, recipe);
-
-    normandy.mock.storage.data.lastShown = '100';
-    spyOn(Date, 'now').and.returnValue(9999999999);
-
-    await action.execute();
-    expect(normandy.showHeartbeat).toHaveBeenCalled();
-  });
-
-  it('should show heartbeat if the last-shown date is null', async () => {
-    const recipe = recipeFactory();
-    const action = new ShowHeartbeatAction(normandy, recipe);
-
-    normandy.mock.storage.data.lastShown = null;
     spyOn(Date, 'now').and.returnValue(10);
 
     await action.execute();
@@ -121,7 +114,7 @@ describe('ShowHeartbeatAction', () => {
     const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
     const params = new URL(postAnswerUrl).searchParams;
     expect(params.get('source')).toEqual('heartbeat');
-    expect(params.get('surveyversion')).toEqual('54');
+    expect(params.get('surveyversion')).toEqual('55');
     expect(params.get('updateChannel')).toEqual('nightly');
     expect(params.get('fxVersion')).toEqual('42.0.1');
     expect(params.get('isDefaultBrowser')).toEqual('1');


### PR DESCRIPTION
Fixes #347 

- Removes 7-day check for heartbeats
- Heartbeat actions now only run once, ever
- Test mode still fires heartbeats errytime
- Updated tests