### PR TITLE
Add Storage.clearStorage to add-on for resetting storage.

### DIFF
--- a/recipe-client-addon/lib/Storage.jsm
+++ b/recipe-client-addon/lib/Storage.jsm
@@ -131,4 +131,18 @@ this.Storage = {
       cloneFunctions: true,
     });
   },
+
+  /**
+   * Clear ALL storage data and save to the disk.
+   */
+  clearAllStorage() {
+    return loadStorage()
+      .then(store => {
+        store.data = {};
+        store.saveSoon();
+      })
+      .catch(err => {
+        log.error(err);
+      });
+  },
 };

--- a/recipe-client-addon/test/browser_Storage.js
+++ b/recipe-client-addon/test/browser_Storage.js
@@ -34,4 +34,14 @@ add_task(function* () {
   const complex = {a: 1, b: [2, 3], c: {d: 4}};
   yield store1.setItem("complex", complex);
   Assert.deepEqual(yield store1.getItem("complex"), complex);
+
+  // Check that clearing the storage removes data from multiple
+  // prefixes.
+  yield store1.setItem("removeTest", 1);
+  yield store2.setItem("removeTest", 2);
+  Assert.equal(yield store1.getItem("removeTest"), 1);
+  Assert.equal(yield store2.getItem("removeTest"), 2);
+  yield Storage.clearAllStorage();
+  Assert.equal(yield store1.getItem("removeTest"), null);
+  Assert.equal(yield store2.getItem("removeTest"), null);
 });


### PR DESCRIPTION
This is mostly useful right now for use in the Browser Console when manually testing things.

@gijsk I was unsure if I should flag you for review on this as well. Should we be flagging you or another peer here on Github when we make changes to the add-on? If you r+ something on Github, is @mythmon clear to commit to mozilla-central (assuming a try push passes, or whatever other steps are involved with filing a bug and merging that I'm not aware of)?