### PR TITLE
CI: Pipe all output through cat, so progress bars aren't shown

### DIFF
--- a/ci/bin/runner.sh
+++ b/ci/bin/runner.sh
@@ -28,7 +28,7 @@ for project in "${PROJECTS[@]}"; do
         echo "============================================================"
 
         pushd ${BASE_DIR}/${project}
-        "${step_script}" "$@"
+        "${step_script}" "$@" | cat
         popd
     fi
 done


### PR DESCRIPTION
This should avoid having CI dependency output larger than Circle will allow us to have. Lets check the logs to make sure that's true.