### PR TITLE
#286: Add CSP via django-csp.

### DIFF
--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -179,6 +179,17 @@ in other Django projects.
 
     .. _mozlog: https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md
 
+.. envvar:: DJANGO_CSP_REPORT_URI
+
+   :default: ``None``
+
+   Controls the ``report-uri`` directive in the Content Security Policy header.
+   Attempts to violate the Content Security Policy are sent by the browser to
+   this URL. See the `MDN documentation on report-uri <report-uri>`_ for more
+   info.
+
+   .. _report-uri: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri
+
 Gunicorn settings
 -----------------
 These settings control how Gunicorn starts, when the default command of the

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -117,18 +117,16 @@ class Core(Configuration):
         if self.CDN_URL:
             srcs.append(self.CDN_URL)
         return srcs
+
     CSP_OBJECT_SRC = "'none'"  # not using <object>, <embed>, and <applet> elements
     CSP_WORKER_SRC = "'none'"  # not using JS Worker, SharedWorker, or ServiceWorkers
     CSP_FRAME_SRC = "'none'"  # not using frames or iframes
+    CSP_BLOCK_ALL_MIXED_CONTENT = True
 
     # these don't fallback to default-src
     CSP_BASE_URI = "'none'"  # not using <base>
     CSP_FRAME_ANCESTORS = "'none'"  # this page isn't iframed elsewhere
     CSP_FORM_ACTION = "'self'"  # we only submit forms to ourselves
-
-    # when https is enabled
-    CSP_UPGRADE_INSECURE_REQUESTS = True
-    CSP_BLOCK_ALL_MIXED_CONTENT = True
 
     # Action names and the path they are located at.
     ACTIONS = {

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -38,6 +38,7 @@ class Core(Configuration):
         'django.middleware.security.SecurityMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'csp.middleware.CSPMiddleware',
     ]
 
     ROOT_URLCONF = 'normandy.urls'
@@ -109,6 +110,12 @@ class Core(Configuration):
             'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats-actions.json')
         }
     }
+
+    def CSP_DEFAULT_SRC(self):
+        srcs = ["'self'"]
+        if self.CDN_URL:
+            srcs.append(self.CDN_URL)
+        return srcs
 
     # Action names and the path they are located at.
     ACTIONS = {
@@ -258,6 +265,9 @@ class Base(Core):
     DEFAULT_FILE_STORAGE = values.Value('storages.backends.overwrite.OverwriteStorage')
     # URL that the CDN exists at to front cached parts of the site, if any.
     CDN_URL = values.URLValue(None)
+
+    # URL for the CSP report-uri directive.
+    CSP_REPORT_URI = values.URLValue(None)
 
     # Normandy settings
     ADMIN_ENABLED = values.BooleanValue(True)

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -111,11 +111,24 @@ class Core(Configuration):
         }
     }
 
+    # Content Security Policy
     def CSP_DEFAULT_SRC(self):
         srcs = ["'self'"]
         if self.CDN_URL:
             srcs.append(self.CDN_URL)
         return srcs
+    CSP_OBJECT_SRC = "'none'"  # not using <object>, <embed>, and <applet> elements
+    CSP_WORKER_SRC = "'none'"  # not using JS Worker, SharedWorker, or ServiceWorkers
+    CSP_FRAME_SRC = "'none'"  # not using frames or iframes
+
+    # these don't fallback to default-src
+    CSP_BASE_URI = "'none'"  # not using <base>
+    CSP_FRAME_ANCESTORS = "'none'"  # this page isn't iframed elsewhere
+    CSP_FORM_ACTION = "'self'"  # we only submit forms to ourselves
+
+    # when https is enabled
+    CSP_UPGRADE_INSECURE_REQUESTS = True
+    CSP_BLOCK_ALL_MIXED_CONTENT = True
 
     # Action names and the path they are located at.
     ACTIONS = {

--- a/recipe-server/requirements/default.txt
+++ b/recipe-server/requirements/default.txt
@@ -124,3 +124,6 @@ whitenoise==2.0.6 \
     --hash=sha256:5aea935dfc09ef2beeb76960b4a808b0bbe65e85fb0b0312434b9c365ca02a41
 newrelic==2.78.0.57 \
     --hash=sha256:2191b7699e14a07efa5d9221270eb29bdf6cce643aa56cff08546ecb3f729be6
+django-csp==3.2 \
+    --hash=sha256:7cec78ba7c426deba6d4bea188dcfc1a8b2609ad98dd539c365605c9ec2996b2 \
+    --hash=sha256:fb56c0126b4e69f854fd1581a4bef25fa7cac1f10235e95f697e297ceef88132

--- a/recipe-server/webpack.config.js
+++ b/recipe-server/webpack.config.js
@@ -44,7 +44,7 @@ if (production) {
 module.exports = [
   {
     context: __dirname,
-    devtool: production ? undefined : 'cheap-module-eval-source-map',
+    devtool: production ? undefined : 'cheap-module-source-map',
 
     entry: {
       selfrepair: [
@@ -108,7 +108,7 @@ module.exports = [
     },
   },
   {
-    devtool: production ? undefined : 'cheap-module-eval-source-map',
+    devtool: production ? undefined : 'cheap-module-source-map',
 
     entry: {
       'console-log': './client/actions/console-log/index',


### PR DESCRIPTION
Because CSP prevents the use of eval, we cannot use the eval-based
sourcemap support in Webpack. The other alternative, inline-source-map,
seems to trigger errors in the Django development server due to URLs
that are too long, so the only remaining alternative is to use
external source maps, which seem to work fine.

Adding @jvehent for review to double-check the CSP directive I'm using (it's `'self' https://optional.cdn.net` for `default-src` across the entire site).