### PR TITLE
api: Escape all unicode in canonical json rendering

### DIFF
--- a/normandy/base/api/renderers.py
+++ b/normandy/base/api/renderers.py
@@ -31,7 +31,12 @@ class CanonicalJSONRenderer(renderers.BaseRenderer):
     charset = None
 
     def render(self, data, media_type=None, renderer_context=None):
-        return canonicaljson.encode_canonical_json(data)
+        # Get canonical json as bytes
+        rendered = canonicaljson.encode_canonical_json(data)
+        # Convert to a unicode string
+        rendered = rendered.decode('utf8')
+        # Encode *all* unicode characters as \u1234 escapes (and convert to bytes)
+        return rendered.encode('unicode_escape')
 
 
 class CustomBrowsableAPIRenderer(renderers.BrowsableAPIRenderer):

--- a/normandy/base/tests/test_renderers.py
+++ b/normandy/base/tests/test_renderers.py
@@ -1,0 +1,13 @@
+from normandy.base.api.renderers import CanonicalJSONRenderer
+
+
+class TestCanonicalJSONRenderer(object):
+    def test_it_works(self):
+        data = {'a': 1, 'b': 2}
+        rendered = CanonicalJSONRenderer().render(data)
+        assert rendered == b'{"a":1,"b":2}'
+
+    def test_it_works_with_euro_signs(self):
+        data = {'USD': '$', 'EURO': '€'}
+        rendered = CanonicalJSONRenderer().render(data)
+        assert rendered == rb'{"EURO":"\u20ac","USD":"$"}'


### PR DESCRIPTION
This is needed to be compatible with Firefox's CanonicalJSON implementation.