### PR TITLE
Fix #469: Use extra_filter_expression as name for filter expressions.

### DIFF
--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -39,7 +39,7 @@ export class RecipeForm extends React.Component {
     recipe: pt.shape({
       name: pt.string.isRequired,
       enabled: pt.bool.isRequired,
-      filter_expression: pt.string.isRequired,
+      extra_filter_expression: pt.string.isRequired,
       action: pt.string.isRequired,
       arguments: pt.object.isRequired,
     }),
@@ -112,7 +112,7 @@ export class RecipeForm extends React.Component {
         />
         <ControlField
           label="Filter Expression"
-          name="filter_expression"
+          name="extra_filter_expression"
           component="textarea"
         />
         <ControlField label="Action" name="action" component="select">
@@ -141,19 +141,19 @@ export class RecipeForm extends React.Component {
  */
 export const formConfig = {
   form: 'recipe',
-  asyncBlurFields: ['filter_expression'],
+  asyncBlurFields: ['extra_filter_expression'],
 
   async asyncValidate(values) {
     const errors = {};
     // Validate that filter expression is valid JEXL
-    if (!values.filter_expression) {
-      errors.filter_expression = 'Filter expression cannot be empty.';
+    if (!values.extra_filter_expression) {
+      errors.extra_filter_expression = 'Filter expression cannot be empty.';
     } else {
       const jexlEnvironment = new JexlEnvironment({});
       try {
-        await jexlEnvironment.eval(values.filter_expression);
+        await jexlEnvironment.eval(values.extra_filter_expression);
       } catch (err) {
-        errors.filter_expression = err.toString();
+        errors.extra_filter_expression = err.toString();
       }
     }
 
@@ -166,7 +166,7 @@ export const formConfig = {
   onSubmit(values, dispatch, { route, recipeId, updateRecipe, addRecipe }) {
     // Filter out unwanted keys for submission.
     const recipe = pick(values, [
-      'name', 'enabled', 'filter_expression', 'action', 'arguments',
+      'name', 'enabled', 'extra_filter_expression', 'action', 'arguments',
     ]);
     const isCloning = route && route.isCloning;
 

--- a/recipe-server/client/control/tests/components/test_RecipeForm.js
+++ b/recipe-server/client/control/tests/components/test_RecipeForm.js
@@ -77,25 +77,25 @@ describe('<RecipeForm>', () => {
   describe('asyncValidate', () => {
     it('should throw if the filter expression is blank', async () => {
       try {
-        await formConfig.asyncValidate({ filter_expression: '' });
+        await formConfig.asyncValidate({ extra_filter_expression: '' });
         expect(false).toBe(true); // Fail if we don't throw.
       } catch (err) {
-        expect('filter_expression' in err).toBe(true);
+        expect('extra_filter_expression' in err).toBe(true);
       }
     });
 
     it('should throw if the filter expression is invalid JEXL', async () => {
       try {
-        await formConfig.asyncValidate({ filter_expression: '2-- + 4 (' });
+        await formConfig.asyncValidate({ extra_filter_expression: '2-- + 4 (' });
         expect(false).toBe(true); // Fail if we don't throw.
       } catch (err) {
-        expect('filter_expression' in err).toBe(true);
+        expect('extra_filter_expression' in err).toBe(true);
       }
     });
 
     it('should pass if the filter expression is valid JEXL', async () => {
       // Should not throw.
-      await formConfig.asyncValidate({ filter_expression: '1+1' });
+      await formConfig.asyncValidate({ extra_filter_expression: '1+1' });
     });
   });
 
@@ -120,7 +120,7 @@ describe('<RecipeForm>', () => {
       expect(updateRecipe).toHaveBeenCalledWith(recipe.id, {
         name: recipe.name,
         enabled: recipe.enabled,
-        filter_expression: recipe.filter_expression,
+        extra_filter_expression: recipe.extra_filter_expression,
         action: recipe.action,
         arguments: recipe.arguments,
       });
@@ -140,7 +140,7 @@ describe('<RecipeForm>', () => {
       expect(addRecipe).toHaveBeenCalledWith({
         name: recipe.name,
         enabled: recipe.enabled,
-        filter_expression: recipe.filter_expression,
+        extra_filter_expression: recipe.extra_filter_expression,
         action: recipe.action,
         arguments: recipe.arguments,
       });
@@ -161,7 +161,7 @@ describe('<RecipeForm>', () => {
       expect(addRecipe).toHaveBeenCalledWith({
         name: recipe.name,
         enabled: recipe.enabled,
-        filter_expression: recipe.filter_expression,
+        extra_filter_expression: recipe.extra_filter_expression,
         action: recipe.action,
         arguments: recipe.arguments,
       });

--- a/recipe-server/client/tests/utils.js
+++ b/recipe-server/client/tests/utils.js
@@ -24,7 +24,7 @@ export function recipeFactory(props = {}) {
     revision_id: 1,
     name: 'Test Recipe',
     enabled: false,
-    filter_expression: 'true',
+    extra_filter_expression: 'true',
     action: 'console-log',
     arguments: {
       surveyId: 'mysurvey',


### PR DESCRIPTION
Updates the frontend to match the field name for the backend.

I ran into this error yesterday and wrote a fix, but this morning I tried replicating the issue on master and couldn't anymore, and assumed I had some stale JS builds or something. But then #469 happened, so I'm not sure anymore.

I think it's important that we reliably replicate this locally before testing and merging this fix.