### PR TITLE
Use Docker 1.10 during CircleCI builds.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,7 @@
 machine:
+  pre:
+    # Install CircleCI's fork for Docker 1.10.0
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
   services:
     - postgresql
     - docker


### PR DESCRIPTION
Just like #418, this PR is trying to see if it can break the linting. In this case, the only suspicious-looking thing was the version of docker used, which may have affected how volumes are mounted. 