### PR TITLE
Enable request.summary logging

### DIFF
--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -143,6 +143,7 @@ class Base(Core):
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
+        'mozilla_cloud_services_logger.django.middleware.RequestSummaryLogger',
     ]
 
     def MIDDLEWARE_CLASSES(self):
@@ -180,6 +181,11 @@ class Base(Core):
             },
             'loggers': {
                 'normandy': {
+                    'propagate': False,
+                    'handlers': ['console'],
+                    'level': 'DEBUG',
+                },
+                'request.summary': {
                     'propagate': False,
                     'handlers': ['console'],
                     'level': 'DEBUG',
@@ -291,7 +297,10 @@ class ProductionReadOnly(Production):
     Settings for a production environment that is read-only. This is
     used on public-facing webheads.
     """
-    EXTRA_MIDDLEWARE_CLASSES = []  # No need for sessions!
+    EXTRA_MIDDLEWARE_CLASSES = [
+        # No need for sessions, so removing those middlewares helps us go fast
+        'mozilla_cloud_services_logger.django.middleware.RequestSummaryLogger',
+    ]
     ADMIN_ENABLED = values.BooleanValue(False)
     SILENCED_SYSTEM_CHECKS = values.ListValue(['security.W003'])  # CSRF check
 


### PR DESCRIPTION
This enables the request summary logging from [mozilla-cloud-service-logger](https://github.com/mozilla/mozilla-cloud-services-logger), which should help debug issues in prod.