### PR TITLE
ci: Fail while piping commands to cat

### DIFF
--- a/ci/bin/runner.sh
+++ b/ci/bin/runner.sh
@@ -20,6 +20,8 @@ count=0
 step=$1
 shift 1
 
+num_errors=0
+
 for project in "${PROJECTS[@]}"; do
     step_script="${BASE_DIR}/${project}/bin/ci/${step}"
     if [[ -f "${step_script}" ]]; then
@@ -30,6 +32,11 @@ for project in "${PROJECTS[@]}"; do
 
         pushd ${BASE_DIR}/${project}
         "${step_script}" "$@" | cat
+        # check exit code of step_script, not cat
+        if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+            num_errors=$((num_errors + 1))
+            echo "FAIL: ${step} for ${project}"
+        fi
         popd
     fi
 done
@@ -38,3 +45,5 @@ if [[ $count -eq 0 ]]; then
     echo "No projects have step $step"
     exit 1
 fi
+
+exit $num_errors


### PR DESCRIPTION
When we piped all of the CI commands into `cat`, we masked the return codes of the sub-commands. This should fix that, by telling bash to fail a pipeline if any of the commands in it fail, instead of only the last one.

Fixes #480.