### PR TITLE
Pin underscore.string and add to lints.

### DIFF
--- a/lints/package.json
+++ b/lints/package.json
@@ -33,7 +33,8 @@
     "redux-thunk": "2.1.0",
     "sha.js": "2.4.5",
     "uglifyjs": "2.4.10",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "underscore.string": "3.3.4"
   },
   "devDependencies": {
     "babel-core": "6.14.0",

--- a/recipe-server/package.json
+++ b/recipe-server/package.json
@@ -44,7 +44,7 @@
     "sha.js": "2.4.5",
     "uglifyjs": "2.4.10",
     "underscore": "1.8.3",
-    "underscore.string": "^3.3.4"
+    "underscore.string": "3.3.4"
   },
   "devDependencies": {
     "babel-core": "6.14.0",


### PR DESCRIPTION
This should fix the CI issue we are seeing on master.

The main issue is that any packages imported in JS need to be installed *somewhere* above the file for the lints to accept the import line. On dev systems, this works because we have everything installed for the recipe-server, but the lint runner doesn't install the recipe-server's packages.

Adding `underscore.string` to the lint packages is a bandaid to fix this, but we should probably think of a better solution in the future. Maybe a better eslint rule so we don't have to install things. Maybe just install everything in each project as we lint.

Fixes #508 
