### PR TITLE
Temporarily disable nsp because it is failing builds.

### DIFF
--- a/lints/bin/default_command
+++ b/lints/bin/default_command
@@ -12,7 +12,9 @@ for directory in *; do
     if [[ -f $directory/package.json ]]; then
         echo "Checking $directory for known NPM security issues..."
         pushd $directory
-        nsp check
+        # Temporarily disable nsp, as it fails builds if it can't reach the NSP servers
+        # See https://github.com/mozilla/normandy/issues/521
+        nsp check || true
         if [[ $? -ne 0 ]]; then
             num_errors=$((num_errors + 1))
         fi


### PR DESCRIPTION
NSP returns a 1 error code even if the failure is due to the
NodeSecurity servers being down, which fails CI builds for spurious
reasons.

There's a bug on file to fix this:
https://github.com/nodesecurity/nsp/issues/111

Until that's resolved, we'll keep running it but not let it fail
builds.