### PR TITLE
Add sync device counts to driver.

### DIFF
--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -75,6 +75,9 @@ this.NormandyDriver = function(sandboxManager, extraContext = {}) {
         isDefaultBrowser: ShellService.isDefaultBrowser() || null,
         searchEngine: null,
         syncSetup: Preferences.isSet("services.sync.username"),
+        syncDesktopDevices: Preferences.get("services.sync.clients.devices.desktop", 0),
+        syncMobileDevices: Preferences.get("services.sync.clients.devices.mobile", 0),
+        syncTotalDevices: Preferences.get("services.sync.numClients", 0),
         plugins: {},
         doNotTrack: Preferences.get("privacy.donottrackheader.enabled", false),
       };

--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -18,3 +18,23 @@ add_task(Utils.withDriver(Assert, function* userId(driver) {
   // Test that userId is a UUID
   ok(Utils.UUID_REGEX.test(driver.userId), "userId is a uuid");
 }));
+
+add_task(Utils.withDriver(Assert, function* syncDeviceCounts(driver) {
+  let client = yield driver.client();
+  is(client.syncMobileDevices, 0, "syncMobileDevices defaults to zero");
+  is(client.syncDesktopDevices, 0, "syncDesktopDevices defaults to zero");
+  is(client.syncTotalDevices, 0, "syncTotalDevices defaults to zero");
+
+  yield SpecialPowers.pushPrefEnv({
+    set: [
+      ["services.sync.numClients", 9],
+      ["services.sync.clients.devices.mobile", 5],
+      ["services.sync.clients.devices.desktop", 4],
+    ],
+  });
+
+  client = yield driver.client();
+  is(client.syncMobileDevices, 5, "syncMobileDevices is read when set");
+  is(client.syncDesktopDevices, 4, "syncDesktopDevices is read when set");
+  is(client.syncTotalDevices, 9, "syncTotalDevices is read when set");
+}));


### PR DESCRIPTION
I also pulled in @Osmose's driver changes from #436, since I needed to fix the same problem with plugins in the add-on driver.

Fixes #412.