### PR TITLE
Heartbeat throttling - #347 #348

### DIFF
--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -24,12 +24,7 @@ export default class ShowHeartbeatAction extends Action {
    */
   async heartbeatShownRecently() {
     const lastShown = await this.heartbeatStorage.getItem('lastShown');
-    let timeSince = Infinity;
-
-    // If no heartbeat has ever been shown, lastShown will be falsey.
-    if (lastShown) {
-      timeSince = new Date() - lastShown;
-    }
+    const timeSince = lastShown ? new Date() - lastShown : Infinity;
 
     // Return a boolean indicating if a heartbeat
     // has shown within the last HEARTBEAT_THROTTLE ms

--- a/client/actions/show-heartbeat/index.js
+++ b/client/actions/show-heartbeat/index.js
@@ -20,9 +20,9 @@ export default class ShowHeartbeatAction extends Action {
 
   /**
    * Calculates the number of milliseconds since the last heartbeat from any recipe
-   * was shown. If no heartbeat has ever been shown, returns Infinity, or "forever ago".
+   * was shown. Returns a boolean indicating if a heartbeat has been shown recently.
    */
-  async timeSinceLastHeartbeat() {
+  async heartbeatShownRecently() {
     const lastShown = await this.heartbeatStorage.getItem('lastShown');
     let timeSince = Infinity;
 
@@ -31,7 +31,9 @@ export default class ShowHeartbeatAction extends Action {
       timeSince = new Date() - lastShown;
     }
 
-    return timeSince;
+    // Return a boolean indicating if a heartbeat
+    // has shown within the last HEARTBEAT_THROTTLE ms
+    return timeSince < HEARTBEAT_THROTTLE;
   }
 
   /**
@@ -57,7 +59,7 @@ export default class ShowHeartbeatAction extends Action {
     } = this.recipe.arguments;
 
     if (!this.normandy.testing && (
-      await this.timeSinceLastHeartbeat() < HEARTBEAT_THROTTLE ||
+      await this.heartbeatShownRecently() ||
       await this.surveyHasShown()
     )) {
       return;

--- a/client/actions/tests/test_show-heartbeat.js
+++ b/client/actions/tests/test_show-heartbeat.js
@@ -14,14 +14,29 @@ describe('ShowHeartbeatAction', () => {
     await action.execute();
   });
 
-  it('should not show heartbeat if it has shown within the past 7 days', async () => {
+  it('should show heartbeat if it has not been shown yet', async() => {
     const recipe = recipeFactory();
     const action = new ShowHeartbeatAction(normandy, recipe);
 
-    normandy.mock.storage.data.lastShown = '100';
-    spyOn(Date, 'now').and.returnValue(10);
+    normandy.mock.storage.data.lastShown = null;
+    spyOn(Date, 'now').and.returnValue(99999999);
 
     await action.execute();
+    expect(normandy.showHeartbeat).toHaveBeenCalled();
+  });
+
+  it('should NOT show heartbeat if it has been shown already', async() => {
+    const recipe = recipeFactory();
+    const action = new ShowHeartbeatAction(normandy, recipe);
+
+    // set the lastShown value in storage,
+    // so heartbeat thinks it's run already before
+    normandy.mock.storage.data.lastShown = '100';
+
+    // attempt to run it again
+    await action.execute();
+
+    // it should NOT run since it's already 'run' once before
     expect(normandy.showHeartbeat).not.toHaveBeenCalled();
   });
 
@@ -31,28 +46,6 @@ describe('ShowHeartbeatAction', () => {
 
     normandy.testing = true;
     normandy.mock.storage.data.lastShown = '100';
-    spyOn(Date, 'now').and.returnValue(10);
-
-    await action.execute();
-    expect(normandy.showHeartbeat).toHaveBeenCalled();
-  });
-
-  it("should show heartbeat if it hasn't shown within the past 7 days", async () => {
-    const recipe = recipeFactory();
-    const action = new ShowHeartbeatAction(normandy, recipe);
-
-    normandy.mock.storage.data.lastShown = '100';
-    spyOn(Date, 'now').and.returnValue(9999999999);
-
-    await action.execute();
-    expect(normandy.showHeartbeat).toHaveBeenCalled();
-  });
-
-  it('should show heartbeat if the last-shown date is null', async () => {
-    const recipe = recipeFactory();
-    const action = new ShowHeartbeatAction(normandy, recipe);
-
-    normandy.mock.storage.data.lastShown = null;
     spyOn(Date, 'now').and.returnValue(10);
 
     await action.execute();


### PR DESCRIPTION
Fixes #347 (Heartbeat should show once and only once)
Fixes #348 (Heartbeats should show once per 24 hours and that's it)

* Checks if heartbeat has ever been shown
* If it has NOT, it checks if a heartbeat has been shown in the last 24 hours
* If one has NOT, then the heartbeat is shown, and storage is updated with the last heartbeat time.

(This PR replaces #357 due to big merge conflicts)
