### PR TITLE
Centralize logging config and actually log to the console.

### DIFF
--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -6,6 +6,7 @@
 const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Preferences.jsm");
+Cu.import("resource://gre/modules/Log.jsm");
 
 const REASONS = {
   APP_STARTUP: 1,      // The application is starting up.
@@ -24,9 +25,11 @@ const DEFAULT_PREFS = {
   dev_mode: false,
   enabled: true,
   startup_delay_seconds: 300,
+  "logging.level": Log.Level.Warn,
 };
 const PREF_DEV_MODE = "extensions.shield-recipe-client.dev_mode";
 const PREF_SELF_SUPPORT_ENABLED = "browser.selfsupport.enabled";
+const PREF_LOGGING_LEVEL = PREF_BRANCH + "logging.level";
 
 let shouldRun = true;
 
@@ -48,11 +51,18 @@ this.startup = function() {
     return;
   }
 
+  // Setup logging and listen for changes to logging prefs
+  Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
+  LogManager.configure(Services.prefs.getIntPref(PREF_LOGGING_LEVEL));
+  Preferences.observe(PREF_LOGGING_LEVEL, LogManager.configure);
+
   Cu.import("resource://shield-recipe-client/lib/RecipeRunner.jsm");
   RecipeRunner.init();
 };
 
 this.shutdown = function(data, reason) {
+  Preferences.ignore(PREF_LOGGING_LEVEL, LogManager.configure);
+
   Cu.import("resource://shield-recipe-client/lib/CleanupManager.jsm");
 
   CleanupManager.cleanup();
@@ -66,6 +76,7 @@ this.shutdown = function(data, reason) {
     "lib/CleanupManager.jsm",
     "lib/EnvExpressions.jsm",
     "lib/Heartbeat.jsm",
+    "lib/Logging.jsm",
     "lib/NormandyApi.jsm",
     "lib/NormandyDriver.jsm",
     "lib/RecipeRunner.jsm",

--- a/recipe-client-addon/lib/EnvExpressions.jsm
+++ b/recipe-client-addon/lib/EnvExpressions.jsm
@@ -9,7 +9,6 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/TelemetryArchive.jsm");
 Cu.import("resource://gre/modules/Task.jsm");
 Cu.import("resource://shield-recipe-client/lib/Sampling.jsm");
-Cu.import("resource://gre/modules/Log.jsm");
 
 this.EXPORTED_SYMBOLS = ["EnvExpressions"];
 

--- a/recipe-client-addon/lib/Heartbeat.jsm
+++ b/recipe-client-addon/lib/Heartbeat.jsm
@@ -9,14 +9,14 @@ const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.import("resource://gre/modules/TelemetryController.jsm");
 Cu.import("resource://gre/modules/Timer.jsm"); /* globals setTimeout, clearTimeout */
-Cu.import("resource://gre/modules/Log.jsm");
 Cu.import("resource://shield-recipe-client/lib/CleanupManager.jsm");
+Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 
 Cu.importGlobalProperties(["URL"]); /* globals URL */
 
 this.EXPORTED_SYMBOLS = ["Heartbeat"];
 
-const log = Log.repository.getLogger("shield-recipe-client");
+const log = LogManager.getLogger("heartbeat");
 const PREF_SURVEY_DURATION = "browser.uitour.surveyDuration";
 const NOTIFICATION_TIME = 3000;
 

--- a/recipe-client-addon/lib/LogManager.jsm
+++ b/recipe-client-addon/lib/LogManager.jsm
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const {utils: Cu} = Components;
+Cu.import("resource://gre/modules/Log.jsm");
+
+this.EXPORTED_SYMBOLS = ["LogManager"];
+
+const ROOT_LOGGER_NAME = "extensions.shield-recipe-client"
+let rootLogger = null;
+
+this.LogManager = {
+  /**
+   * Configure the root logger for the Recipe Client. Must be called at
+   * least once before using any loggers created via getLogger.
+   * @param {Number} loggingLevel
+   *        Logging level to use as defined in Log.jsm
+   */
+  configure(loggingLevel) {
+    if (!rootLogger) {
+      rootLogger = Log.repository.getLogger(ROOT_LOGGER_NAME);
+      rootLogger.addAppender(new Log.ConsoleAppender(new Log.BasicFormatter()));
+    }
+    rootLogger.level = loggingLevel;
+  },
+
+  /**
+   * Obtain a named logger with the recipe client logger as its parent.
+   * @param {String} name
+   *        Name of the logger to obtain.
+   * @return {Logger}
+   */
+  getLogger(name) {
+    return Log.repository.getLogger(`${ROOT_LOGGER_NAME}.${name}`);
+  },
+};

--- a/recipe-client-addon/lib/NormandyApi.jsm
+++ b/recipe-client-addon/lib/NormandyApi.jsm
@@ -9,12 +9,12 @@ const {utils: Cu, classes: Cc, interfaces: Ci} = Components;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Task.jsm");
 Cu.import("resource://gre/modules/CanonicalJSON.jsm");
-Cu.import("resource://gre/modules/Log.jsm");
+Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 Cu.importGlobalProperties(["fetch"]); /* globals fetch */
 
 this.EXPORTED_SYMBOLS = ["NormandyApi"];
 
-const log = Log.repository.getLogger("extensions.shield-recipe-client");
+const log = LogManager.getLogger("normandy-api");
 const prefs = Services.prefs.getBranch("extensions.shield-recipe-client.");
 
 this.NormandyApi = {

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -12,7 +12,7 @@ Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.import("resource:///modules/ShellService.jsm");
 Cu.import("resource://gre/modules/AddonManager.jsm");
 Cu.import("resource://gre/modules/Timer.jsm"); /* globals setTimeout, clearTimeout */
-Cu.import("resource://gre/modules/Log.jsm");
+Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 Cu.import("resource://shield-recipe-client/lib/Storage.jsm");
 Cu.import("resource://shield-recipe-client/lib/Heartbeat.jsm");
 
@@ -20,8 +20,8 @@ const {generateUUID} = Cc["@mozilla.org/uuid-generator;1"].getService(Ci.nsIUUID
 
 this.EXPORTED_SYMBOLS = ["NormandyDriver"];
 
-const log = Log.repository.getLogger("extensions.shield-recipe-client");
-const actionLog = Log.repository.getLogger("extensions.shield-recipe-client.actions");
+const log = LogManager.getLogger("normandy-driver");
+const actionLog = LogManager.getLogger("normandy-driver.actions");
 
 this.NormandyDriver = function(sandboxManager, extraContext = {}) {
   if (!sandboxManager) {

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -8,7 +8,7 @@ const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Timer.jsm"); /* globals setTimeout */
 Cu.import("resource://gre/modules/Task.jsm");
-Cu.import("resource://gre/modules/Log.jsm");
+Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 Cu.import("resource://shield-recipe-client/lib/NormandyDriver.jsm");
 Cu.import("resource://shield-recipe-client/lib/EnvExpressions.jsm");
 Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm");
@@ -17,7 +17,7 @@ Cu.importGlobalProperties(["fetch"]); /* globals fetch */
 
 this.EXPORTED_SYMBOLS = ["RecipeRunner"];
 
-const log = Log.repository.getLogger("extensions.shield-recipe-client");
+const log = LogManager.getLogger("recipe-runner");
 const prefs = Services.prefs.getBranch("extensions.shield-recipe-client.");
 
 this.RecipeRunner = {
@@ -72,7 +72,7 @@ this.RecipeRunner = {
     try {
       extraContext = yield this.getExtraContext();
     } catch (e) {
-      log.warning(`Couldn't get extra filter context: ${e}`);
+      log.warn(`Couldn't get extra filter context: ${e}`);
       extraContext = {};
     }
 

--- a/recipe-client-addon/lib/Sampling.jsm
+++ b/recipe-client-addon/lib/Sampling.jsm
@@ -5,12 +5,12 @@
 "use strict";
 
 const {utils: Cu} = Components;
-Cu.import("resource://gre/modules/Log.jsm");
+Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 Cu.importGlobalProperties(["crypto", "TextEncoder"]);
 
 this.EXPORTED_SYMBOLS = ["Sampling"];
 
-const log = Log.repository.getLogger("extensions.shield-recipe-client");
+const log = LogManager.getLogger("sampling");
 
 /**
  * Map from the range [0, 1] to [0, max(sha256)].

--- a/recipe-client-addon/lib/Storage.jsm
+++ b/recipe-client-addon/lib/Storage.jsm
@@ -6,7 +6,7 @@
 
 const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://gre/modules/Log.jsm");
+Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 
 XPCOMUtils.defineLazyModuleGetter(this, "JSONFile", "resource://gre/modules/JSONFile.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "OS", "resource://gre/modules/osfile.jsm");
@@ -14,7 +14,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "Task", "resource://gre/modules/Task.jsm
 
 this.EXPORTED_SYMBOLS = ["Storage"];
 
-const log = Log.repository.getLogger("extensions.shield-recipe-client");
+const log = LogManager.getLogger("storage");
 let storePromise;
 
 function loadStorage() {

--- a/recipe-client-addon/test/.eslintrc.js
+++ b/recipe-client-addon/test/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     isnot: false,
     ok: false,
     SpecialPowers: false,
+    SimpleTest: false,
   },
   rules: {
     "spaced-comment": 2,

--- a/recipe-client-addon/test/browser.ini
+++ b/recipe-client-addon/test/browser.ini
@@ -7,3 +7,4 @@
   support-files =
     test_server.sjs
 [browser_RecipeRunner.js]
+[browser_LogManager.js]

--- a/recipe-client-addon/test/browser_LogManager.js
+++ b/recipe-client-addon/test/browser_LogManager.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const {utils: Cu} = Components;
+
+Cu.import("resource://gre/modules/Log.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/LogManager.jsm", this);
+
+add_task(function*() {
+  // Ensure that configuring the logger affects all generated loggers.
+  const firstLogger = LogManager.getLogger("first");
+  LogManager.configure(5);
+  const secondLogger = LogManager.getLogger("second");
+  is(firstLogger.level, 5, "First logger level inherited from root logger.");
+  is(secondLogger.level, 5, "Second logger level inherited from root logger.");
+
+  // Ensure that our loggers have at least one appender.
+  LogManager.configure(Log.Level.Warn);
+  const logger  = LogManager.getLogger("test");
+  ok(logger.appenders.length > 0, true, "Loggers have at least one appender.");
+
+  // Ensure our loggers log to the console.
+  yield new Promise(resolve => {
+    SimpleTest.waitForExplicitFinish();
+    SimpleTest.monitorConsole(resolve, [{message: /legend has it/}]);
+    logger.warn("legend has it");
+    SimpleTest.endMonitorConsole();
+  });
+});


### PR DESCRIPTION
Turns out loggers made with Log.jsm need "appenders" attached to them to actually log things anywhere. Appenders are inherited from parent loggers (determined via dot separate, e.g. foo is a parent logger of foo.bar), so this patch configures the parent logger and creates loggers for the rest of the add-on as children of that parent, which logs to the console. This finally lets us actually see error messages when fetching recipes goes wrong!

I would've liked to write a test for the preference watching, but I suspect that, during test runs, the add-on itself thinks it's being run for the first time and doesn't set anything up. Someday we should figure that out but that's for another bug.

r?