### PR TITLE
Reenable mock server

### DIFF
--- a/ci/bin/runner.sh
+++ b/ci/bin/runner.sh
@@ -10,6 +10,7 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
 PROJECTS=(
     recipe-client-addon
     recipe-server
+    mock-recipe-server
     lints
     compose
     eslint-config-normandy

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,10 @@ dependencies:
   override:
     - ./ci/bin/runner.sh dependencies
 
+compile:
+  override:
+    - ./ci/bin/runner.sh compile
+
 test:
   override:
     - ./ci/bin/runner.sh test

--- a/mock-recipe-server/bin/generate.sh
+++ b/mock-recipe-server/bin/generate.sh
@@ -13,7 +13,7 @@ compose () {
 
 # Shut down docker even if we error out.
 function finish {
-    compose down
+    compose stop
 }
 trap finish EXIT
 

--- a/mock-recipe-server/bin/generate.sh
+++ b/mock-recipe-server/bin/generate.sh
@@ -3,6 +3,20 @@ set -eu
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
 
+compose () {
+    docker-compose \
+        -p mockrecipeserver \
+        -f "$REPO_DIR/compose/docker-compose.yml" \
+        -f "$REPO_DIR/mock-recipe-server/docker-compose.yml" \
+        $@
+}
+
+# Shut down docker even if we error out.
+function finish {
+    compose down
+}
+trap finish EXIT
+
 # MOCK_SERVER_ARTIFACTS is exported so the docker-compose config can
 # use it to mount the artifact volume.
 export MOCK_SERVER_ARTIFACTS=$1
@@ -10,9 +24,5 @@ MOCK_SERVER_DOMAIN=$2
 
 # Generate mock server files
 echo "Generating mock server files"
-docker-compose \
-  -p mockrecipeserver \
-  -f "$REPO_DIR/compose/docker-compose.yml" \
-  -f "$REPO_DIR/mock-recipe-server/docker-compose.yml" \
-  run \
-  testgen /mock-server/generate.py /build $MOCK_SERVER_DOMAIN
+compose run normandy ./bin/wait-for-it.sh database:5432
+compose run testgen /mock-server/generate.py /build $MOCK_SERVER_DOMAIN

--- a/mock-recipe-server/bin/setup.sh
+++ b/mock-recipe-server/bin/setup.sh
@@ -13,7 +13,7 @@ compose () {
 
 # Shut down docker even if we error out.
 function finish {
-    compose down
+    compose stop
 }
 trap finish EXIT
 

--- a/mock-recipe-server/bin/setup.sh
+++ b/mock-recipe-server/bin/setup.sh
@@ -5,7 +5,10 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
 WAIT_FOR_DB="./bin/wait-for-it.sh database:5432 --"
 
 compose () {
-    docker-compose -p mockrecipeserver $@
+    docker-compose \
+        -p mockrecipeserver \
+        -f "$REPO_DIR/compose/docker-compose.yml" \
+        $@
 }
 
 # Shut down docker even if we error out.

--- a/mock-recipe-server/bin/setup.sh
+++ b/mock-recipe-server/bin/setup.sh
@@ -2,13 +2,24 @@
 set -eu
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
+WAIT_FOR_DB="./bin/wait-for-it.sh database:5432 --"
+
+compose () {
+    docker-compose -p mockrecipeserver $@
+}
+
+# Shut down docker even if we error out.
+function finish {
+    compose down
+}
+trap finish EXIT
 
 # Setup recipe-server container
 echo "Initializing mock server containers"
 pushd "$REPO_DIR/compose"
 ./bin/genkeys.sh
-docker-compose -p mockrecipeserver run normandy ./manage.py migrate
-docker-compose -p mockrecipeserver run normandy ./manage.py update_actions
-docker-compose -p mockrecipeserver run normandy ./manage.py update_product_details
-docker-compose -p mockrecipeserver run normandy ./manage.py initial_data
+compose run normandy $WAIT_FOR_DB ./manage.py migrate
+compose run normandy ./manage.py update_actions
+compose run normandy ./manage.py update_product_details
+compose run normandy ./manage.py initial_data
 popd

--- a/recipe-server/bin/ci/dependencies
+++ b/recipe-server/bin/ci/dependencies
@@ -2,7 +2,7 @@
 set -eu
 
 # build image
-docker build -t normandy:build .
+docker build -t mozilla/normandy:latest .
 # pull other docker images used below
 docker pull giorgos/takis
 # get MaxMind GeoIP database for tests

--- a/recipe-server/bin/ci/deploy
+++ b/recipe-server/bin/ci/deploy
@@ -23,9 +23,13 @@ retry 3 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWO
 
 # docker tag and push git branch to dockerhub
 if [ -n "$1" ]; then
-    [ "$1" == master ] && TAG=latest || TAG="$1"
-    docker tag normandy:build "mozilla/normandy:$TAG" ||
-        (echo "Couldn't tag normandy:build as mozilla/normandy:$TAG" && false)
+    if [ "$1" == master ]; then
+        TAG=latest
+    else
+        TAG="$1"
+        docker tag mozilla/normandy:latest "mozilla/normandy:$TAG" ||
+            (echo "Couldn't re-tag mozilla/normandy:latest as mozilla/normandy:$TAG" && false)
+    fi
     retry 3 docker push "mozilla/normandy:$TAG" ||
         (echo "Couldn't push mozilla/normandy:$TAG" && false)
     echo "Pushed mozilla/normandy:$TAG"

--- a/recipe-server/bin/wait-for-it.sh
+++ b/recipe-server/bin/wait-for-it.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# The MIT License (MIT)
+# Copyright (c) 2016 Giles Hall
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
This is #434, with the commit from #440 that added a wait script for docker containers to fix mock-recipe-server builds, along with another commit that fixes a bug in container cleanup (the commit message explains it well) and re-enables mock-recipe-server in CI.

This is blocked by #434, and I'll rebase it after that lands. But I want to put it up now to see what automation thinks of it. If automation is happy, this could probably be reviewed as well, if anyone wants to take a glance at the two commits directly. Otherwise, once I rebase I'll request reviews myself.