### PR TITLE
Fix #501: Add default value for enabled plus functional test improvements.

### DIFF
--- a/functional_tests/tests/test_basic.py
+++ b/functional_tests/tests/test_basic.py
@@ -2,8 +2,15 @@ from utils import Element, ElementGroup, FormField, Page, SelectField, wait_for
 
 
 class LoginPage(Page):
+    form = Element('#login-form')
     username = FormField('#id_username')
     password = FormField('#id_password')
+
+    def login(self):
+        self.wait_for_element('form')
+        self.username = 'admin'
+        self.password = 'asdfqwer'
+        self.password.submit()
 
 
 class RecipeListPage(Page):
@@ -21,6 +28,16 @@ class RecipeFormPage(Page):
     delete_button = Element('a.delete')
 
 
+class ConsoleLogFormPage(RecipeFormPage):
+    message = FormField('[name="arguments.message"]')
+
+
+class ShowHeartbeatFormPage(RecipeFormPage):
+    survey_id = FormField('[name="arguments.surveyId"]')
+    message = FormField('[name="arguments.message"]')
+    thanks_message = FormField('[name="arguments.thanksMessage"]')
+
+
 class RecipeDeletePage(Page):
     form = Element('.crud-form')
     confirm_button = Element('.delete[type="submit"]')
@@ -31,12 +48,7 @@ def test_create_recipe_console_log(selenium):
     # Load control interface, expect login redirect.
     selenium.get('http://normandy:8000/control/')
     assert '/control/login' in selenium.current_url
-
-    # Login
-    login_page = LoginPage(selenium)
-    login_page.username = 'admin'
-    login_page.password = 'asdfqwer'
-    login_page.password.submit()
+    LoginPage(selenium).login()
 
     # Check for empty recipe listing
     recipe_list_page = RecipeListPage(selenium)
@@ -45,30 +57,106 @@ def test_create_recipe_console_log(selenium):
 
     # Load new recipe page
     recipe_list_page.new_recipe_button.click()
-    recipe_form_page = RecipeFormPage(selenium)
-    recipe_form_page.wait_for_element('form')
+    form_page = ConsoleLogFormPage(selenium)
+    form_page.wait_for_element('form')
 
     # Fill out form
-    recipe_form_page.name = 'Test Recipe'
-    recipe_form_page.enabled.click()
-    recipe_form_page.extra_filter_expression = 'true'
-    recipe_form_page.action.select_by_value('console-log')
-    recipe_form_page.select('[name="arguments.message"]').send_keys('Test Message')
-    recipe_form_page.form.submit()
+    form_page.name = 'Console-Log-Test'
+    form_page.enabled.click()
+    form_page.extra_filter_expression = 'true'
+    form_page.action.select_by_value('console-log')
+    form_page.wait_for_element('message')
+    form_page.message = 'Test Message'
+    form_page.form.submit()
 
     # Wait until we navigate away from the new recipe page
-    wait_for(selenium, lambda driver: '/control/recipe/new' not in driver.current_url)
+    wait_for(selenium, lambda driver: '/control/recipe/new/' not in driver.current_url)
 
     # Check that the recipe list is updated
     selenium.get('http://normandy:8000/control/')
     assert len(recipe_list_page.recipe_rows) == 1
     columns = recipe_list_page.recipe_rows[0].find_elements_by_tag_name('td')
-    assert columns[0].text == 'Test Recipe'
+    assert columns[0].text == 'Console-Log-Test'
 
     # Delete the recipe we created
     recipe_list_page.recipe_rows[0].click()
-    recipe_form_page.wait_for_element('form')
-    recipe_form_page.delete_button.click()
+    form_page.wait_for_element('form')
+    form_page.delete_button.click()
+
+    recipe_delete_page = RecipeDeletePage(selenium)
+    recipe_delete_page.wait_for_element('form')
+    recipe_delete_page.confirm_button.click()
+
+    recipe_list_page.wait_for_element('recipe_list')
+    assert len(recipe_list_page.recipe_rows) == 0
+
+
+def test_create_disabled_recipe(selenium):
+    """Test creating a recipe that is disabled."""
+    # Load new recipe page
+    selenium.get('http://normandy:8000/control/recipe/new/')
+    LoginPage(selenium).login()  # Login, which will continue on
+    form_page = ConsoleLogFormPage(selenium)
+    form_page.wait_for_element('form')
+
+    # Fill out form
+    form_page.name = 'Console-Log-Test'
+    form_page.extra_filter_expression = 'false'
+    form_page.action.select_by_value('console-log')
+    form_page.wait_for_element('message')
+    form_page.message = 'Test Message'
+    form_page.form.submit()
+
+    # Wait until we navigate away from the new recipe page and delete
+    wait_for(selenium, lambda driver: '/control/recipe/new' not in driver.current_url)
+    selenium.get(selenium.current_url + 'delete/')
+
+    recipe_delete_page = RecipeDeletePage(selenium)
+    recipe_delete_page.wait_for_element('form')
+    recipe_delete_page.confirm_button.click()
+
+
+def test_create_recipe_show_heartbeat(selenium):
+    """Test creating and deleting a show-heartbeat recipe."""
+    # Load control interface, expect login redirect.
+    selenium.get('http://normandy:8000/control/')
+    assert '/control/login/' in selenium.current_url
+    LoginPage(selenium).login()
+
+    # Check for empty recipe listing
+    recipe_list_page = RecipeListPage(selenium)
+    recipe_list_page.wait_for_element('recipe_list')
+    assert len(recipe_list_page.recipe_rows) == 0
+
+    # Load new recipe page
+    recipe_list_page.new_recipe_button.click()
+    form_page = ShowHeartbeatFormPage(selenium)
+    form_page.wait_for_element('form')
+
+    # Fill out form
+    form_page.name = 'Show-Heartbeat-Test'
+    form_page.enabled.click()
+    form_page.extra_filter_expression = 'true'
+    form_page.action.select_by_value('show-heartbeat')
+    form_page.wait_for_element('survey_id')
+    form_page.survey_id = 'test-survey'
+    form_page.message = 'Test Message'
+    form_page.thanks_message = 'Thanks!'
+    form_page.form.submit()
+
+    # Wait until we navigate away from the new recipe page
+    wait_for(selenium, lambda driver: '/control/recipe/new/' not in driver.current_url)
+
+    # Check that the recipe list is updated
+    selenium.get('http://normandy:8000/control/')
+    assert len(recipe_list_page.recipe_rows) == 1
+    columns = recipe_list_page.recipe_rows[0].find_elements_by_tag_name('td')
+    assert columns[0].text == 'Show-Heartbeat-Test'
+
+    # Delete the recipe we created
+    recipe_list_page.recipe_rows[0].click()
+    form_page.wait_for_element('form')
+    form_page.delete_button.click()
 
     recipe_delete_page = RecipeDeletePage(selenium)
     recipe_delete_page.wait_for_element('form')

--- a/functional_tests/tests/test_basic.py
+++ b/functional_tests/tests/test_basic.py
@@ -26,7 +26,8 @@ class RecipeDeletePage(Page):
     confirm_button = Element('.delete[type="submit"]')
 
 
-def test_login_create_recipe(selenium):
+def test_create_recipe_console_log(selenium):
+    """Test creating and deleting a console-log recipe."""
     # Load control interface, expect login redirect.
     selenium.get('http://normandy:8000/control/')
     assert '/control/login' in selenium.current_url

--- a/functional_tests/tests/test_basic.py
+++ b/functional_tests/tests/test_basic.py
@@ -18,6 +18,12 @@ class RecipeFormPage(Page):
     enabled = FormField('[name="enabled"]')
     extra_filter_expression = FormField('[name="extra_filter_expression"]')
     action = SelectField('select[name="action"]')
+    delete_button = Element('a.delete')
+
+
+class RecipeDeletePage(Page):
+    form = Element('.crud-form')
+    confirm_button = Element('.delete[type="submit"]')
 
 
 def test_login_create_recipe(selenium):
@@ -33,13 +39,13 @@ def test_login_create_recipe(selenium):
 
     # Check for empty recipe listing
     recipe_list_page = RecipeListPage(selenium)
-    wait_for(selenium, lambda driver: recipe_list_page.recipe_list is not None)
+    recipe_list_page.wait_for_element('recipe_list')
     assert len(recipe_list_page.recipe_rows) == 0
 
     # Load new recipe page
     recipe_list_page.new_recipe_button.click()
     recipe_form_page = RecipeFormPage(selenium)
-    wait_for(selenium, lambda driver: recipe_form_page.form is not None)
+    recipe_form_page.wait_for_element('form')
 
     # Fill out form
     recipe_form_page.name = 'Test Recipe'
@@ -57,3 +63,15 @@ def test_login_create_recipe(selenium):
     assert len(recipe_list_page.recipe_rows) == 1
     columns = recipe_list_page.recipe_rows[0].find_elements_by_tag_name('td')
     assert columns[0].text == 'Test Recipe'
+
+    # Delete the recipe we created
+    recipe_list_page.recipe_rows[0].click()
+    recipe_form_page.wait_for_element('form')
+    recipe_form_page.delete_button.click()
+
+    recipe_delete_page = RecipeDeletePage(selenium)
+    recipe_delete_page.wait_for_element('form')
+    recipe_delete_page.confirm_button.click()
+
+    recipe_list_page.wait_for_element('recipe_list')
+    assert len(recipe_list_page.recipe_rows) == 0

--- a/functional_tests/tests/utils.py
+++ b/functional_tests/tests/utils.py
@@ -2,6 +2,21 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 
 
 class Page(object):
+    """
+    Base class for page-specific wrappers used during tests.
+
+    To use, write a subclass for a single page in the application, and
+    assign Element instances to its attributes for each element you
+    wish to use in a test::
+
+        class MyPage(Page):
+            important_link = Element('a.important')
+
+        def test_something(selenium):
+            selenium.get('http://website.com')
+            page = MyPage(selenium)
+            page.important_link.click()
+    """
     def __init__(self, driver):
         self.driver = driver
 
@@ -14,10 +29,20 @@ class Page(object):
         return self.driver.find_elements_by_css_selector(selector)
 
     def wait_for_element(self, name, timeout=10):
+        """
+        Shorthand for waiting until an element defined on this class
+        exists on the page.
+
+        :param name:
+            Attribute name of the Element instance to wait for.
+        :param timeout:
+            Seconds to wait before throwing an error. Defaults to 10 seconds.
+        """
         return wait_for(self.driver, lambda driver: getattr(self, name) is not None, timeout)
 
 
 class Element(object):
+    """Descriptor for defining elements on a Page object."""
     def __init__(self, selector):
         self.selector = selector
 
@@ -26,16 +51,22 @@ class Element(object):
 
 
 class FormField(Element):
+    """
+    Element that, when assigned to, sends the value as keyboard input to
+    the underlying element.
+    """
     def __set__(self, instance, value):
         instance.select(self.selector).send_keys(value)
 
 
 class SelectField(Element):
+    """Returns a Select wrapper for the underlying element."""
     def __get__(self, instance, owner):
         return Select(super().__get__(instance, owner))
 
 
 class ElementGroup(object):
+    """Descriptor for defining groups of elements on a Page object."""
     def __init__(self, selector):
         self.selector = selector
 
@@ -44,4 +75,8 @@ class ElementGroup(object):
 
 
 def wait_for(driver, callback, timeout=10):
+    """
+    Waits until the given callback returns a truthy value. Throws an
+    error if the timeout is reached before the callback passes.
+    """
     return WebDriverWait(driver, timeout).until(lambda d: callback(d))

--- a/functional_tests/tests/utils.py
+++ b/functional_tests/tests/utils.py
@@ -13,6 +13,9 @@ class Page(object):
         """Shorthand for finding elements by a CSS selector."""
         return self.driver.find_elements_by_css_selector(selector)
 
+    def wait_for_element(self, name, timeout=10):
+        return wait_for(self.driver, lambda driver: getattr(self, name) is not None, timeout)
+
 
 class Element(object):
     def __init__(self, selector):

--- a/functional_tests/tests/utils.py
+++ b/functional_tests/tests/utils.py
@@ -1,0 +1,44 @@
+from selenium.webdriver.support.ui import Select, WebDriverWait
+
+
+class Page(object):
+    def __init__(self, driver):
+        self.driver = driver
+
+    def select(self, selector):
+        """Shorthand for finding an element by a CSS selector."""
+        return self.driver.find_element_by_css_selector(selector)
+
+    def select_all(self, selector):
+        """Shorthand for finding elements by a CSS selector."""
+        return self.driver.find_elements_by_css_selector(selector)
+
+
+class Element(object):
+    def __init__(self, selector):
+        self.selector = selector
+
+    def __get__(self, instance, owner):
+        return instance.select(self.selector)
+
+
+class FormField(Element):
+    def __set__(self, instance, value):
+        instance.select(self.selector).send_keys(value)
+
+
+class SelectField(Element):
+    def __get__(self, instance, owner):
+        return Select(super().__get__(instance, owner))
+
+
+class ElementGroup(object):
+    def __init__(self, selector):
+        self.selector = selector
+
+    def __get__(self, instance, owner):
+        return instance.select_all(self.selector)
+
+
+def wait_for(driver, callback, timeout=10):
+    return WebDriverWait(driver, timeout).until(lambda d: callback(d))

--- a/recipe-server/normandy/recipes/api/serializers.py
+++ b/recipe-server/normandy/recipes/api/serializers.py
@@ -91,7 +91,7 @@ class RecipeSerializer(serializers.ModelSerializer):
         return instance
 
     def create(self, validated_data):
-        recipe = Recipe.objects.create(enabled=validated_data.pop('enabled'))
+        recipe = Recipe.objects.create(enabled=validated_data.pop('enabled', False))
         recipe.save()
 
         return self.update(recipe, validated_data)


### PR DESCRIPTION
The actual fix for the bug is in the last commit, 33b1e4b. The rest of the commits are a refactoring of the functional tests to use Page objects (which make writing and reading functional tests easier), and adding two new tests: one for creating a show-heartbeat testcase, and another for creating a disabled recipe, which was how I replicated the bug. This still isn't 100% coverage of the recipe creation process, but should be a large improvement.

r?