### PR TITLE
Downgrade eventlet to 0.17.4 to fix Python 3.6 compatibility

### DIFF
--- a/recipe-server/requirements/default.txt
+++ b/recipe-server/requirements/default.txt
@@ -43,9 +43,9 @@ djangorestframework==3.3.2 \
 ecdsa==0.13 \
     --hash=sha256:40d002cf360d0e035cf2cb985e1308d41aaa087cbfc135b2dc2d844296ea546c \
     --hash=sha256:64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa
-eventlet==0.18.4 \
-    --hash=sha256:ba25805af353d0378594ce60163e4660e97bdb4c8121da49c9e0beb643404055 \
-    --hash=sha256:74ef11d67ee5e85e009b0fced733c907620bca1ab8e6b0489d9f247405ab2685
+eventlet==0.17.4 \
+    --hash=sha256:f647ab6faeaa44df5d18caecdf424524f949ff8ba9cdee56096742f8acc15246 \
+    --hash=sha256:8721e9714eaff8d20f2407e0d3a80069db6b57c9226c26ee9db25c541d06556d
 factory-boy==2.6.0 \
     --hash=sha256:116610a170918df342db2c4bafbc8f4b91780c49878f929d89e360f10ad29d2a \
     --hash=sha256:75e4c9786ed28d19ec7fb500f3c7221a6eb87748cbc6f5e2eeaca4c3d68f30cb


### PR DESCRIPTION
Eventlet > 0.17.4 has a problem with Python 3.6: https://github.com/eventlet/eventlet/issues/371

Eventlet is only used by Gunicorn when enabled by setting a environment variable.