### PR TITLE
Hotfix: Heartbeat Recipe Creation

### DIFF
--- a/recipe-server/client/control/components/action_fields/HeartbeatFields.js
+++ b/recipe-server/client/control/components/action_fields/HeartbeatFields.js
@@ -5,7 +5,7 @@ import { ControlField } from 'control/components/Fields';
 /**
  * Form fields for the show-heartbeat action.
  */
-export default function HeartbeatFields({ fields }) {
+export default function HeartbeatFields({ fields = {} }) {
   return (
     <div className="arguments-fields">
       <p className="info">
@@ -74,8 +74,6 @@ export default function HeartbeatFields({ fields }) {
       </ControlField>
 
       {
-        fields &&
-        fields.repeatOption &&
         fields.repeatOption === 'xdays' &&
           <ControlField
             label="Days before user is re-prompted"

--- a/recipe-server/client/control/tests/components/test_ConsoleLogFields.js
+++ b/recipe-server/client/control/tests/components/test_ConsoleLogFields.js
@@ -1,0 +1,14 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ConsoleLogFields from 'control/components/action_fields/ConsoleLogFields';
+
+describe('<ConsoleLogFields>', () => {
+  it('should work', () => {
+    const wrapper = () =>
+      shallow(<ConsoleLogFields />);
+
+    expect(wrapper).not.toThrow();
+  });
+});

--- a/recipe-server/client/control/tests/components/test_HeartbeatFields.js
+++ b/recipe-server/client/control/tests/components/test_HeartbeatFields.js
@@ -1,0 +1,21 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import HeartbeatFields from 'control/components/action_fields/HeartbeatFields';
+
+describe('<HeartbeatFields>', () => {
+  it('should render when a `fields` prop is given', () => {
+    const wrapper = () =>
+      shallow(<HeartbeatFields fields={{}} />);
+
+    expect(wrapper).not.toThrow();
+  });
+
+  it('should render when a `fields` prop is not given', () => {
+    const wrapper = () =>
+      shallow(<HeartbeatFields />);
+
+    expect(wrapper).not.toThrow();
+  });
+});

--- a/recipe-server/client/control/tests/components/test_RecipeForm.js
+++ b/recipe-server/client/control/tests/components/test_RecipeForm.js
@@ -5,6 +5,7 @@ import { SubmissionError } from 'redux-form';
 
 import { RecipeForm, formConfig, initialValuesWrapper } from 'control/components/RecipeForm.js';
 import ConsoleLogFields from 'control/components/action_fields/ConsoleLogFields.js';
+import HeartbeatFields from 'control/components/action_fields/HeartbeatFields.js';
 import { recipeFactory } from '../../../tests/utils.js';
 
 /**
@@ -24,12 +25,22 @@ describe('<RecipeForm>', () => {
     expect(wrapper.hasClass('recipe-form loading')).toBe(true);
   });
 
-  it('should render the fields for the specified action', () => {
-    const wrapper = shallow(
-      <RecipeForm selectedAction="console-log" {...propFactory()} />
-    );
-    expect(wrapper.find(ConsoleLogFields).length).toBe(1);
+  describe('Argument fields', () => {
+    it('should render the fields for the console-log action', () => {
+      const wrapper = shallow(
+        <RecipeForm selectedAction="console-log" {...propFactory()} />
+      );
+      expect(wrapper.find(ConsoleLogFields).length).toBe(1);
+    });
+
+    it('should render the fields for the show-heartbeat action', () => {
+      const wrapper = shallow(
+        <RecipeForm selectedAction="show-heartbeat" {...propFactory()} />
+      );
+      expect(wrapper.find(HeartbeatFields).length).toBe(1);
+    });
   });
+
 
   it('should render a delete button if editing an existing recipe', () => {
     const recipe = recipeFactory();


### PR DESCRIPTION
Fixes #493 

- Fixes missing `fields` variable in `HeartbeatFields` argument (therefor fixing the recipe creation bug outlined in #493)
- Adds tests for `HeartbeatFields` and `ConsoleLogFields` to ensure they render correctly without throwing errors, regardless of props passed in.