### PR TITLE
Fix #444: Alias global object to window in recipe-client sandboxes.

### DIFF
--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -151,24 +151,32 @@ this.RecipeRunner = {
           let a = new Action(sandboxedDriver, sandboxedRecipe);
           a.execute()
             .then(actionFinished)
-            .catch(err => sandboxedDriver.log(err, 'error'));
+            .catch(actionFailed);
         };
 
-        window.registerAction = registerAction;
-        window.setTimeout = sandboxedDriver.setTimeout;
-        window.clearTimeout = sandboxedDriver.clearTimeout;
+        this.window = this;
+        this.registerAction = registerAction;
+        this.setTimeout = sandboxedDriver.setTimeout;
+        this.clearTimeout = sandboxedDriver.clearTimeout;
       `;
 
       const driver = new NormandyDriver(sandboxManager, extraContext);
       sandbox.sandboxedDriver = Cu.cloneInto(driver, sandbox, {cloneFunctions: true});
       sandbox.sandboxedRecipe = Cu.cloneInto(recipe, sandbox);
+
+      // Results are cloned so that they don't become inaccessible when
+      // the sandbox they came from is nuked when the hold is removed.
       sandbox.actionFinished = result => {
+        const clonedResult = Cu.cloneInto(result, {});
         sandboxManager.removeHold("recipeExecution");
-        resolve(result);
+        resolve(clonedResult);
       };
       sandbox.actionFailed = err => {
+        // Error objects can't be cloned, so we just copy the message
+        // (which doesn't need to be cloned) to be somewhat useful.
+        const message = err.message;
         sandboxManager.removeHold("recipeExecution");
-        reject(err);
+        reject(new Error(message));
       };
 
       sandboxManager.addHold("recipeExecution");

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -172,6 +172,8 @@ this.RecipeRunner = {
         resolve(clonedResult);
       };
       sandbox.actionFailed = err => {
+        Cu.reportError(err);
+
         // Error objects can't be cloned, so we just copy the message
         // (which doesn't need to be cloned) to be somewhat useful.
         const message = err.message;

--- a/recipe-client-addon/lib/SandboxManager.jsm
+++ b/recipe-client-addon/lib/SandboxManager.jsm
@@ -56,8 +56,6 @@ function makeSandbox() {
     wantGlobalProperties: ["URL", "URLSearchParams"],
   });
 
-  sandbox.window = Cu.cloneInto({}, sandbox);
-
   const url = "resource://shield-recipe-client/data/EventEmitter.js";
   Services.scriptloader.loadSubScript(url, sandbox);
 

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -3,8 +3,9 @@
 const {utils: Cu} = Components;
 Cu.import("resource://shield-recipe-client/lib/RecipeRunner.jsm", this);
 
-add_task(function*() {
-  // Test that RecipeRunner can execute a basic recipe/action.
+add_task(function* execute() {
+  // Test that RecipeRunner can execute a basic recipe/action and return
+  // the result of execute.
   const recipe = {
     foo: "bar",
   };
@@ -16,7 +17,7 @@ add_task(function*() {
 
       execute() {
         return new Promise(resolve => {
-          resolve(this.recipe.foo);
+          resolve({foo: this.recipe.foo});
         });
       }
     }
@@ -25,5 +26,62 @@ add_task(function*() {
   `;
 
   const result = yield RecipeRunner.executeAction(recipe, {}, actionScript);
-  is(result, "bar", "Recipe executed correctly");
+  is(result.foo, "bar", "Recipe executed correctly");
+});
+
+add_task(function* error() {
+  // Test that RecipeRunner rejects with error messages from within the
+  // sandbox.
+  const actionScript = `
+    class TestAction {
+      execute() {
+        return new Promise((resolve, reject) => {
+          reject(new Error("ERROR MESSAGE"));
+        });
+      }
+    }
+
+    registerAction('test-action', TestAction);
+  `;
+
+  let gotException = false;
+  try {
+    yield RecipeRunner.executeAction({}, {}, actionScript);
+  } catch (err) {
+    gotException = true;
+    is(err.message, "ERROR MESSAGE", "RecipeRunner throws errors from the sandbox correctly.");
+  }
+  ok(gotException, "RecipeRunner threw an error from the sandbox.");
+});
+
+add_task(function* globalObject() {
+  // Test that window is an alias for the global object, and that it
+  // has some expected functions available on it.
+  const actionScript = `
+    window.setOnWindow = "set";
+    this.setOnGlobal = "set";
+
+    class TestAction {
+      execute() {
+        return new Promise(resolve => {
+          resolve({
+            setOnWindow: setOnWindow,
+            setOnGlobal: window.setOnGlobal,
+            setTimeoutExists: setTimeout !== undefined,
+            clearTimeoutExists: clearTimeout !== undefined,
+          });
+        });
+      }
+    }
+
+    registerAction('test-action', TestAction);
+  `;
+
+  const result = yield RecipeRunner.executeAction({}, {}, actionScript);
+  Assert.deepEqual(result, {
+    setOnWindow: "set",
+    setOnGlobal: "set",
+    setTimeoutExists: true,
+    clearTimeoutExists: true,
+  }, "sandbox.window is the global object and has expected functions.");
 });


### PR DESCRIPTION
This fixes an issue where our babel-ified action code was trying to call `setTimeout` (because babel compiles to a browser-like environment) and failing because we were defining `window` in the sandbox as a standalone object, instead of aliasing it to the global object.

r?