### PR TITLE
recipe-server: Add release info for Sentry

### DIFF
--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -127,8 +127,14 @@ in other Django projects.
 
     :default: ``None``
 
-    The DSN for Raven to report errors to Sentry. Defaults to ``None``. Not
-    required.
+    Optional. The DSN for Raven to report errors to Sentry.
+
+.. envvar:: DJANGO_RAVEN_CONFIG_RELEASE
+
+    :default: ``None``
+
+    Optional. The release for Raven to report to Sentry. Automatically set by
+    production Docker images.
 
 .. envvar:: DJANGO_AUTOGRAPH_URL
 

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -195,9 +195,20 @@ class Base(Core):
     EMAIL_USE_TLS = values.BooleanValue(True)
     EMAIL_HOST_PASSWORD = values.Value()
     EMAIL_BACKEND = values.Value('django.core.mail.backends.smtp.EmailBackend')
-    RAVEN_CONFIG = {
-        'dsn': values.URLValue(None, environ_name='RAVEN_CONFIG_DSN'),
-    }
+
+    def RAVEN_CONFIG(self):
+        version_path = os.path.join(Core.BASE_DIR, '__version__', 'tag')
+        try:
+            with open(version_path) as f:
+                version = f.read().strip()
+        except IOError:
+            version = None
+
+        return {
+            'dsn': values.URLValue(None, environ_name='RAVEN_CONFIG_DSN'),
+            'release': values.Value(version, environ_name='RAVEN_CONFIG_RELEASE'),
+        }
+
     # statsd
     STATSD_HOST = values.Value('localhost')
     STATSD_PORT = values.IntegerValue(8125)


### PR DESCRIPTION
I'd like to put this out with v30, I think it will help track things on Sentry. Plus, we can use "Resolved in next version" on Sentry, which will be nice.