### PR TITLE
Correct LogManager.jsm filename in list of modules to unload.

### DIFF
--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -76,7 +76,7 @@ this.shutdown = function(data, reason) {
     "lib/CleanupManager.jsm",
     "lib/EnvExpressions.jsm",
     "lib/Heartbeat.jsm",
-    "lib/Logging.jsm",
+    "lib/LogManager.jsm",
     "lib/NormandyApi.jsm",
     "lib/NormandyDriver.jsm",
     "lib/RecipeRunner.jsm",


### PR DESCRIPTION
Fixing @gijsk 's feedback on https://github.com/mozilla/normandy/commit/388cbecf2c8534fea0c9cd8786449c3891ceee08#commitcomment-20564702.

@gijsk I was considering seeing how hard it is to write an eslint rule that checks this list against the files in those directories, but even better than that, is there any reason we can't just have the bootstrap code list out the jsm/js files in those directories and unload them automatically? Then we wouldn't have to maintain the list, although it would potentially be more prone to unloading things we don't want it to by accident.