### PR TITLE
#336 Configurable Reprompting

### DIFF
--- a/recipe-server/client/actions/show-heartbeat/index.js
+++ b/recipe-server/client/actions/show-heartbeat/index.js
@@ -168,14 +168,17 @@ export default class ShowHeartbeatAction extends Action {
   }
 
   /**
-   * Checks the repeat argument for this recipe,
-   * then determines if the recipe can be qualified as 'ran'.
-   * This ultimately decides if the prompt is shown at all
-   * to the end user.
+   * Checks the repeatOption argument for this recipe
+   * and determines if the recipe has fully executed.
    *
-   * @return {boolean}        Has the heartbeat been shown?
+   * Each `repeatOption` setting has different requirements
+   * to consider the heartbeat as executed; `once` will appear to the
+   * user once and never again, while `nag` may appear to the user multiple times
+   * before it is interacted with and considers itself 'executed'.
+   *
+   * @return {boolean}   Has this recipe fulfilled its execution criteria?
    */
-  async heartbeatHasRan() {
+  async heartbeatHasExecuted() {
     let hasShown = false;
     const {
       repeatOption,
@@ -217,7 +220,7 @@ export default class ShowHeartbeatAction extends Action {
         // if a heartbeat has been shown in the past 24 hours
         await this.heartbeatShownRecently() ||
         // or this specific heartbeat has already ran
-        await this.heartbeatHasRan()
+        await this.heartbeatHasExecuted()
       );
   }
 

--- a/recipe-server/client/actions/show-heartbeat/index.js
+++ b/recipe-server/client/actions/show-heartbeat/index.js
@@ -62,7 +62,7 @@ export default class ShowHeartbeatAction extends Action {
    */
   async heartbeatShownRecently() {
     const lastShown = await this.heartbeatStorage.getItem('lastShown');
-    const timeSince = !!lastShown ? // eslint-disable-line no-extra-boolean-cast
+    const timeSince = lastShown ?
       new Date() - parseFloat(lastShown) : Infinity;
 
     // Return a boolean indicating if a heartbeat

--- a/recipe-server/client/actions/show-heartbeat/package.json
+++ b/recipe-server/client/actions/show-heartbeat/package.json
@@ -17,6 +17,16 @@
         "thanksMessage"
       ],
       "properties": {
+        "repeatOption": {
+          "type": "string",
+          "description": "Determines how often an action executes. (once|nag|xdays)",
+          "default": "once"
+        },
+        "repeatEvery": {
+          "type": "number",
+          "description": "How often (in days) the action is displayed.",
+          "default": null
+        },
         "includeTelemetryUUID": {
           "type": "boolean",
           "description": "Include unique user ID in post-answer-url and Telemetry",

--- a/recipe-server/client/actions/tests/test_show-heartbeat.js
+++ b/recipe-server/client/actions/tests/test_show-heartbeat.js
@@ -14,32 +14,6 @@ describe('ShowHeartbeatAction', () => {
     await action.execute();
   });
 
-  // it('should show heartbeat if it has not been shown yet', async() => {
-  //   const recipe = recipeFactory();
-  //   const action = new ShowHeartbeatAction(normandy, recipe);
-
-  //   normandy.mock.storage.data.lastShown = null;
-  //   spyOn(Date, 'now').and.returnValue(99999999);
-
-  //   await action.execute();
-  //   expect(normandy.showHeartbeat).toHaveBeenCalled();
-  // });
-
-  // it('should NOT show heartbeat if it has been shown already', async() => {
-  //   const recipe = recipeFactory();
-  //   const action = new ShowHeartbeatAction(normandy, recipe);
-
-  //   // set the lastShown value in storage,
-  //   // so heartbeat thinks it's run already before
-  //   normandy.mock.storage.data.lastShown = '100';
-
-  //   // attempt to run it again
-  //   await action.execute();
-
-  //   // it should NOT run since it's already 'run' once before
-  //   expect(normandy.showHeartbeat).not.toHaveBeenCalled();
-  // });
-
   it('should show heartbeat in testing mode regardless of when it was last shown', async () => {
     const recipe = recipeFactory();
     const action = new ShowHeartbeatAction(normandy, recipe);
@@ -55,8 +29,8 @@ describe('ShowHeartbeatAction', () => {
   it('should pass the correct arguments to showHeartbeat', async () => {
     const showHeartbeatArgs = {
       arguments: {
-        message: 'test message',
-        thanksMessage: 'thanks!',
+        message: 'Test Message',
+        thanksMessage: 'Thank you!',
         learnMoreMessage: 'Learn More',
         learnMoreUrl: 'http://example.com',
       },
@@ -82,111 +56,340 @@ describe('ShowHeartbeatAction', () => {
     }));
   });
 
-  it('should not bother to annotate an empty post-answer URL', async () => {
-    const recipe = recipeFactory({
-      arguments: {
-        postAnswerUrl: '',
-      },
-    });
-    const action = new ShowHeartbeatAction(normandy, recipe);
+  describe('Repeat Options', () => {
+    // should not show if another hbeat played within the last 24 hours
 
-    await action.execute();
-    const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
-    expect(postAnswerUrl).toEqual('');
+    /*
+       .d88888b.  888b    888  .d8888b.  8888888888
+      d88P" "Y88b 8888b   888 d88P  Y88b 888
+      888     888 88888b  888 888    888 888
+      888     888 888Y88b 888 888        8888888
+      888     888 888 Y88b888 888        888
+      888     888 888  Y88888 888    888 888
+      Y88b. .d88P 888   Y8888 Y88b  d88P 888
+       "Y88888P"  888    Y888  "Y8888P"  8888888888
+     */
+    describe('`once`', () => {
+      afterEach(() => {
+        normandy.showHeartbeat.calls.reset();
+        delete normandy.mock.storage.data.lastShown;
+      });
+
+      it('should NOT show if another heartbeat has ran already', async() => {
+        const firstAction = new ShowHeartbeatAction(normandy, recipeFactory());
+        await firstAction.execute();
+
+        // first time should run fine
+        expect(normandy.showHeartbeat).toHaveBeenCalled();
+
+        // clear the history of calls from the testing
+        normandy.showHeartbeat.calls.reset();
+
+        const secondAction = new ShowHeartbeatAction(normandy, recipeFactory());
+        await secondAction.execute();
+        // second time should NOT run
+        expect(normandy.showHeartbeat).not.toHaveBeenCalled();
+      });
+
+      it('should set the last-shown date', async () => {
+        const action = new ShowHeartbeatAction(normandy, recipeFactory());
+
+        spyOn(Date, 'now').and.returnValue(10);
+
+        expect(normandy.mock.storage.data.lastShown).toBeUndefined();
+        await action.execute();
+        expect(normandy.mock.storage.data.lastShown).toEqual('10');
+      });
+
+      it('should show if it has not been shown already', async() => {
+        const onceRecipe = recipeFactory();
+
+        const action = new ShowHeartbeatAction(normandy, onceRecipe);
+        await action.execute();
+
+        expect(normandy.showHeartbeat).toHaveBeenCalled();
+      });
+
+      it('should NOT show if it has been shown already', async() => {
+        const onceRecipe = recipeFactory();
+
+        const action = new ShowHeartbeatAction(normandy, onceRecipe);
+
+        // set the lastShown value in storage,
+        // so heartbeat thinks it's run already before
+        normandy.mock.storage.data.lastShown = '1337';
+
+        // attempt to run it again
+        await action.execute();
+
+        // it should NOT run since it's already 'run' once before
+        expect(normandy.showHeartbeat).not.toHaveBeenCalled();
+      });
+    });
+
+
+    /*
+      888b    888        d8888  .d8888b.
+      8888b   888       d88888 d88P  Y88b
+      88888b  888      d88P888 888    888
+      888Y88b 888     d88P 888 888
+      888 Y88b888    d88P  888 888  88888
+      888  Y88888   d88P   888 888    888
+      888   Y8888  d8888888888 Y88b  d88P
+      888    Y888 d88P     888  "Y8888P88
+     */
+    describe('`nag`', () => {
+      afterEach(() => {
+        normandy.showHeartbeat.calls.reset();
+        delete normandy.mock.storage.data.lastShown;
+      });
+
+      const nagConfig = {
+        arguments: {
+          repeatOption: 'nag',
+        },
+      };
+
+      it('should NOT show if another heartbeat has ran already', async() => {
+        const firstRecipe = recipeFactory({ ...nagConfig });
+        const firstAction = new ShowHeartbeatAction(normandy, firstRecipe);
+        await firstAction.execute();
+
+        // first time should run fine
+        expect(normandy.showHeartbeat).toHaveBeenCalled();
+
+        // clear the history of calls from the testing
+        normandy.showHeartbeat.calls.reset();
+
+        const secondRecipe = recipeFactory({ ...nagConfig });
+        const secondAction = new ShowHeartbeatAction(normandy, secondRecipe);
+        await secondAction.execute();
+        // second time should NOT run
+        expect(normandy.showHeartbeat).not.toHaveBeenCalled();
+      });
+
+      it('should set the last-shown date', async () => {
+        const action = new ShowHeartbeatAction(normandy, recipeFactory({ ...nagConfig }));
+
+        spyOn(Date, 'now').and.returnValue(10);
+
+        expect(normandy.mock.storage.data.lastShown).toBeUndefined();
+        await action.execute();
+        expect(normandy.mock.storage.data.lastShown).toEqual('10');
+      });
+
+      it('should show if a user has not interacted with it', async () => {
+        const testRecipe = recipeFactory({ ...nagConfig });
+        const testAction = new ShowHeartbeatAction(normandy, testRecipe);
+        await testAction.execute();
+        expect(normandy.showHeartbeat).toHaveBeenCalled();
+      });
+
+      it('should not show if the user has interacted with it', async() => {
+        const testAction = new ShowHeartbeatAction(normandy, recipeFactory({ ...nagConfig }));
+        expect(normandy.showHeartbeat).not.toHaveBeenCalled();
+
+        // fake the 'last interacted' value
+        testAction.updateLastInteraction();
+
+        await testAction.execute();
+
+        expect(normandy.showHeartbeat).not.toHaveBeenCalled();
+      });
+    });
+
+
+    /*
+      Y88b   d88P 8888888b.        d8888 Y88b   d88P  .d8888b.
+       Y88b d88P  888  "Y88b      d88888  Y88b d88P  d88P  Y88b
+        Y88o88P   888    888     d88P888   Y88o88P   Y88b.
+         Y888P    888    888    d88P 888    Y888P     "Y888b.
+         d888b    888    888   d88P  888     888         "Y88b.
+        d88888b   888    888  d88P   888     888           "888
+       d88P Y88b  888  .d88P d8888888888     888     Y88b  d88P
+      d88P   Y88b 8888888P" d88P     888     888      "Y8888P"
+     */
+    describe('`xdays`', () => {
+      afterEach(() => {
+        normandy.showHeartbeat.calls.reset();
+        delete normandy.mock.storage.data.lastShown;
+      });
+
+      const ONE_DAY = (1000 * 3600 * 24); // in milliseconds
+      const repeatEvery = 7; // days
+      const xdaysConfig = {
+        arguments: {
+          repeatOption: 'xdays',
+          repeatEvery,
+        },
+      };
+
+      it('should not show if less than `repeatEvery` days has elapsed', async () => {
+        const action = new ShowHeartbeatAction(normandy, recipeFactory({ ...xdaysConfig }));
+
+        let idx = 0;
+        const max = repeatEvery - 1;
+        for (idx; idx <= max; idx++) {
+          normandy.showHeartbeat.calls.reset();
+          // set last shown to be exactly [idx] days ago
+          normandy.mock.storage.data.lastShown =
+            Date.now() - (idx * ONE_DAY);
+
+          await action.execute();
+
+          expect(normandy.showHeartbeat).not.toHaveBeenCalled();
+        }
+      });
+
+      it('should only show if at least `repeatEvery` days has elapsed', async () => {
+        const action = new ShowHeartbeatAction(normandy, recipeFactory({ ...xdaysConfig }));
+
+        let idx = repeatEvery;
+        // check double the max amount,
+        // as an arbitrary limit
+        const max = idx + repeatEvery;
+        for (idx; idx <= max; idx++) {
+          normandy.showHeartbeat.calls.reset();
+          // set last shown to be exactly [idx] days ago
+          normandy.mock.storage.data.lastShown =
+            Date.now() - (idx * ONE_DAY);
+
+          await action.execute();
+          expect(normandy.showHeartbeat).toHaveBeenCalled();
+        }
+      });
+
+      it('should set the last-shown date', async () => {
+        const action = new ShowHeartbeatAction(normandy, recipeFactory({ ...xdaysConfig }));
+
+        spyOn(Date, 'now').and.returnValue(10);
+
+        expect(normandy.mock.storage.data.lastShown).toBeUndefined();
+        await action.execute();
+        expect(normandy.mock.storage.data.lastShown).toEqual('10');
+      });
+    });
   });
 
-  it('should annotate the post-answer URL with extra query args', async () => {
-    const url = 'https://example.com';
-    const recipe = recipeFactory({
-      arguments: {
-        postAnswerUrl: url,
-      },
+/*
+8888888b.   .d88888b.   .d8888b. 88888888888      888     888 8888888b.  888
+888   Y88b d88P" "Y88b d88P  Y88b    888          888     888 888   Y88b 888
+888    888 888     888 Y88b.         888          888     888 888    888 888
+888   d88P 888     888  "Y888b.      888          888     888 888   d88P 888
+8888888P"  888     888     "Y88b.    888          888     888 8888888P"  888
+888        888     888       "888    888   888888 888     888 888 T88b   888
+888        Y88b. .d88P Y88b  d88P    888          Y88b. .d88P 888  T88b  888
+888         "Y88888P"   "Y8888P"     888           "Y88888P"  888   T88b 88888888
+ */
+  describe('Post-answer URL annotation', () => {
+    it('should not bother to annotate an empty post-answer URL', async () => {
+      const recipe = recipeFactory({
+        arguments: {
+          postAnswerUrl: '',
+        },
+      });
+      const action = new ShowHeartbeatAction(normandy, recipe);
+
+      await action.execute();
+      const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
+      expect(postAnswerUrl).toEqual('');
     });
-    const action = new ShowHeartbeatAction(normandy, recipe);
 
-    normandy.mock.client.version = '42.0.1';
-    normandy.mock.client.channel = 'nightly';
-    normandy.mock.client.isDefaultBrowser = true;
-    normandy.mock.client.searchEngine = 'shady-tims';
-    normandy.mock.client.syncSetup = true;
+    it('should annotate the post-answer URL with extra query args', async () => {
+      const url = 'https://example.com';
+      const recipe = recipeFactory({
+        arguments: {
+          postAnswerUrl: url,
+        },
+      });
+      const action = new ShowHeartbeatAction(normandy, recipe);
 
-    await action.execute();
-    const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
-    const params = new URL(postAnswerUrl).searchParams;
-    expect(params.get('source')).toEqual('heartbeat');
-    expect(params.get('surveyversion')).toEqual('55');
-    expect(params.get('updateChannel')).toEqual('nightly');
-    expect(params.get('fxVersion')).toEqual('42.0.1');
-    expect(params.get('isDefaultBrowser')).toEqual('1');
-    expect(params.get('searchEngine')).toEqual('shady-tims');
-    expect(params.get('syncSetup')).toEqual('1');
+      normandy.mock.client.version = '42.0.1';
+      normandy.mock.client.channel = 'nightly';
+      normandy.mock.client.isDefaultBrowser = true;
+      normandy.mock.client.searchEngine = 'shady-tims';
+      normandy.mock.client.syncSetup = true;
 
-    // telemetry data is turned off, so no userId should be passed into params
-    expect(params.get('userId')).toBeNull();
+      await action.execute();
+      const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
+      const params = new URL(postAnswerUrl).searchParams;
+      expect(params.get('source')).toEqual('heartbeat');
+      expect(params.get('surveyversion')).toEqual('55');
+      expect(params.get('updateChannel')).toEqual('nightly');
+      expect(params.get('fxVersion')).toEqual('42.0.1');
+      expect(params.get('isDefaultBrowser')).toEqual('1');
+      expect(params.get('searchEngine')).toEqual('shady-tims');
+      expect(params.get('syncSetup')).toEqual('1');
+
+      // telemetry data is turned off, so no userId should be passed into params
+      expect(params.get('userId')).toBeNull();
+    });
+
+
+    it('should annotate the post-answer URL with google analytics params', async () => {
+      const url = 'https://example.com';
+      const recipe = recipeFactory({
+        action: 'show-heartbeat',
+        arguments: {
+          postAnswerUrl: url,
+          message: 'This is a test message!!',
+        },
+      });
+      const action = new ShowHeartbeatAction(normandy, recipe);
+
+      normandy.mock.client.version = '42.0.1';
+      normandy.mock.client.channel = 'nightly';
+      normandy.mock.client.isDefaultBrowser = true;
+      normandy.mock.client.searchEngine = 'shady-tims';
+      normandy.mock.client.syncSetup = true;
+
+      await action.execute();
+      const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
+      const params = new URL(postAnswerUrl).searchParams;
+      expect(params.get('utm_source')).toEqual('firefox');
+      expect(params.get('utm_medium')).toEqual('show-heartbeat');
+      expect(params.get('utm_campaign')).toEqual('Thisisatestmessage%21%21');
+    });
+
+
+    it('should annotate the post-answer URL if it has an existing query string', async () => {
+      const url = 'https://example.com?foo=bar';
+      const recipe = recipeFactory({
+        arguments: {
+          postAnswerUrl: url,
+        },
+      });
+      const action = new ShowHeartbeatAction(normandy, recipe);
+
+      normandy.mock.client.version = '42.0.1';
+      normandy.mock.client.channel = 'nightly';
+
+      await action.execute();
+      const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
+      const params = new URL(postAnswerUrl).searchParams;
+      expect(params.get('foo')).toEqual('bar');
+      expect(params.get('source')).toEqual('heartbeat');
+    });
+
+    it('should annotate the post-answer URL with a testing param in testing mode', async () => {
+      const url = 'https://example.com';
+      const recipe = recipeFactory({
+        arguments: {
+          postAnswerUrl: url,
+        },
+      });
+      const action = new ShowHeartbeatAction(normandy, recipe);
+
+      normandy.testing = true;
+
+      await action.execute();
+      const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
+      const params = new URL(postAnswerUrl).searchParams;
+      expect(params.get('testing')).toEqual('1');
+    });
   });
 
-
-  it('should annotate the post-answer URL with google analytics params', async () => {
-    const url = 'https://example.com';
-    const recipe = recipeFactory({
-      action: 'show-heartbeat',
-      arguments: {
-        postAnswerUrl: url,
-        message: 'This is a test message!!',
-      },
-    });
-    const action = new ShowHeartbeatAction(normandy, recipe);
-
-    normandy.mock.client.version = '42.0.1';
-    normandy.mock.client.channel = 'nightly';
-    normandy.mock.client.isDefaultBrowser = true;
-    normandy.mock.client.searchEngine = 'shady-tims';
-    normandy.mock.client.syncSetup = true;
-
-    await action.execute();
-    const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
-    const params = new URL(postAnswerUrl).searchParams;
-    expect(params.get('utm_source')).toEqual('firefox');
-    expect(params.get('utm_medium')).toEqual('show-heartbeat');
-    expect(params.get('utm_campaign')).toEqual('Thisisatestmessage%21%21');
-  });
-
-
-  it('should annotate the post-answer URL if it has an existing query string', async () => {
-    const url = 'https://example.com?foo=bar';
-    const recipe = recipeFactory({
-      arguments: {
-        postAnswerUrl: url,
-      },
-    });
-    const action = new ShowHeartbeatAction(normandy, recipe);
-
-    normandy.mock.client.version = '42.0.1';
-    normandy.mock.client.channel = 'nightly';
-
-    await action.execute();
-    const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
-    const params = new URL(postAnswerUrl).searchParams;
-    expect(params.get('foo')).toEqual('bar');
-    expect(params.get('source')).toEqual('heartbeat');
-  });
-
-  it('should annotate the post-answer URL with a testing param in testing mode', async () => {
-    const url = 'https://example.com';
-    const recipe = recipeFactory({
-      arguments: {
-        postAnswerUrl: url,
-      },
-    });
-    const action = new ShowHeartbeatAction(normandy, recipe);
-
-    normandy.testing = true;
-
-    await action.execute();
-    const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
-    const params = new URL(postAnswerUrl).searchParams;
-    expect(params.get('testing')).toEqual('1');
-  });
+  // END POST-URL
 
   it('should pass some extra telemetry arguments to showHeartbeat', async () => {
     const recipe = recipeFactory({
@@ -246,15 +449,5 @@ describe('ShowHeartbeatAction', () => {
     expect(normandy.showHeartbeat).toHaveBeenCalledWith(jasmine.objectContaining({
       testing: 1,
     }));
-  });
-
-  it('should set the last-shown date', async () => {
-    const action = new ShowHeartbeatAction(normandy, recipeFactory());
-
-    spyOn(Date, 'now').and.returnValue(10);
-
-    expect(normandy.mock.storage.data.lastShown).toBeUndefined();
-    await action.execute();
-    expect(normandy.mock.storage.data.lastShown).toEqual('10');
   });
 });

--- a/recipe-server/client/actions/tests/test_show-heartbeat.js
+++ b/recipe-server/client/actions/tests/test_show-heartbeat.js
@@ -14,31 +14,31 @@ describe('ShowHeartbeatAction', () => {
     await action.execute();
   });
 
-  it('should show heartbeat if it has not been shown yet', async() => {
-    const recipe = recipeFactory();
-    const action = new ShowHeartbeatAction(normandy, recipe);
+  // it('should show heartbeat if it has not been shown yet', async() => {
+  //   const recipe = recipeFactory();
+  //   const action = new ShowHeartbeatAction(normandy, recipe);
 
-    normandy.mock.storage.data.lastShown = null;
-    spyOn(Date, 'now').and.returnValue(99999999);
+  //   normandy.mock.storage.data.lastShown = null;
+  //   spyOn(Date, 'now').and.returnValue(99999999);
 
-    await action.execute();
-    expect(normandy.showHeartbeat).toHaveBeenCalled();
-  });
+  //   await action.execute();
+  //   expect(normandy.showHeartbeat).toHaveBeenCalled();
+  // });
 
-  it('should NOT show heartbeat if it has been shown already', async() => {
-    const recipe = recipeFactory();
-    const action = new ShowHeartbeatAction(normandy, recipe);
+  // it('should NOT show heartbeat if it has been shown already', async() => {
+  //   const recipe = recipeFactory();
+  //   const action = new ShowHeartbeatAction(normandy, recipe);
 
-    // set the lastShown value in storage,
-    // so heartbeat thinks it's run already before
-    normandy.mock.storage.data.lastShown = '100';
+  //   // set the lastShown value in storage,
+  //   // so heartbeat thinks it's run already before
+  //   normandy.mock.storage.data.lastShown = '100';
 
-    // attempt to run it again
-    await action.execute();
+  //   // attempt to run it again
+  //   await action.execute();
 
-    // it should NOT run since it's already 'run' once before
-    expect(normandy.showHeartbeat).not.toHaveBeenCalled();
-  });
+  //   // it should NOT run since it's already 'run' once before
+  //   expect(normandy.showHeartbeat).not.toHaveBeenCalled();
+  // });
 
   it('should show heartbeat in testing mode regardless of when it was last shown', async () => {
     const recipe = recipeFactory();

--- a/recipe-server/client/actions/tests/test_show-heartbeat.js
+++ b/recipe-server/client/actions/tests/test_show-heartbeat.js
@@ -57,18 +57,6 @@ describe('ShowHeartbeatAction', () => {
   });
 
   describe('Repeat Options', () => {
-    // should not show if another hbeat played within the last 24 hours
-
-    /*
-       .d88888b.  888b    888  .d8888b.  8888888888
-      d88P" "Y88b 8888b   888 d88P  Y88b 888
-      888     888 88888b  888 888    888 888
-      888     888 888Y88b 888 888        8888888
-      888     888 888 Y88b888 888        888
-      888     888 888  Y88888 888    888 888
-      Y88b. .d88P 888   Y8888 Y88b  d88P 888
-       "Y88888P"  888    Y888  "Y8888P"  8888888888
-     */
     describe('`once`', () => {
       afterEach(() => {
         normandy.showHeartbeat.calls.reset();
@@ -128,16 +116,6 @@ describe('ShowHeartbeatAction', () => {
     });
 
 
-    /*
-      888b    888        d8888  .d8888b.
-      8888b   888       d88888 d88P  Y88b
-      88888b  888      d88P888 888    888
-      888Y88b 888     d88P 888 888
-      888 Y88b888    d88P  888 888  88888
-      888  Y88888   d88P   888 888    888
-      888   Y8888  d8888888888 Y88b  d88P
-      888    Y888 d88P     888  "Y8888P88
-     */
     describe('`nag`', () => {
       afterEach(() => {
         normandy.showHeartbeat.calls.reset();
@@ -199,16 +177,6 @@ describe('ShowHeartbeatAction', () => {
     });
 
 
-    /*
-      Y88b   d88P 8888888b.        d8888 Y88b   d88P  .d8888b.
-       Y88b d88P  888  "Y88b      d88888  Y88b d88P  d88P  Y88b
-        Y88o88P   888    888     d88P888   Y88o88P   Y88b.
-         Y888P    888    888    d88P 888    Y888P     "Y888b.
-         d888b    888    888   d88P  888     888         "Y88b.
-        d88888b   888    888  d88P   888     888           "888
-       d88P Y88b  888  .d88P d8888888888     888     Y88b  d88P
-      d88P   Y88b 8888888P" d88P     888     888      "Y8888P"
-     */
     describe('`xdays`', () => {
       afterEach(() => {
         normandy.showHeartbeat.calls.reset();
@@ -231,7 +199,7 @@ describe('ShowHeartbeatAction', () => {
         const max = repeatEvery - 1;
         for (idx; idx <= max; idx++) {
           normandy.showHeartbeat.calls.reset();
-          // set last shown to be exactly [idx] days ago
+          // set last shown to be exactly `idx` days ago
           normandy.mock.storage.data.lastShown =
             Date.now() - (idx * ONE_DAY);
 
@@ -271,16 +239,7 @@ describe('ShowHeartbeatAction', () => {
     });
   });
 
-/*
-8888888b.   .d88888b.   .d8888b. 88888888888      888     888 8888888b.  888
-888   Y88b d88P" "Y88b d88P  Y88b    888          888     888 888   Y88b 888
-888    888 888     888 Y88b.         888          888     888 888    888 888
-888   d88P 888     888  "Y888b.      888          888     888 888   d88P 888
-8888888P"  888     888     "Y88b.    888          888     888 8888888P"  888
-888        888     888       "888    888   888888 888     888 888 T88b   888
-888        Y88b. .d88P Y88b  d88P    888          Y88b. .d88P 888  T88b  888
-888         "Y88888P"   "Y8888P"     888           "Y88888P"  888   T88b 88888888
- */
+
   describe('Post-answer URL annotation', () => {
     it('should not bother to annotate an empty post-answer URL', async () => {
       const recipe = recipeFactory({
@@ -314,7 +273,7 @@ describe('ShowHeartbeatAction', () => {
       const postAnswerUrl = normandy.showHeartbeat.calls.argsFor(0)[0].postAnswerUrl;
       const params = new URL(postAnswerUrl).searchParams;
       expect(params.get('source')).toEqual('heartbeat');
-      expect(params.get('surveyversion')).toEqual('55');
+      expect(params.get('surveyversion')).toEqual('56');
       expect(params.get('updateChannel')).toEqual('nightly');
       expect(params.get('fxVersion')).toEqual('42.0.1');
       expect(params.get('isDefaultBrowser')).toEqual('1');

--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -61,20 +61,14 @@ export class RecipeForm extends React.Component {
       return null;
     }
 
-    this.cloneCache = this.cloneCache || {};
-    const cache = this.cloneCache;
-
-    if (!cache[displayedRecipe.id]) {
-      cache[displayedRecipe.id] = (
-        <span className="cloning-message callout">
-          {'You are cloning '}
-          <Link to={`/control/recipe/${displayedRecipe.id}/`}>
-            {displayedRecipe.name} ({displayedRecipe.action})
-          </Link>.
-        </span>
-      );
-    }
-    return cache[displayedRecipe.id];
+    return (
+      <span className="cloning-message callout">
+        {'You are cloning '}
+        <Link to={`/control/recipe/${displayedRecipe.id}/`}>
+          {displayedRecipe.name} ({displayedRecipe.action})
+        </Link>.
+      </span>
+    );
   }
 
   render() {

--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -43,6 +43,7 @@ export class RecipeForm extends React.Component {
       action: pt.string.isRequired,
       arguments: pt.object.isRequired,
     }),
+    recipeFields: pt.object,
     // route prop passed from router
     route: pt.object,
   };
@@ -54,15 +55,26 @@ export class RecipeForm extends React.Component {
 
   renderCloningMessage() {
     const isCloning = this.props.route && this.props.route.isCloning;
-    const displayedRecipe = this.props.recipe || {};
+    const displayedRecipe = this.props.recipe;
 
-    return isCloning &&
-      (<span className="cloning-message callout">
-        {'You are cloning '}
-        <Link to={`/control/recipe/${displayedRecipe.id}/`}>
-          {displayedRecipe.name} ({displayedRecipe.action})
-        </Link>.
-      </span>);
+    if (!isCloning || !displayedRecipe) {
+      return null;
+    }
+
+    this.cloneCache = this.cloneCache || {};
+    const cache = this.cloneCache;
+
+    if (!cache[displayedRecipe.id]) {
+      cache[displayedRecipe.id] = (
+        <span className="cloning-message callout">
+          {'You are cloning '}
+          <Link to={`/control/recipe/${displayedRecipe.id}/`}>
+            {displayedRecipe.name} ({displayedRecipe.action})
+          </Link>.
+        </span>
+      );
+    }
+    return cache[displayedRecipe.id];
   }
 
   render() {
@@ -73,8 +85,10 @@ export class RecipeForm extends React.Component {
       recipe,
       recipeId,
       route,
+      recipeFields,
     } = this.props;
-    const ArgumentsFields = RecipeForm.argumentsFields[selectedAction] || null;
+    const noop = () => null;
+    const ArgumentsFields = RecipeForm.argumentsFields[selectedAction] || noop;
 
     // Show a loading indicator if we haven't yet loaded the recipe.
     if (recipeId && !recipe) {
@@ -112,7 +126,7 @@ export class RecipeForm extends React.Component {
           <option value="console-log">Log to Console</option>
           <option value="show-heartbeat">Heartbeat Prompt</option>
         </ControlField>
-        {ArgumentsFields && <ArgumentsFields />}
+        <ArgumentsFields fields={recipeFields} />
         <div className="form-actions">
           {recipeId && !isCloning &&
             <Link className="button delete" to={`/control/recipe/${recipeId}/delete/`}>
@@ -217,6 +231,7 @@ const connector = connect(
   // Pull selected action from the form state.
   state => ({
     selectedAction: selector(state, 'action'),
+    recipeFields: selector(state, 'arguments'),
   }),
 
   // Bound functions for writing to the server.

--- a/recipe-server/client/control/components/action_fields/HeartbeatFields.js
+++ b/recipe-server/client/control/components/action_fields/HeartbeatFields.js
@@ -61,7 +61,7 @@ export default function HeartbeatFields({ fields }) {
         component="select"
       >
         <option value="once" default>{`
-          Do not show this prompt to specific users more than once
+          Do not show this prompt to users more than once.
         `}</option>
         <option value="nag">{`
           Show this prompt until the user interacts with it in any way,
@@ -69,7 +69,7 @@ export default function HeartbeatFields({ fields }) {
         `}</option>
         <option value="xdays">{`
           Allow re-prompting users who have already seen this prompt
-          after ${fields.repeatEvery || 'X'} days since they last saw it
+          after ${fields.repeatEvery || 'X'} days since they last saw it.
         `}</option>
       </ControlField>
 

--- a/recipe-server/client/control/components/action_fields/HeartbeatFields.js
+++ b/recipe-server/client/control/components/action_fields/HeartbeatFields.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { PropTypes as pt } from 'react';
 
 import { ControlField } from 'control/components/Fields';
 
 /**
  * Form fields for the show-heartbeat action.
  */
-export default function HeartbeatFields() {
+export default function HeartbeatFields({ fields }) {
   return (
     <div className="arguments-fields">
       <p className="info">
@@ -41,13 +41,7 @@ export default function HeartbeatFields() {
         component="input"
         type="text"
       />
-      <ControlField
-        label="Include unique user ID in Post-Answer URL (and Telemetry)"
-        name="arguments.includeTelemetryUUID"
-        component="input"
-        type="checkbox"
-        className="checkbox-field"
-      />
+
       <ControlField
         label="Learn More Message"
         name="arguments.learnMoreMessage"
@@ -60,6 +54,49 @@ export default function HeartbeatFields() {
         component="input"
         type="text"
       />
+
+      <ControlField
+        label="How often should the prompt be shown?"
+        name="arguments.repeatOption"
+        component="select"
+      >
+        <option value="once" default>{`
+          Do not show this prompt to specific users more than once
+        `}</option>
+        <option value="nag">{`
+          Show this prompt until the user interacts with it in any way,
+          and then never again.
+        `}</option>
+        <option value="xdays">{`
+          Allow re-prompting users who have already seen this prompt
+          after ${fields.repeatEvery || 'X'} days since they last saw it
+        `}</option>
+      </ControlField>
+
+      {
+        fields &&
+        fields.repeatOption &&
+        fields.repeatOption === 'xdays' &&
+          <ControlField
+            label="Days before user is re-prompted"
+            name="arguments.repeatEvery"
+            component="input"
+            type="number"
+          />
+      }
+
+      <ControlField
+        label="Include unique user ID in Post-Answer URL (and Telemetry)"
+        name="arguments.includeTelemetryUUID"
+        component="input"
+        type="checkbox"
+        className="checkbox-field"
+      />
     </div>
   );
 }
+
+HeartbeatFields.propTypes = {
+  fields: pt.object,
+};
+

--- a/recipe-server/client/control/sass/partials/_common.scss
+++ b/recipe-server/client/control/sass/partials/_common.scss
@@ -40,6 +40,7 @@ textarea {
   border-radius: 3px;
   font: normal normal 300 15px/30px $SourceSansPro;
   padding: 5px 10px;
+  text-transform: none;
   width: 100%;
 
   &:focus {

--- a/recipe-server/client/selfrepair/normandy_driver.js
+++ b/recipe-server/client/selfrepair/normandy_driver.js
@@ -16,7 +16,7 @@ export class LocalStorage {
     this.skipDurability = skipDurability;
   }
 
-  async isDurable() {
+  isDurable() {
     const durabilityStatus = localStorage.getItem(STORAGE_DURABILITY_KEY);
     return (parseInt(durabilityStatus, 10) >= 2);
   }
@@ -25,8 +25,8 @@ export class LocalStorage {
     return `${this.prefix}-${key}`;
   }
 
-  async getItem(key) {
-    const storageIsDurable = await this.isDurable();
+  getItem(key) {
+    const storageIsDurable = this.isDurable();
     if (!storageIsDurable && !this.skipDurability) {
       throw new Error('Storage durability unconfirmed');
     }
@@ -38,11 +38,11 @@ export class LocalStorage {
     }
   }
 
-  async setItem(key, value) {
+  setItem(key, value) {
     return localStorage.setItem(this._makeKey(key), JSON.stringify(value));
   }
 
-  async removeItem(key) {
+  removeItem(key) {
     return localStorage.removeItem(this._makeKey(key));
   }
 }

--- a/recipe-server/client/selfrepair/normandy_driver.js
+++ b/recipe-server/client/selfrepair/normandy_driver.js
@@ -60,7 +60,7 @@ export class HeartbeatEmitter {
     'Voted',
     'TelemetrySent',
     'Engaged',
-  ]
+  ];
 
   constructor() {
     this.callbacks = {};

--- a/recipe-server/client/tests/utils.js
+++ b/recipe-server/client/tests/utils.js
@@ -16,7 +16,7 @@ export function urlPathMatcher(path) {
  */
 export function recipeFactory(props = {}) {
   // If we leave arguments, it will overwrite itself below.
-  const args = props.arguments;
+  const args = { ...props.arguments };
   delete props.arguments;
 
   return {
@@ -34,6 +34,7 @@ export function recipeFactory(props = {}) {
       postAnswerUrl: 'http://example.com',
       learnMoreMessage: 'Learn More',
       learnMoreUrl: 'http://example.com',
+      repeatOption: 'once',
       ...args,
     },
     ...props,

--- a/recipe-server/package.json
+++ b/recipe-server/package.json
@@ -26,7 +26,7 @@
     "jquery": "3.1.0",
     "json-editor": "0.7.28",
     "json-loader": "0.5.4",
-    "localforage": "^1.4.3",
+    "localforage": "1.4.3",
     "moment": "2.14.1",
     "node-sass": "3.9.3",
     "node-uuid": "1.4.7",


### PR DESCRIPTION
- Adds `repeatOption` and `repeatEvery` properties to `show-heartbeat` actions.
  - `repeatOption` select input consists of three options: `once`, `nag`, or `xdays`
    - `once` will display a prompt once and only once, ever
    - `nag` will display until the user interacts with the prompt in a meaningful way
    - `xdays` will show after waiting at least _x_ days since the last time it appeared
  - If `xdays` is selected, an additional form field for `repeatEvery` appears, which dictates how often the prompt is due to show.
- Adds tests for new show-heartbeat configurations