### PR TITLE
recipe-client-addon: Add bucketSampling to filter expressions

### DIFF
--- a/recipe-client-addon/lib/EnvExpressions.jsm
+++ b/recipe-client-addon/lib/EnvExpressions.jsm
@@ -28,6 +28,7 @@ XPCOMUtils.defineLazyGetter(this, "jexl", () => {
   jexl.addTransforms({
     date: dateString => new Date(dateString),
     stableSample: Sampling.stableSample,
+    bucketSample: Sampling.bucketSample,
   });
   return jexl;
 });

--- a/recipe-client-addon/lib/Sampling.jsm
+++ b/recipe-client-addon/lib/Sampling.jsm
@@ -5,77 +5,121 @@
 "use strict";
 
 const {utils: Cu} = Components;
-Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
+Cu.import("resource://gre/modules/Task.jsm");
 Cu.importGlobalProperties(["crypto", "TextEncoder"]);
 
 this.EXPORTED_SYMBOLS = ["Sampling"];
 
-const log = LogManager.getLogger("sampling");
-
-/**
- * Map from the range [0, 1] to [0, max(sha256)].
- * @param  {number} frac A float from 0.0 to 1.0.
- * @return {string} A 48 bit number represented in hex, padded to 12 characters.
- */
-function fractionToKey(frac) {
-  const hashBits = 48;
-  const hashLength = hashBits / 4;
-
-  if (frac < 0 || frac > 1) {
-    throw new Error(`frac must be between 0 and 1 inclusive (got ${frac})`);
-  }
-
-  const mult = Math.pow(2, hashBits) - 1;
-  const inDecimal = Math.floor(frac * mult);
-  let hexDigits = inDecimal.toString(16);
-  if (hexDigits.length < hashLength) {
-    // Left pad with zeroes
-    // If N zeroes are needed, generate an array of nulls N+1 elements long,
-    // and inserts zeroes between each null.
-    hexDigits = Array(hashLength - hexDigits.length + 1).join("0") + hexDigits;
-  }
-
-  // Saturate at 2**48 - 1
-  if (hexDigits.length > hashLength) {
-    hexDigits = Array(hashLength + 1).join("f");
-  }
-
-  return hexDigits;
-}
-
-function bufferToHex(buffer) {
-  const hexCodes = [];
-  const view = new DataView(buffer);
-  for (let i = 0; i < view.byteLength; i += 4) {
-    // Using getUint32 reduces the number of iterations needed (we process 4 bytes each time)
-    const value = view.getUint32(i);
-    // toString(16) will give the hex representation of the number without padding
-    hexCodes.push(value.toString(16).padStart(8, "0"));
-  }
-
-  // Join all the hex strings into one
-  return hexCodes.join("");
-}
-
 this.Sampling = {
-  stableSample(input, rate) {
-    const hasher = crypto.subtle;
+  /**
+   * Map from the range [0, 1] to [0, 2^48].
+   * @param  {number} frac A float from 0.0 to 1.0.
+   * @return {string} A 48 bit number represented in hex, padded to 12 characters.
+   */
+  fractionToKey(frac) {
+    const hashBits = 48;
+    const hashLength = hashBits / 4;  // each hexadecimal digit represents 4 bits
 
-    return hasher.digest("SHA-256", new TextEncoder("utf-8").encode(JSON.stringify(input)))
-      .then(hash => {
-        // truncate hash to 12 characters (2^48)
-        const inputHash = bufferToHex(hash).slice(0, 12);
-        const samplePoint = fractionToKey(rate);
+    if (frac < 0 || frac > 1) {
+      throw new Error(`frac must be between 0 and 1 inclusive (got ${frac})`);
+    }
 
-        if (samplePoint.length !== 12 || inputHash.length !== 12) {
-          throw new Error("Unexpected hash length");
-        }
+    const mult = Math.pow(2, hashBits) - 1;
+    const inDecimal = Math.floor(frac * mult);
+    let hexDigits = inDecimal.toString(16);
+    if (hexDigits.length < hashLength) {
+      // Left pad with zeroes
+      // If N zeroes are needed, generate an array of nulls N+1 elements long,
+      // and inserts zeroes between each null.
+      hexDigits = Array(hashLength - hexDigits.length + 1).join("0") + hexDigits;
+    }
 
-        return inputHash < samplePoint;
+    // Saturate at 2**48 - 1
+    if (hexDigits.length > hashLength) {
+      hexDigits = Array(hashLength + 1).join("f");
+    }
 
-      })
-      .catch(error => {
-        log.error(`Error: ${error}`);
-      });
+    return hexDigits;
   },
+
+  bufferToHex(buffer) {
+    const hexCodes = [];
+    const view = new DataView(buffer);
+    for (let i = 0; i < view.byteLength; i += 4) {
+      // Using getUint32 reduces the number of iterations needed (we process 4 bytes each time)
+      const value = view.getUint32(i);
+      // toString(16) will give the hex representation of the number without padding
+      hexCodes.push(value.toString(16).padStart(8, "0"));
+    }
+
+    // Join all the hex strings into one
+    return hexCodes.join("");
+  },
+
+  rangeBucketSample(inputHash, minBucket, maxBucket, bucketCount) {
+    const minHash = Sampling.fractionToKey(minBucket / bucketCount);
+    const maxHash = Sampling.fractionToKey(maxBucket / bucketCount);
+    return (minHash <= inputHash) && (inputHash < maxHash);
+  },
+
+  /**
+   * @promise A hash of `data`, truncated to the 12 most significant characters.
+   */
+  truncatedHash: Task.async(function* (data) {
+    const hasher = crypto.subtle;
+    const input = new TextEncoder("utf-8").encode(JSON.stringify(data));
+    const hash = yield hasher.digest("SHA-256", input);
+    // truncate hash to 12 characters (2^48), because the full hash is larger
+    // than JS can meaningfully represent as a number.
+    return Sampling.bufferToHex(hash).slice(0, 12);
+  }),
+
+  /**
+   * Sample by splitting the input into two buckets, one with a size (rate) and
+   * another with a size (1.0 - rate), and then check if the input's hash falls
+   * into the first bucket.
+   *
+   * @param    {object}  input Input to hash to determine the sample.
+   * @param    {Number}  rate  Number between 0.0 and 1.0 to sample at. A value of
+   *                           0.25 returns true 25% of the time.
+   * @promises {boolean} True if the input is in the sample.
+   */
+  stableSample: Task.async(function* (input, rate) {
+    const inputHash = yield Sampling.truncatedHash(input);
+    const samplePoint = Sampling.fractionToKey(rate);
+
+    return inputHash < samplePoint;
+  }),
+
+  /**
+   * Sample by splitting the input space into a series of buckets, and checking
+   * if the given input is in a range of buckets.
+   *
+   * The range to check is defined by a start point and length, and can wrap
+   * around the input space. For example, if there are 100 buckets, and we ask to
+   * check 50 buckets starting from bucket 70, then buckets 70-100 and 0-19 will
+   * be checked.
+   *
+   * @param {object}     input Input to hash to determine the matching bucket.
+   * @param {integer}    start Index of the bucket to start checking.
+   * @param {integer}    count Number of buckets to check.
+   * @param {integer}    total Total number of buckets to group inputs into.
+   * @promises {boolean} True if the given input is within the range of buckets
+   *                     we're checking. */
+  bucketSample: Task.async(function* (input, start, count, total) {
+    const inputHash = yield Sampling.truncatedHash(input);
+    const wrappedStart = start % total;
+    const end = wrappedStart + count;
+
+    // If the range we're testing wraps, we have to check two ranges: from start
+    // to max, and from min to end.
+    if (end > total) {
+      return (
+        Sampling.rangeBucketSample(inputHash, 0, end % total, total)
+        || Sampling.rangeBucketSample(inputHash, wrappedStart, total, total)
+      );
+    }
+
+    return Sampling.rangeBucketSample(inputHash, wrappedStart, wrappedStart + count, total);
+  }),
 };

--- a/recipe-client-addon/moz.build
+++ b/recipe-client-addon/moz.build
@@ -15,8 +15,8 @@ FINAL_TARGET_PP_FILES.features['shield-recipe-client@mozilla.org'] += [
   'install.rdf.in'
 ]
 
-BROWSER_CHROME_MANIFESTS += [
-    'test/browser.ini',
-]
+BROWSER_CHROME_MANIFESTS += ['test/browser.ini']
+
+XPCSHELL_TESTS_MANIFESTS += ['test/xpcshell.ini']
 
 JAR_MANIFESTS += ['jar.mn']

--- a/recipe-client-addon/test/.eslintrc.js
+++ b/recipe-client-addon/test/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
   rules: {
     "spaced-comment": 2,
     "space-before-function-paren": 2,
+    "require-yield": 0
   }
 };

--- a/recipe-client-addon/test/browser_env_expressions.js
+++ b/recipe-client-addon/test/browser_env_expressions.js
@@ -53,4 +53,12 @@ add_task(function* () {
   // Test stable sample returns true for matching samples
   val = yield EnvExpressions.eval('["test"]|stableSample(0)');
   is(val, false, "Stable sample returns false for 0% sample");
+
+  // Test bucket sample returns true for a known sample
+  val = yield EnvExpressions.eval('["test1"]|bucketSample(0, 5, 10)');
+  is(val, true, "Bucket sample returns true for a known sample");
+
+  // Test bucket sample returns false for a known sample
+  val = yield EnvExpressions.eval('["test2"]|bucketSample(0, 5, 10)');
+  is(val, false, "Bucket sample returns true for a known sample");
 });

--- a/recipe-client-addon/test/browser_env_expressions.js
+++ b/recipe-client-addon/test/browser_env_expressions.js
@@ -54,11 +54,15 @@ add_task(function* () {
   val = yield EnvExpressions.eval('["test"]|stableSample(0)');
   is(val, false, "Stable sample returns false for 0% sample");
 
-  // Test bucket sample returns true for a known sample
-  val = yield EnvExpressions.eval('["test1"]|bucketSample(0, 5, 10)');
-  is(val, true, "Bucket sample returns true for a known sample");
+  // Test stable sample for known samples
+  val = yield EnvExpressions.eval('["test-1"]|stableSample(0.5)');
+  is(val, true, "Stable sample returns true for a known sample");
+  val = yield EnvExpressions.eval('["test-4"]|stableSample(0.5)');
+  is(val, false, "Stable sample returns false for a known sample");
 
-  // Test bucket sample returns false for a known sample
-  val = yield EnvExpressions.eval('["test2"]|bucketSample(0, 5, 10)');
-  is(val, false, "Bucket sample returns true for a known sample");
+  // Test bucket sample for known samples
+  val = yield EnvExpressions.eval('["test-1"]|bucketSample(0, 5, 10)');
+  is(val, true, "Bucket sample returns true for a known sample");
+  val = yield EnvExpressions.eval('["test-4"]|bucketSample(0, 5, 10)');
+  is(val, false, "Bucket sample returns false for a known sample");
 });

--- a/recipe-client-addon/test/test_Sampling.js
+++ b/recipe-client-addon/test/test_Sampling.js
@@ -1,0 +1,64 @@
+"use strict";
+// Cu is defined in xpc_head.js
+
+Cu.import("resource://gre/modules/Task.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/Sampling.jsm", this);
+
+add_task(function* testStableSample () {
+  // Absolute samples
+  equal(yield Sampling.stableSample("test", 1), true, "stableSample returns true for 100% sample");
+  equal(yield Sampling.stableSample("test", 0), false, "stableSample returns false for 0% sample");
+
+  // Known samples. The numbers are nonces to make the tests pass
+  equal(yield Sampling.stableSample("test-0", 0.5), true, "stableSample returns true for known matching sample");
+  equal(yield Sampling.stableSample("test-1", 0.5), false, "stableSample returns false for known non-matching sample");
+});
+
+add_task(function* testBucketSample () {
+  // Absolute samples
+  equal(yield Sampling.bucketSample("test", 0, 10, 10), true, "bucketSample returns true for 100% sample");
+  equal(yield Sampling.bucketSample("test", 0, 0, 10), false, "bucketSample returns false for 0% sample");
+
+  // Known samples. The numbers are nonces to make the tests pass
+  equal(yield Sampling.bucketSample("test-0", 0, 5, 10), true, "bucketSample returns true for known matching sample");
+  equal(yield Sampling.bucketSample("test-1", 0, 5, 10), false, "bucketSample returns false for known non-matching sample");
+});
+
+add_test(function testFractionToKey() {
+  // Test that results are always 12 character hexadecimal strings.
+  const expected_regex = /[0-9a-f]{12}/;
+  const count = 100;
+  let successes = 0;
+  for (let i = 0; i < count; i++) {
+    const p = Sampling.fractionToKey(Math.random());
+    if (expected_regex.test(p)) {
+      successes++;
+    }
+  }
+  equal(successes, count, "fractionToKey makes keys the right length");
+  run_next_test();
+});
+
+add_task(function* testTruncatedHash() {
+  const expected_regex = /[0-9a-f]{12}/;
+  const count = 100;
+  let successes = 0;
+  for (let i = 0; i < count; i++) {
+    const h = yield Sampling.truncatedHash(Math.random());
+    if (expected_regex.test(h)) {
+      successes++;
+    }
+  }
+  equal(successes, count, "truncatedHash makes hashes the right length");
+});
+
+add_test(function testBufferToHex() {
+  const data = new ArrayBuffer(4);
+  const view = new DataView(data);
+  view.setUint8(0, 0xff);
+  view.setUint8(1, 0x7f);
+  view.setUint8(2, 0x3f);
+  view.setUint8(3, 0x1f);
+  equal(Sampling.bufferToHex(data), "ff7f3f1f");
+  run_next_test();
+})

--- a/recipe-client-addon/test/test_Sampling.js
+++ b/recipe-client-addon/test/test_Sampling.js
@@ -1,10 +1,11 @@
 "use strict";
 // Cu is defined in xpc_head.js
+/* globals Cu, equal */
 
 Cu.import("resource://gre/modules/Task.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/Sampling.jsm", this);
 
-add_task(function* testStableSample () {
+add_task(function* testStableSample() {
   // Absolute samples
   equal(yield Sampling.stableSample("test", 1), true, "stableSample returns true for 100% sample");
   equal(yield Sampling.stableSample("test", 0), false, "stableSample returns false for 0% sample");
@@ -14,7 +15,7 @@ add_task(function* testStableSample () {
   equal(yield Sampling.stableSample("test-1", 0.5), false, "stableSample returns false for known non-matching sample");
 });
 
-add_task(function* testBucketSample () {
+add_task(function* testBucketSample() {
   // Absolute samples
   equal(yield Sampling.bucketSample("test", 0, 10, 10), true, "bucketSample returns true for 100% sample");
   equal(yield Sampling.bucketSample("test", 0, 0, 10), false, "bucketSample returns false for 0% sample");
@@ -24,7 +25,7 @@ add_task(function* testBucketSample () {
   equal(yield Sampling.bucketSample("test-1", 0, 5, 10), false, "bucketSample returns false for known non-matching sample");
 });
 
-add_test(function testFractionToKey() {
+add_task(function* testFractionToKey() {
   // Test that results are always 12 character hexadecimal strings.
   const expected_regex = /[0-9a-f]{12}/;
   const count = 100;
@@ -36,7 +37,6 @@ add_test(function testFractionToKey() {
     }
   }
   equal(successes, count, "fractionToKey makes keys the right length");
-  run_next_test();
 });
 
 add_task(function* testTruncatedHash() {
@@ -52,7 +52,7 @@ add_task(function* testTruncatedHash() {
   equal(successes, count, "truncatedHash makes hashes the right length");
 });
 
-add_test(function testBufferToHex() {
+add_task(function* testBufferToHex() {
   const data = new ArrayBuffer(4);
   const view = new DataView(data);
   view.setUint8(0, 0xff);
@@ -60,5 +60,4 @@ add_test(function testBufferToHex() {
   view.setUint8(2, 0x3f);
   view.setUint8(3, 0x1f);
   equal(Sampling.bufferToHex(data), "ff7f3f1f");
-  run_next_test();
-})
+});

--- a/recipe-client-addon/test/xpc_head.js
+++ b/recipe-client-addon/test/xpc_head.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const {interfaces: Ci, utils: Cu} = Components;
+
+Cu.import("resource://gre/modules/Services.jsm");
+
+// Load our bootstrap extension manifest so we can access our chrome/resource URIs.
+// Cargo culted from formautofill system add-on
+const EXTENSION_ID = "shield-recipe-client@mozilla.org";
+let extensionDir = Services.dirsvc.get("GreD", Ci.nsIFile);
+extensionDir.append("browser");
+extensionDir.append("features");
+extensionDir.append(EXTENSION_ID);
+// If the unpacked extension doesn't exist, use the packed version.
+if (!extensionDir.exists()) {
+  extensionDir = extensionDir.parent;
+  extensionDir.append(EXTENSION_ID + ".xpi");
+}
+Components.manager.addBootstrappedManifestLocation(extensionDir);

--- a/recipe-client-addon/test/xpcshell.ini
+++ b/recipe-client-addon/test/xpcshell.ini
@@ -1,0 +1,4 @@
+[DEFAULT]
+head = xpc_head.js
+
+[test_Sampling.js]


### PR DESCRIPTION
Based on mozilla/normandy-addon#38.

Fixes #413.

TODO:

* [x] Actually run these tests in mozilla-central (I'm waiting on a build right now)
  * [x] Figure out values that make the tests pass