### PR TITLE
Remove unused in-memory caching infrastructure and docs

### DIFF
--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -130,14 +130,6 @@ in other Django projects.
     The DSN for Raven to report errors to Sentry. Defaults to ``None``. Not
     required.
 
-.. envvar:: DJANGO_CACHES_RECIPE_TIME
-
-    :default: ``300`` (5 minutes)
-
-    The amount of time in seconds to hold Recipes in the cache. This may be set
-    to 0 in non-production environments to ease testing. In production
-    environments, setting this value too low can be a denial-of-service risk.
-
 .. envvar:: DJANGO_AUTOGRAPH_URL
 
     The URL where an Autograph_ server can be reached. If left blank, content

--- a/normandy/conftest.py
+++ b/normandy/conftest.py
@@ -1,8 +1,5 @@
 import hashlib
 
-from django.core.cache import caches
-from django.conf import settings
-
 import pytest
 from rest_framework.test import APIClient
 
@@ -17,14 +14,6 @@ def api_client():
     client = APIClient()
     client.force_authenticate(user=user)
     return client
-
-
-@pytest.yield_fixture(autouse=True)
-def django_cache(request):
-    """Require a django test cache"""
-    yield None
-    for cache_name in settings.CACHES.keys():
-        caches[cache_name].clear()
 
 
 @pytest.fixture

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -98,18 +98,6 @@ class Core(Configuration):
         )
     }
 
-    CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-            'LOCATION': 'default',
-        },
-        'recipes': {
-            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-            'LOCATION': 'recipes',
-            'TIMEOUT': values.IntegerValue(300, environ_name='CACHES_RECIPES_TIMEOUT'),
-        },
-    }
-
     WEBPACK_LOADER = {
         'DEFAULT': {
             'BUNDLE_DIR_NAME': 'bundles/',


### PR DESCRIPTION
It hasn't been used since we stopped caching recipe filtering in memory.