### PR TITLE
recipe-server: Use correct docker image name in docker-run.sh

### DIFF
--- a/lints/Dockerfile
+++ b/lints/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.5.2-slim
 WORKDIR /app
 RUN groupadd --gid 1001 app && useradd -g app --uid 1001 --shell /usr/sbin/nologin app
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl apt-transport-https
+    curl apt-transport-https git
 
 # Install node from NodeSource
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/recipe-server/bin/ci/docker-run.sh
+++ b/recipe-server/bin/ci/docker-run.sh
@@ -40,5 +40,5 @@ docker run \
   --env DJANGO_CONFIGURATION=Test \
   --net host \
   "${DOCKER_ARGS[@]}" \
-  normandy:build \
+  mozilla/normandy:latest \
   "$@"


### PR DESCRIPTION
Fixes #482