### PR TITLE
Don't run CI for mock-recipe-server for now

### DIFF
--- a/ci/bin/runner.sh
+++ b/ci/bin/runner.sh
@@ -10,7 +10,6 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
 PROJECTS=(
     recipe-client-addon
     recipe-server
-    mock-recipe-server
     lints
     compose
     eslint-config-normandy

--- a/circle.yml
+++ b/circle.yml
@@ -21,10 +21,6 @@ dependencies:
   override:
     - ./ci/bin/runner.sh dependencies
 
-compile:
-  override:
-    - ./ci/bin/runner.sh compile
-
 test:
   override:
     - ./ci/bin/runner.sh test


### PR DESCRIPTION
It is breaking other things, and needs some more thought.

My first thought was to just  revert all the commits, but that ended up being too complex. My second thought was to manually delete everything. That would have worked, but would have been hard to undo. Simply disabling this in CI makes it easy to pick this work back up in the future.