### PR TITLE
fix the parquet type of fields_user_agent_version

### DIFF
--- a/recipe-server/parquet_schemas/normandy.admin.docker.app/request.summary.cfg
+++ b/recipe-server/parquet_schemas/normandy.admin.docker.app/request.summary.cfg
@@ -26,7 +26,7 @@ message Log {
     optional binary fields_uid (UTF8);
     optional binary fields_user_agent_browser (UTF8);
     optional binary fields_user_agent_os (UTF8);
-    optional binary fields_user_agent_version (UTF8);
+    optional int64 fields_user_agent_version;
     optional int64 fields_errno;
     optional int64 fields_t;
     optional group Fields (MAP) {

--- a/recipe-server/parquet_schemas/normandy.app.docker.app/request.summary.cfg
+++ b/recipe-server/parquet_schemas/normandy.app.docker.app/request.summary.cfg
@@ -26,7 +26,7 @@ message Log {
     optional binary fields_uid (UTF8);
     optional binary fields_user_agent_browser (UTF8);
     optional binary fields_user_agent_os (UTF8);
-    optional binary fields_user_agent_version (UTF8);
+    optional int64 fields_user_agent_version;
     optional int64 fields_errno;
     optional int64 fields_t;
     optional group Fields (MAP) {


### PR DESCRIPTION
issue revealed by new testing scripts in cloudops-deployment