### PR TITLE
Fix recipe-client-addon README.

### DIFF
--- a/recipe-client-addon/README.md
+++ b/recipe-client-addon/README.md
@@ -2,7 +2,7 @@
 
 Client to download and run recipes from [Normandy Recipe Server][server].
 
-[server](https://github.com/mozilla/normandy)
+[server]: https://github.com/mozilla/normandy
 
 # Development
 


### PR DESCRIPTION
Actually what I'm testing is if the linting works on new PRs. #409 has a bunch of linting errors in CI for files it didn't touch, that seem to be because the flake8 config is no longer at the root of the repo, which begs the question: Why did it pass on the original monorepo PR?

And it seemed smart to fix something while I was testing.