### PR TITLE
mock-recipe-server Test Cases

### DIFF
--- a/mock-recipe-server/api_index.html
+++ b/mock-recipe-server/api_index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <title>SHIELD Test Service</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        background: #F6F4EF;
+        color: #585755;
+        font-family: sans-serif;
+        font-size: 15px;
+        line-height: 1.4em;
+        margin: 0 auto;
+        width: 720px;
+        word-wrap: break-word;
+      }
+
+      a {
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      li {
+        margin-bottom: .5em;
+      }
+
+      pre, code {
+        background: #EEE;
+        border: 1px solid #CCC;
+      }
+
+      pre {
+        margin: 0 0 1.5em;
+        padding: 5px;
+      }
+
+      code {
+        box-decoration-break: clone;
+        padding: 2px 4px;
+        position: relative;
+        top: -1px;
+      }
+
+      .testcase {
+        background: #FFF;
+        margin: 0 0 20px;
+      }
+
+      .testcase h3 {
+        background: #585755;
+        color: #FFF;
+        margin: 0;
+        padding: 15px
+      }
+
+      .testcase-content {
+        padding: 15px;
+      }
+
+      .testcase-content p {
+        margin: 0 0 1.5em;
+      }
+
+      textarea {
+        border: 1px solid #ece7db;
+        border-radius: 3px;
+        display: block;
+        height: 6em;
+        overflow: auto;
+        padding: 5px;
+        white-space: pre;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>SHIELD Test Service</h1>
+    <p>
+      This service hosts the data needed for running manual tests of the
+      <a href="https://wiki.mozilla.org/Firefox/SHIELD">SHIELD</a> recipe
+      client. The scripts that generate this page and the data are
+      <a href="https://github.com/mozilla/normandy/tree/master/mock-recipe-server">
+      hosted on Github</a>.
+    </p>
+    <h2>Setting up for Testing</h2>
+    <ol>
+      <li>
+        Obtain a copy of Firefox with the SHIELD recipe client system add-on
+        installed. You can check <code>about:support</code> to ensure that you
+        have it.
+      </li>
+      <li>
+        Set the <code>extensions.shield-recipe-client.dev_mode</code> preference
+        to <code>true</code> to run recipes immediately on startup.
+      </li>
+      <li>
+        Set the <code>extensions.shield-recipe-client.logging.level</code>
+        preference to <code>0</code> to enable more logging.
+      </li>
+      <li>
+        Set the <code>security.content.signature.root_hash</code> preference to
+        <code>4C:35:B1:C3:E3:12:D9:55:E7:78:ED:D0:A7:E7:8A:38:83:04:EF:01:BF:FA:03:29:B2:46:9F:3C:C5:EC:36:04</code>.
+        This is the public hash used for verifying content signatures of the
+        test data.
+      </li>
+    </ol>
+    <h2>Verifying a Test Case</h2>
+    <p>
+      You have two options for verifying a test case depending on how thoroughly
+      you want to test the client:
+    </p>
+    <ul>
+      <li>
+        Find the test in the list below, set the
+        <code>extensions.shield-recipe-client.api_url</code> preference to the
+        given URL, and restart your browser. Upon restart, the client will
+        download recipes and execute them. This tests the recipe client from
+        startup to recipe execution.
+      </li>
+      <li>
+        If you have enabled the browser chrome debugging toolbox in the DevTools
+        settings, you can copy and paste the code from the textbox into the
+        Browser Console to immediately set the right preferences and fetch the
+        recipes. This skips testing a small amount of initialization, but is
+        otherwise a quick and reliable way of testing.
+      </li>
+    </ul>
+    <h2>Test Cases</h2>
+    {% for fixture in fixtures %}
+      <div class="testcase" data-name="{{ fixture.name }}">
+        <h3>{{ fixture.name }}</h3>
+        <div class="testcase-content">
+          {{ fixture.description|safe }}
+          <p><strong>URL:</strong> <code class="url"></code></p>
+          <textarea class="browser-code"></textarea>
+        </div>
+      </div>
+    {% endfor %}
+    <script>
+      // Caluclate URLs relative to the current domain and populate each
+      // testcase with them.
+      let testcases = Array.from(document.querySelectorAll('.testcase'));
+      for (let testcase of testcases) {
+        let url = new URL(`/${testcase.dataset.name}/api/v1`, window.location);
+        testcase.querySelector('.url').textContent = url.href;
+        testcase.querySelector('.browser-code').value = (
+          `Cu.import('resource://shield-recipe-client/lib/Storage.jsm');\n` +
+          `Storage.clearAllStorage();\n` +
+          `Services.prefs.setCharPref("extensions.shield-recipe-client.api_url", "${url.href}");\n` +
+          `Cu.import('resource://shield-recipe-client/lib/RecipeRunner.jsm');\n` +
+          `RecipeRunner.start();`
+        );
+      }
+
+      // Select entire textbox when it gets focus to make things quicker.
+      document.addEventListener('focusin', ({ target }) => {
+        if (target.tagName && target.tagName.toLowerCase() === 'textarea') {
+          target.select();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/mock-recipe-server/api_index.html
+++ b/mock-recipe-server/api_index.html
@@ -129,11 +129,11 @@
       </li>
     </ul>
     <h2>Test Cases</h2>
-    {% for fixture in fixtures %}
-      <div class="testcase" data-name="{{ fixture.name }}">
-        <h3>{{ fixture.name }}</h3>
+    {% for testcase in testcases %}
+      <div class="testcase" data-name="{{ testcase.name }}">
+        <h3>{{ testcase.name }}</h3>
         <div class="testcase-content">
-          {{ fixture.description|safe }}
+          {{ testcase.description|safe }}
           <p><strong>URL:</strong> <code class="url"></code></p>
           <textarea class="browser-code"></textarea>
         </div>

--- a/mock-recipe-server/fixtures.py
+++ b/mock-recipe-server/fixtures.py
@@ -2,13 +2,20 @@ from normandy.recipes.models import Action, Recipe
 from normandy.recipes.tests import ClientFactory, RecipeFactory
 
 
-def console_log_action():
-    return Action.objects.get(name='console-log')
+def console_log(message, **kwargs):
+    return RecipeFactory(
+        action=Action.objects.get(name='console-log'),
+        arguments={'message': message},
+        **kwargs
+    )
 
 
 def get_fixtures():
     """Return all defined fixtures."""
-    return [FixtureClass() for FixtureClass in Fixture.__subclasses__()]
+    return sorted(
+        [FixtureClass() for FixtureClass in Fixture.__subclasses__()],
+        key=lambda f: f.name
+    )
 
 
 class Fixture(object):
@@ -20,6 +27,10 @@ class Fixture(object):
     @property
     def name(self):
         return self.__class__.__name__
+
+    @property
+    def description(self):
+        return '<p class="description">{}</p>'.format(self.__doc__)
 
     def load(self):
         """
@@ -45,10 +56,8 @@ class Fixture(object):
 
 
 class ConsoleLogBasic(Fixture):
-    """A single console-log action."""
+    """Matches all clients. Logs a message to the console."""
     def load_data(self):
-        RecipeFactory(
-            action=console_log_action(),
-            arguments={'message': 'Test Message'},
+        console_log('ConsoleLogBasic executed', filter_expression='true')
             filter_expression='true',
         )

--- a/mock-recipe-server/generate.py
+++ b/mock-recipe-server/generate.py
@@ -28,7 +28,7 @@ from normandy.base.utils import canonical_json_dumps  # noqa
 from normandy.recipes.api.serializers import ClientSerializer  # noqa
 from normandy.recipes.models import Action  # noqa
 
-from fixtures import get_fixtures  # noqa
+from testcases import get_testcases  # noqa
 
 
 class APIPath(object):
@@ -74,35 +74,35 @@ class APIPath(object):
 
 def main():
     """
-    Load each defined fixture from fixtures.py and save the state of the API
-    after each fixture is loaded.
+    Load each defined testcase from testcases.py and save the state of the API
+    after each testcase is loaded.
     """
     build_path = Path(sys.argv[1])
     domain = sys.argv[2]
-    fixtures = get_fixtures()
-    for fixture in fixtures:
-        fixture.load()
-        fixture_api_path = APIPath(build_path / fixture.name, 'https://proxy:8443')
-        serialize_api(fixture, fixture_api_path, domain)
+    testcases = get_testcases()
+    for testcase in testcases:
+        testcase.load()
+        testcase_api_path = APIPath(build_path / testcase.name, 'https://proxy:8443')
+        serialize_api(testcase, testcase_api_path, domain)
 
     # Write the root index page.
     index_template_path = Path(__file__).parent / 'api_index.html'
     with index_template_path.open() as f:
         index_template = Template(f.read())
 
-    context = Context({'fixtures': fixtures})
+    context = Context({'testcases': testcases})
     index_path = build_path / 'index.html'
     with index_path.open(mode='w') as f:
         f.write(index_template.render(context))
 
 
-def serialize_api(fixture, api_path, domain):
+def serialize_api(testcase, api_path, domain):
     """
     Fetch API responses from the service and save them to the
     filesystem.
 
-    :param fixture:
-        Fixture object that was last loaded to provide a client object
+    :param testcase:
+        TestCase object that was last loaded to provide a client object
         to serialize to the client classification endpoint.
     :param api_path:
         APIPath object for the root URL and path to fetch and save
@@ -118,7 +118,7 @@ def serialize_api(fixture, api_path, domain):
     root_path.add('recipe', 'signed').save()
 
     # Client classification (manually rendered as canonical json)
-    client = fixture.client()
+    client = testcase.client()
     client_data = ClientSerializer(client).data
     client_json = canonical_json_dumps(client_data)
     root_path.add('classify_client').save(client_json)
@@ -128,7 +128,7 @@ def serialize_api(fixture, api_path, domain):
         action_path = root_path.add('action', action.name)
 
         action_data = json.loads(action_path.fetch())
-        new_url = update_url(action_data['implementation_url'], fixture, domain)
+        new_url = update_url(action_data['implementation_url'], testcase, domain)
         action_data['implementation_url'] = new_url
         action_json = canonical_json_dumps(action_data)
         action_path.save(action_json)
@@ -137,17 +137,17 @@ def serialize_api(fixture, api_path, domain):
         action_path.add('implementation', action.implementation_hash).save()
 
 
-def update_url(url, fixture, domain):
+def update_url(url, testcase, domain):
     """
     Modify the URL to use the domain and to add the name of the given
-    fixture as the first path segment.
+    testcase as the first path segment.
     """
     parsed_url = urlparse(url)
     parsed_domain = urlparse(domain)
     return urlunparse((
         parsed_domain.scheme,
         parsed_domain.netloc,
-        '/' + fixture.name + parsed_url.path,
+        '/' + testcase.name + parsed_url.path,
         parsed_url.params,
         parsed_url.query,
         parsed_url.fragment,

--- a/mock-recipe-server/testcases.py
+++ b/mock-recipe-server/testcases.py
@@ -10,19 +10,19 @@ def console_log(message, **kwargs):
     )
 
 
-def get_fixtures():
-    """Return all defined fixtures."""
+def get_testcases():
+    """Return all defined testcases."""
     return sorted(
-        [FixtureClass() for FixtureClass in Fixture.__subclasses__()],
+        [TestCaseClass() for TestCaseClass in TestCase.__subclasses__()],
         key=lambda f: f.name
     )
 
 
-class Fixture(object):
+class TestCase(object):
     """
-    Collection of data for a specific manual test case. Includes both
-    data to be loaded in the database, and data needed to represent
-    API responses that don't use the database.
+    Configuration for a specific manual test case. Subclasses can
+    override methods on this class to customize the state of the server
+    that will be serialized, or, if necessary, the serialization itself.
     """
     @property
     def name(self):
@@ -34,7 +34,7 @@ class Fixture(object):
 
     def load(self):
         """
-        Clear out all existing recipes and load this fixture's data in
+        Clear out all existing recipes and load this test's data in
         its place.
         """
         Recipe.objects.all().delete()
@@ -42,22 +42,20 @@ class Fixture(object):
 
     def load_data(self):
         """
-        Create data specific to this fixture. Individual fixtures must
-        override this.
+        Create data specific to this test. Override to populate the
+        database with recipes and other data the test case needs.
         """
-        raise NotImplementedError()
+        pass
 
     def client(self):
         """
         Return a Client object that the client classification endpoint
-        should render for this fixture.
+        should render for this test.
         """
         return ClientFactory()
 
 
-class ConsoleLogBasic(Fixture):
+class ConsoleLogBasic(TestCase):
     """Matches all clients. Logs a message to the console."""
     def load_data(self):
         console_log('ConsoleLogBasic executed', filter_expression='true')
-            filter_expression='true',
-        )

--- a/mock-recipe-server/testcases.py
+++ b/mock-recipe-server/testcases.py
@@ -1,5 +1,11 @@
+import json
+import random
+from urllib.parse import urlparse, urlunparse
+
+from normandy.base.utils import canonical_json_dumps
+from normandy.recipes.api.serializers import ClientSerializer
 from normandy.recipes.models import Action, Recipe
-from normandy.recipes.tests import ClientFactory, RecipeFactory
+from normandy.recipes.tests import ClientFactory, RecipeFactory, SignatureFactory
 
 
 def console_log(message, **kwargs):
@@ -8,6 +14,34 @@ def console_log(message, **kwargs):
         arguments={'message': message},
         **kwargs
     )
+
+
+def show_heartbeat(**kwargs):
+    return RecipeFactory(
+        action=Action.objects.get(name='show-heartbeat'),
+        **kwargs
+    )
+
+
+def generate_long_message():
+    phrases = [
+        'You all know the mission and what is at stake.',
+        ('I have come to trust each of you with my life, but I have also heard murmurs of '
+         'discontent.'),
+        'I share your concerns.',
+        'We are trained for espionage.',
+        'We would be legends, but the records are sealed.',
+        'Glory in battle is not our way.',
+        'Think of our heroes: the Silent Step, who defeated a nation with a single shot.',
+        'Or the Ever Alert, who kept armies at bay with hidden facts.',
+        'These giants do not seem to give us solace here, but they are not all that we are.',
+        'Before the network, there was the fleet.',
+        'Before diplomacy, there were soldiers.',
+        'Our influence stopped the rachni, but before that, we held the line.',
+        'Our influence stopped the krogan, but before that, we held the line!',
+        'Our influence will stop Saren! In the battle today, we will hold the line!',
+    ]
+    return ' '.join([random.choice(phrases) for _ in range(1000)])
 
 
 def get_testcases():
@@ -54,8 +88,288 @@ class TestCase(object):
         """
         return ClientFactory()
 
+    def serialize_api(self, api_path, domain):
+        """
+        Fetch API responses from the service and save them to the
+        filesystem.
+
+        :param api_path:
+            APIPath object for the root URL and path to fetch and save
+            responses from and to.
+        :param domain:
+            Protocol and domain to use for absolute URLs in the serialized
+            API.
+        """
+        root_path = api_path.add('api', 'v1')
+        self.serialize_recipe_api(root_path)
+        self.serialize_client_api(root_path)
+        self.serialize_action_api(root_path, domain)
+
+    def serialize_recipe_api(self, root_path):
+        root_path.add('recipe').save()
+        root_path.add('recipe', 'signed').save()
+
+    def serialize_client_api(self, root_path):
+        client = self.client()
+        client_data = ClientSerializer(client).data
+        client_json = canonical_json_dumps(client_data)
+        root_path.add('classify_client').save(client_json)
+
+    def serialize_action_api(self, root_path, domain):
+        for action in Action.objects.all():
+            # Action
+            action_path = root_path.add('action', action.name)
+            action_data = json.loads(action_path.fetch())
+
+            new_url = self.update_url(action_data['implementation_url'], domain)
+            action_data['implementation_url'] = new_url
+
+            action_json = canonical_json_dumps(action_data)
+            action_path.save(action_json)
+
+            # Action implementation
+            action_path.add('implementation', action.implementation_hash).save()
+
+    def update_url(self, url, domain):
+        """
+        Modify the URL to use the domain and to add the name of the
+        test case as the first path segment.
+        """
+        parsed_url = urlparse(url)
+        parsed_domain = urlparse(domain)
+        return urlunparse((
+            parsed_domain.scheme,
+            parsed_domain.netloc,
+            '/' + self.name + parsed_url.path,
+            parsed_url.params,
+            parsed_url.query,
+            parsed_url.fragment,
+        ))
+
+
+class FilterVersion(TestCase):
+    """
+    Matches Firefox version 50.0.0. Logs to the console.
+    """
+    def load_data(self):
+        console_log('FilterVersion executed', filter_expression='normandy.version=="50.0.0"')
+
+
+class FilterChannel(TestCase):
+    """
+    Matches Firefox channel Aurora. Logs to the console.
+    """
+    def load_data(self):
+        console_log('FilterChannel executed', filter_expression='normandy.channel=="aurora"')
+
+
+class FilterDefaultBrowser(TestCase):
+    """
+    Matches if Firefox is the default browser. Logs to the console.
+    """
+    def load_data(self):
+        console_log(
+            'FilterDefaultBrowser executed',
+            filter_expression='normandy.isDefaultBrowser==true'
+        )
+
+
+class FilterGeolocationMatch(TestCase):
+    """
+    Matches if the server geolocates the user to the US, which this test
+    case does. Logs to the console.
+    """
+    def client(self):
+        return ClientFactory(country='US')
+
+    def load_data(self):
+        console_log(
+            'FilterGeolocationMatch executed',
+            filter_expression='normandy.country=="US"'
+        )
+
+
+class FilterGeolocationNoMatch(TestCase):
+    """
+    Matches if the server geolocates the user to the US; the server is
+    set to geolocate the user to France. Logs to the console.
+    """
+    def client(self):
+        return ClientFactory(country='FR')
+
+    def load_data(self):
+        console_log(
+            'FilterGeolocationNoMatch executed',
+            filter_expression='normandy.country=="US"'
+        )
+
+
+class FilterSample0(TestCase):
+    """
+    Recipe set to a 0% sample of users (effectively should never be
+    run). Logs to the console.
+    """
+    def load_data(self):
+        console_log('FilterSample0 executed', filter_expression='normandy.userId|stableSample(0)')
+
+
+class FilterSample100(TestCase):
+    """
+    Recipe set to a 100% sample of users (effectively should always be
+    run). Logs to the console.
+    """
+    def load_data(self):
+        console_log(
+            'FilterSample100 executed',
+            filter_expression='normandy.userId|stableSample(1)'
+        )
+
+
+class FilterTelemetry(TestCase):
+    @property
+    def description(self):
+        # We can't use a docstring due to the formatting for the code
+        # sample.
+        code = '\n'.join([
+            'Components.utils.import("resource://gre/modules/TelemetryController.jsm");',
+            'TelemetryController.submitExternalPing("testping", {foo: "bar"});</pre>',
+        ])
+        return """
+            <p class="description">Matches users with a telemetry ping named <code>testping</code>
+            with the payload <code>{{foo: "bar"}}</code>. You can send a telemetry ping with the
+            following code pasted into the Browser Console:</p>
+            <pre>{code}</pre>
+        """.format(code=code)
+
+    def load_data(self):
+        console_log(
+            'FilterTelemetry executed',
+            filter_expression='''
+                telemetry.testping.payload.foo=="bar"
+            '''
+        )
+
 
 class ConsoleLogBasic(TestCase):
     """Matches all clients. Logs a message to the console."""
     def load_data(self):
         console_log('ConsoleLogBasic executed', filter_expression='true')
+
+
+class ShowHeartbeatStars(TestCase):
+    """
+    Matches all clients. Shows a Heartbeat prompt with a 5-star rating
+    control.
+    """
+    def load_data(self):
+        show_heartbeat(
+            filter_expression='true',
+            arguments={
+                'includeTelemetryUUID': False,
+                'surveyId': 'test-survey',
+                'message': 'ShowHeartbeatStars test prompt',
+                'engagementButtonLabel': '',
+                'thanksMessage': 'Thanks!',
+                'postAnswerUrl': 'https://www.mozilla.org',
+                'learnMoreMessage': 'Learn More',
+                'learnMoreUrl': 'https://wiki.mozilla.org/Firefox/Shield',
+            }
+        )
+
+
+class ShowHeartbeatButton(TestCase):
+    """
+    Matches all clients. Shows a Heartbeat prompt with a clickable
+    button.
+    """
+    def load_data(self):
+        show_heartbeat(
+            filter_expression='true',
+            arguments={
+                'includeTelemetryUUID': False,
+                'surveyId': 'test-survey',
+                'message': 'ShowHeartbeatButton test prompt',
+                'engagementButtonLabel': 'Click me!',
+                'thanksMessage': 'Thanks!',
+                'postAnswerUrl': 'https://www.mozilla.org',
+                'learnMoreMessage': 'Learn More',
+                'learnMoreUrl': 'https://wiki.mozilla.org/Firefox/Shield',
+            }
+        )
+
+
+class FilterLongExpression(TestCase):
+    """
+    Matches all clients using a <em>very long</em> filter expression. Logs to
+    the console.
+    """
+    def load_data(self):
+        truthy_choices = [
+            'true',
+            '1 + 7 == 8',
+            '5 > 4',
+            '((4 * 8) - 12) > -5',
+            '4 in [1, 2, 4]',
+            '{foo: "bar"}.foo == "bar"',
+            '"bar" in "foobarbaz"',
+            'normandy.userId|stableSample(1)',
+        ]
+        truthy_expressions = [random.choice(truthy_choices) for _ in range(1000)]
+        filter_expression = '&&'.join(['({})'.format(expr) for expr in truthy_expressions])
+        console_log('FilterLongExpression executed', filter_expression=filter_expression)
+
+
+class ConsoleLogLongMessage(TestCase):
+    """
+    Matches all clients. Logs to the console with a <em>very long</em>
+    message.
+    """
+    def load_data(self):
+        message = generate_long_message()
+        console_log('ConsoleLogLongMessage executed: ' + message, filter_expression='true')
+
+
+class HeartbeatLongMessages(TestCase):
+    """
+    Matches all clients. Shows a Heartbeat prompt with
+    <em>very long</em> strings.
+    """
+    def load_data(self):
+        message = generate_long_message()
+        show_heartbeat(
+            filter_expression='true',
+            arguments={
+                'includeTelemetryUUID': False,
+                'surveyId': 'test-survey',
+                'message': message,
+                'engagementButtonLabel': message,
+                'thanksMessage': message,
+                'postAnswerUrl': 'https://www.mozilla.org',
+                'learnMoreMessage': message,
+                'learnMoreUrl': 'https://wiki.mozilla.org/Firefox/Shield',
+            }
+        )
+
+
+class ErrorMissingAPI(TestCase):
+    """Returns a 404 Not Found response."""
+    def serialize_recipe_api(self, root_path):
+        pass  # No recipe API == 404!
+
+
+class ErrorMalformedJSON(TestCase):
+    """Returns invalid JSON in the server response."""
+    def serialize_recipe_api(self, root_path):
+        root_path.add('recipe').save('{invalid: "JSON"[ %2}')
+        root_path.add('recipe', 'signed').save('&invalid" JSON')
+
+
+class ErrorInvalidSignature(TestCase):
+    """
+    Returns a recipe with invalid signatures, which should not be
+    executed. If it does anyway, it will log to the console.
+    """
+    def load_data(self):
+        recipe = console_log('ErrorInvalidSignature executed', filter_expression='true')
+        recipe.signature = SignatureFactory.create(data='blockbuster night part 1'.encode())
+        recipe.save()


### PR DESCRIPTION
Phew, finally! Okay. So. This is a bit later than I expected, but I'm 200% convinced it's crazy-useful.

- Adds an index page for the mock API server that lists out instructions on how to run test cases, the test cases and their descriptions, and code that you can run in the Browser Console to run the test case. This is most of #420, with the minor exception of some links in our docs/wiki pointing to the actual live mock server.

  ![](https://d17oy1vhnax1f7.cloudfront.net/items/2i4734443K1Z2G3b3909/test-server-screenshot.png?v=fac02937)
- Renames `Fixture` to `TestCase`. I'm mildly annoyed that this might be confusing compared to other testing libraries with test case classes, but it's really a better word for what these are.
- Adds all the test cases mentioned in #391. I had to move the serialization logic to the `TestCase` class to override it for two of the tests, and I'm not 100% happy with how I did that move, but I think it does, in fact, belong there.

This one's open for anyone who wants to review it. r?

# ~~Blocked by~~

* [x] #448 Re-enable mock-recipe-server in CI