### PR TITLE
Bug 1325409: Remove unnecessary cleanup.

### DIFF
--- a/recipe-client-addon/lib/Heartbeat.jsm
+++ b/recipe-client-addon/lib/Heartbeat.jsm
@@ -331,7 +331,6 @@ this.Heartbeat = class {
 
   close() {
     this.notificationBox.removeNotification(this.notice);
-    this.cleanup();
   }
 
   cleanup() {


### PR DESCRIPTION
Cleanup is already run when the notification is removed, so calling it
in close() causes it to be called twice. Also, when the notification
is removed, it sends a Heartbeat event, which fails if cleanup has
already happened.