### PR TITLE
Primitive History, Request/Approve/Reject UIs

### DIFF
--- a/recipe-server/client/control/actions/ControlActions.js
+++ b/recipe-server/client/control/actions/ControlActions.js
@@ -47,7 +47,7 @@ const apiRequestMap = {
 
   fetchSingleRevision(recipeInfo) {
     return {
-      url: `${BASE_API_URL}recipe_version/${recipeInfo.revisionId}/`,
+      url: `${BASE_API_URL}recipe_revision/${recipeInfo.revisionId}/`,
       settings: {
         method: 'GET',
       },
@@ -55,9 +55,72 @@ const apiRequestMap = {
     };
   },
 
-  fetchRecipeHistory(recipeInfo) {
+  getApprovalRequests() {
     return {
-      url: `${BASE_API_URL}recipe/${recipeInfo.recipeId}/history/`,
+      url: `${BASE_API_URL}approval_request/`,
+      settings: {
+        method: 'GET',
+      },
+      errorNotification: 'Error fetching approval requests.',
+    };
+  },
+
+  getApprovalRequestInfo({ requestId }) {
+    return {
+      url: `${BASE_API_URL}approval_request/${requestId}/`,
+      settings: {
+        method: 'GET',
+      },
+      errorNotification: 'Error fetching approval request info.',
+    };
+  },
+
+  openApprovalRequest({ revisionId }) {
+    return {
+      url: `${BASE_API_URL}recipe_revision/${revisionId}/request_approval/`,
+      settings: {
+        method: 'POST',
+        body: JSON.stringify({ revisionId }),
+      },
+      errorNotification: 'Error creating new approval request.',
+    };
+  },
+
+  acceptApprovalRequest({ requestId, comment }) {
+    return {
+      url: `${BASE_API_URL}approval_request/${requestId}/approve/`,
+      settings: {
+        method: 'POST',
+        body: JSON.stringify({ comment }),
+      },
+      errorNotification: 'Error accepting recipe approval.',
+    };
+  },
+
+  rejectApprovalRequest({ requestId, comment }) {
+    return {
+      url: `${BASE_API_URL}approval_request/${requestId}/reject/`,
+      settings: {
+        method: 'POST',
+        body: JSON.stringify({ comment }),
+      },
+      errorNotification: 'Error rejecting recipe approval.',
+    };
+  },
+
+  closeApprovalRequest({ requestId }) {
+    return {
+      url: `${BASE_API_URL}approval_request/${requestId}/close/`,
+      settings: {
+        method: 'POST',
+      },
+      errorNotification: 'Error closing recipe approval request.',
+    };
+  },
+
+  fetchRecipeHistory({ recipeId }) {
+    return {
+      url: `${BASE_API_URL}recipe/${recipeId}/history/`,
       settings: {
         method: 'GET',
       },
@@ -65,11 +128,11 @@ const apiRequestMap = {
     };
   },
 
-  addRecipe(recipeInfo) {
+  addRecipe({ recipe }) {
     return {
       url: `${BASE_API_URL}recipe/`,
       settings: {
-        body: JSON.stringify(recipeInfo.recipe),
+        body: JSON.stringify(recipe),
         method: 'POST',
       },
     };
@@ -190,11 +253,13 @@ function makeApiRequest(requestType, requestData) {
     })
     .then(response => {
       if (response.status >= 400) {
-        dispatch(requestComplete({
-          status: 'error',
-          notification: apiRequestConfig.errorNotification,
-        }));
-        return response.json().then(err => { throw err; });
+        return response.json().then(({ error }) => {
+          dispatch(requestComplete({
+            status: 'error',
+            notification: `${apiRequestConfig.errorNotification} ${error}`,
+          }));
+          throw new Error(error);
+        });
       }
       dispatch(requestComplete({
         status: 'success',

--- a/recipe-server/client/control/components/DraftComment.js
+++ b/recipe-server/client/control/components/DraftComment.js
@@ -1,0 +1,21 @@
+import React, { PropTypes as pt } from 'react';
+
+export default function DraftComment(props) {
+  const {
+    request,
+  } = props;
+
+  if (!request || !request.comment) {
+    return null;
+  }
+
+  return (
+    <div className="status-indicator">
+      { request.comment }
+    </div>
+  );
+}
+
+DraftComment.propTypes = {
+  request: pt.object,
+};

--- a/recipe-server/client/control/components/DraftStatus.js
+++ b/recipe-server/client/control/components/DraftStatus.js
@@ -1,0 +1,37 @@
+import React, { PropTypes as pt } from 'react';
+import DraftStatusIcon from 'control/components/DraftStatusIcon';
+import { getRecipeApprovalRequest } from 'control/selectors/RecipesSelector';
+
+export default function DraftStatus(props) {
+  const {
+    recipe,
+  } = props;
+
+  const request = getRecipeApprovalRequest(recipe);
+  let status = !!request || 'Draft';
+
+  if (request) {
+    const {
+      approved,
+    } = request;
+
+    if (approved) {
+      status = 'Approved';
+    } else {
+      status = 'Pending review';
+    }
+  }
+
+  return (
+    <div className={'status-indicator'}>
+      <DraftStatusIcon
+        request={request}
+        statusText={status}
+      />
+      {status}
+    </div>
+  );
+}
+DraftStatus.propTypes = {
+  recipe: pt.object.isRequired,
+};

--- a/recipe-server/client/control/components/DraftStatusIcon.js
+++ b/recipe-server/client/control/components/DraftStatusIcon.js
@@ -1,0 +1,42 @@
+import React, { PropTypes as pt } from 'react';
+import cx from 'classnames';
+
+export default function DraftStatusIcon({
+  request,
+  className,
+  statusText,
+}) {
+  // has this revision been approved/published?
+  const approvedClasses = request && request.approved && 'fa-check-circle-o';
+
+  // we know it's a draft if it doesnt have an approval, and hasn't been approved before
+  const isDraft = !request;
+  const draftClasses = isDraft && 'fa-circle-o';
+
+  // is the revision a draft that is in review?
+  const isPending = request && !request.approved;
+  const pendingClasses = isPending && 'fa-dot-circle-o';
+
+  // compile all possible classes
+  const iconClass = cx(
+    'draft-status-icon',
+    'fa',
+    'pre',
+    approvedClasses,
+    draftClasses,
+    pendingClasses,
+  );
+
+  return (
+    <i
+      title={statusText}
+      className={cx(iconClass, className)}
+    />
+  );
+}
+
+DraftStatusIcon.propTypes = {
+  request: pt.object,
+  className: pt.string,
+  statusText: pt.string,
+};

--- a/recipe-server/client/control/components/HistoryItem.js
+++ b/recipe-server/client/control/components/HistoryItem.js
@@ -1,0 +1,297 @@
+import React, { PropTypes as pt } from 'react';
+import { push } from 'react-router-redux';
+import _string from 'underscore.string';
+import moment from 'moment';
+import cx from 'classnames';
+import { diff } from 'deep-diff';
+
+import { getRecipeApprovalRequest } from 'control/selectors/RecipesSelector';
+
+import DraftStatusIcon from 'control/components/DraftStatusIcon';
+
+const RECIPE_SHAPE = pt.shape({
+  revision_id: pt.string.isRequired,
+});
+
+const REVISION_SHAPE = pt.shape({
+  recipe: RECIPE_SHAPE.isRequired,
+  date_created: pt.string.isRequired,
+  comment: pt.string.isRequired,
+});
+
+export default class HistoryItem extends React.Component {
+  static propTypes = {
+    dispatch: pt.func.isRequired,
+    revision: REVISION_SHAPE.isRequired,
+    recipe: RECIPE_SHAPE.isRequired,
+    el: pt.string.isRequired,
+    forceShow: pt.bool,
+    hideActiveStatus: pt.bool,
+    disableClickHandler: pt.bool,
+    previous: REVISION_SHAPE,
+    direction: pt.oneOf(['asc', 'desc']),
+    revisionId: pt.string,
+  };
+
+  static formatChangeLabel(value) {
+    const camelCaseRegex = /([A-Z]+[a-z]*)|([a-z]+)|(\d+)/g;
+
+    let labelValue = _string(value)
+      // _'s become spaces
+      .replaceAll('_', ' ')
+      // .'s become >'s
+      .replaceAll(/\./, ' > ')
+      // Get the raw text value, since we need to do some non-underscore.string manipulation
+      .value()
+      // Infer where spaces in the label should be based on the camelCase'd property name
+      .split(camelCaseRegex)
+      // remove empty array entries
+      .filter(x => x)
+      .join(' ');
+
+    labelValue = _string(labelValue)
+      // Ensure Text Looks Like This
+      .titleize()
+      // return the string value
+      .value();
+
+    return labelValue;
+  }
+
+  static generateDiffItem({ path, lhs, rhs, kind }, index) {
+    const iconClass = cx(
+      'fa',
+      // Edited
+      kind === 'E' && 'fa-pencil-square-o',
+      kind === 'A' && 'fa-pencil-square-o',
+      // New field
+      kind === 'N' && 'fa-plus-square-o',
+      // Deleted field
+      kind === 'D' && 'fa-minus-square-o',
+    );
+
+    const fromValue = kind === 'E' ? lhs : rhs;
+    const toValue = rhs;
+
+    let itemClass;
+    switch (kind) {
+      case 'E':
+      case 'A':
+        itemClass = 'edit';
+        break;
+      case 'N':
+        itemClass = 'new';
+        break;
+      case 'D':
+        itemClass = 'delete';
+        break;
+      default:
+        itemClass = '';
+        break;
+    }
+
+    return (
+      <li className={itemClass} key={index}>
+        <div className="change-label">
+          <i className={iconClass} aria-hidden="true" />
+          { HistoryItem.formatChangeLabel(path.join('.')) }:
+        </div>
+        <div className="change-values">
+          <span className="change-from">{fromValue}</span>
+          {
+            kind === 'E' &&
+              <span>
+                {' → '}
+                <span className="change-to">{toValue}</span>
+              </span>
+          }
+        </div>
+      </li>
+    );
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      showInfo: !!props.forceShow,
+    };
+    this.handleClick = ::this.handleClick;
+  }
+
+  getDisplayedDiffs(difference) {
+    const dontDisplay = [
+      'last_updated',
+      'revision_id',
+      'extra_filter_expression',
+      'latest_revision_id',
+      'approval_request',
+    ];
+
+    return [].concat(difference)
+      .map(update => {
+        const path = update.path.join('.');
+        return dontDisplay.indexOf(path) > -1 ? null : { ...update };
+      })
+      .filter(x => x);
+  }
+
+  /**
+   * When a revision is clicked, open the recipe form with changes from
+   * the clicked revision.
+   */
+  handleClick() {
+    const {
+      dispatch,
+      revision,
+      recipe,
+      disableClickHandler,
+    } = this.props;
+
+    if (disableClickHandler) {
+      return;
+    }
+
+    // Do not include form state changes if the current revision was
+    // clicked.
+    if (revision.recipe.revision_id === recipe.latest_revision_id) {
+      dispatch(push(`/control/recipe/${recipe.id}/`));
+    } else {
+      dispatch(push({
+        pathname: `/control/recipe/${recipe.id}/${revision.id}/`,
+        state: { selectedRevision: revision.recipe },
+      }));
+    }
+  }
+
+  generateDiffList(difference) {
+    if (!difference || !difference.length) {
+      return null;
+    }
+
+    this.diffCache = this.diffCache || {};
+    const cacheKey = difference.map(change => change.kind + change.path.join(':'));
+    if (this.diffCache[cacheKey]) {
+      return this.diffCache[cacheKey];
+    }
+
+    const displayedDifferences = this.getDisplayedDiffs(difference);
+
+    this.diffCache[cacheKey] = (
+      <ul className="change-list">
+        {
+          displayedDifferences.map(HistoryItem.generateDiffItem)
+        }
+      </ul>
+    );
+
+    return this.diffCache[cacheKey];
+  }
+
+  render() {
+    const { showInfo } = this.state;
+    const {
+      revision,
+      recipe,
+      revisionId,
+      forceShow,
+      direction,
+      hideActiveStatus,
+    } = this.props;
+
+    const approvalRequest = getRecipeApprovalRequest(recipe);
+
+    const isLatest = revision.recipe.revision_id === recipe.latest_revision_id;
+    const isCurrentlyViewing = revision.recipe.revision_id === recipe.latest_revision_id
+      || revisionId === recipe.latest_revision_id;
+    const isApproved = approvalRequest && approvalRequest.approved;
+
+    // additional color-coded classes
+    // (basically, selected = blue, approved = green)
+    const colorClasses = cx(
+      !hideActiveStatus && isLatest && 'color-red',
+      !hideActiveStatus && isCurrentlyViewing && 'color-blue',
+      isApproved && !isCurrentlyViewing && 'color-green'
+    );
+
+    const Element = this.props.el || 'div';
+
+    const lastUpdated = moment(revision.recipe.last_updated);
+    let lastUpdatedString = lastUpdated.format('MMM Do, YYYY');
+
+    // if the last update was made today,
+    if (lastUpdatedString === moment().format('MMM Do, YYYY')) {
+      // add an 'x mins ago' bit of text
+      lastUpdatedString = `${lastUpdatedString} (${lastUpdated.fromNow()})`;
+    } else {
+      // otherwise, format it as xx:yy pm
+      lastUpdatedString = `${lastUpdatedString} (${lastUpdated.format('h:mma')})`;
+    }
+
+    const revisionDiff = this.props.previous ?
+      diff(this.props.previous.recipe, revision.recipe)
+      : [];
+
+    const objDiffInfo = this.getDisplayedDiffs(revisionDiff);
+    const elDiffList = showInfo && this.generateDiffList(revisionDiff);
+
+
+    const rootClass = cx('history-item', colorClasses);
+    const lblNumChanges = `${objDiffInfo.length} changes`;
+    const lblHistoryButton = `${showInfo ? '-' : '+'} ${lblNumChanges}`;
+
+    const arrowDir = direction === 'asc' ? 'up' : 'down';
+
+    const revisionLabel = revision.recipe.revision_id ?
+      `Revision ${revision.recipe.revision_id.slice(0, 7)}...`
+      : '';
+
+    return (
+      <Element
+        className={rootClass}
+      >
+        {
+          !hideActiveStatus && isCurrentlyViewing &&
+            <i
+              className={'currently-viewing fa pre fa-eye'}
+              title={'You are currently viewing this revision.'}
+            />
+        }
+        <div className="history-content">
+          <div onClick={this.handleClick}>
+            <div
+              className="history-id"
+              title={revision.recipe.revision_id}
+            >
+              <DraftStatusIcon
+                className={colorClasses}
+                request={getRecipeApprovalRequest(revision.recipe)}
+              />
+              { revisionLabel }
+              <small>
+               { lastUpdatedString }
+              </small>
+              {
+                revision.comment &&
+                  <pre className="history-comment" children={revision.comment} />
+              }
+            </div>
+          </div>
+          {
+            !forceShow && revisionDiff && !!revisionDiff.length &&
+              <span
+                className="show-changes"
+                children={lblHistoryButton}
+                onClick={() => {
+                  this.setState({
+                    showInfo: !showInfo,
+                  });
+                }}
+              />
+          }
+          { elDiffList }
+        </div>
+        <i className={`fa fa-long-arrow-${arrowDir}`} aria-hidden="true" />
+      </Element>
+    );
+  }
+}

--- a/recipe-server/client/control/components/HistoryList.js
+++ b/recipe-server/client/control/components/HistoryList.js
@@ -1,0 +1,38 @@
+import React, { PropTypes as pt } from 'react';
+import cx from 'classnames';
+import HistoryItem from 'control/components/HistoryItem';
+
+export default function HistoryList({
+  isRecipeContainer,
+  recipe,
+  revisions,
+  dispatch,
+  direction,
+}) {
+  return (
+    <ul className={cx('recipe-history', isRecipeContainer && 'is-full')}>
+      {revisions.map((revision, index) =>
+        <HistoryItem
+          el={'li'}
+          key={`${revision.id} ${index}`}
+          revision={revision}
+          revisionId={revision.id}
+          recipe={recipe}
+          previous={revisions[index + (direction === 'asc' ? 1 : -1)]}
+          forceShow={isRecipeContainer}
+          hideActiveStatus={isRecipeContainer}
+          disableClickHandler={isRecipeContainer}
+          dispatch={dispatch}
+          direction={direction}
+        />
+      )}
+    </ul>
+  );
+}
+HistoryList.propTypes = {
+  dispatch: pt.func.isRequired,
+  recipe: pt.object.isRequired,
+  revisions: pt.arrayOf(pt.object).isRequired,
+  isRecipeContainer: pt.bool,
+  direction: pt.oneOf(['asc', 'desc']),
+};

--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -10,6 +10,7 @@ import {
   SubmissionError,
 } from 'redux-form';
 import { pick } from 'underscore';
+import cx from 'classnames';
 
 import {
   makeApiRequest,
@@ -17,12 +18,22 @@ import {
   recipeAdded,
   showNotification,
   setSelectedRecipe,
+  singleRecipeReceived,
 } from 'control/actions/ControlActions';
+
+import {
+  getRecipeApprovalRequest,
+} from 'control/selectors/RecipesSelector';
+
 import composeRecipeContainer from 'control/components/RecipeContainer';
+import DraftStatus from 'control/components/DraftStatus';
+import DraftComment from 'control/components/DraftComment';
 import { ControlField } from 'control/components/Fields';
+import RecipeHistory from 'control/components/RecipeHistory';
 import HeartbeatFields from 'control/components/action_fields/HeartbeatFields';
 import ConsoleLogFields from 'control/components/action_fields/ConsoleLogFields';
 import JexlEnvironment from 'selfrepair/JexlEnvironment';
+import DropdownMenu from 'control/components/DropdownMenu';
 
 
 export const selector = formValueSelector('recipe');
@@ -46,12 +57,167 @@ export class RecipeForm extends React.Component {
     recipeFields: pt.object,
     // route prop passed from router
     route: pt.object,
+    routeParams: pt.object,
+    dispatch: pt.func.isRequired,
+    recipeEntries: pt.object.isRequired,
+    updateRecipe: pt.func.isRequired,
+    // pristine is from redux-form
+    pristine: pt.bool.isRequired,
   };
 
   static argumentsFields = {
     'console-log': ConsoleLogFields,
     'show-heartbeat': HeartbeatFields,
   };
+
+  static loadingElement = (
+    <div className="recipe-form loading">
+      <i className="fa fa-spinner fa-spin fa-3x fa-fw" />
+      <p>Loading recipe...</p>
+    </div>
+  );
+
+  constructor(props) {
+    super(props);
+
+    this.formActionRevert = ::this.formActionRevert;
+    this.formActionApprove = ::this.formActionApprove;
+    this.formActionReject = ::this.formActionReject;
+    this.formActionRequestReview = ::this.formActionRequestReview;
+    this.formActionCloseReview = ::this.formActionCloseReview;
+
+    this.commentArea = {};
+
+    this.state = {
+      comment: {},
+    };
+  }
+
+  getOutdatedStatus() {
+    const {
+      routeParams,
+    } = this.props;
+
+    return !!routeParams.revisionId;
+  }
+
+
+  createFormButton(args) {
+    this.buttonCache = this.buttonCache || {};
+    const key = JSON.stringify(args);
+    // check cache key, generate button if necessary
+    if (!this.buttonCache[key]) {
+      const {
+        className,
+        label,
+        Element = 'button',
+        type = 'button',
+        ...props,
+      } = args;
+
+      this.buttonCache[key] = (
+        <Element
+          className={cx('button', className)}
+          onClick={props.onClick}
+          children={label}
+          type={type}
+          key={label + className}
+          {...props}
+        />
+      );
+    }
+    // return the (now) cached button
+    return this.buttonCache[key];
+  }
+
+  formActionRevert() {
+    const {
+      recipeId,
+      recipe,
+    } = this.props;
+
+    this.props.updateRecipe(recipeId, recipe);
+  }
+
+  formActionApprove() {
+    const {
+      recipe,
+    } = this.props;
+
+    if (!recipe || !recipe.approval_request) {
+      // Throw an error, since this shouldn't ever happen.
+      throw new Error('Recipe and/or approval request doesn\'t exist for approval.');
+    }
+
+    this.props.dispatch(makeApiRequest('acceptApprovalRequest', {
+      requestId: recipe.approval_request.id,
+      comment: this.state.comment.accept,
+    }));
+  }
+
+  formActionReject() {
+    const {
+      recipe,
+    } = this.props;
+
+    if (!recipe || !recipe.approval_request) {
+      // Throw an error, since this shouldn't ever happen.
+      throw new Error('Recipe and/or approval request doesn\'t exist for rejection.');
+    }
+
+    this.props.dispatch(makeApiRequest('rejectApprovalRequest', {
+      requestId: recipe.approval_request.id,
+      comment: this.state.comment.reject,
+    }));
+  }
+
+  formActionRequestReview() {
+    const {
+      routeParams,
+      dispatch,
+      recipe,
+    } = this.props;
+
+    let revisionId = routeParams && routeParams.revisionId;
+    if (!revisionId) {
+      revisionId = recipe.revision_id;
+    }
+
+    dispatch(makeApiRequest('openApprovalRequest', {
+      revisionId,
+    }))
+      .then(response => {
+        dispatch(showNotification({
+          messageType: 'success',
+          message: 'Approval review requested!',
+        }));
+        dispatch(singleRecipeReceived({
+          ...recipe,
+          approval_request: { ...response },
+        }));
+      });
+  }
+
+  formActionCloseReview() {
+    const {
+      recipe,
+      dispatch,
+    } = this.props;
+
+    dispatch(makeApiRequest('closeApprovalRequest', {
+      requestId: recipe.approval_request.id,
+    }))
+      .then(() => {
+        dispatch(showNotification({
+          messageType: 'success',
+          message: 'Approval review closed.',
+        }));
+        dispatch(singleRecipeReceived({
+          ...recipe,
+          approval_request: null,
+        }));
+      });
+  }
 
   renderCloningMessage() {
     const isCloning = this.props.route && this.props.route.isCloning;
@@ -71,6 +237,165 @@ export class RecipeForm extends React.Component {
     );
   }
 
+  renderFormActionButtons({ disabled }) {
+    const {
+      route,
+      recipe,
+      recipeId,
+      pristine,
+    } = this.props;
+
+    const revertButton = this.createFormButton({
+      disabled,
+      className: 'submit',
+      onClick: this.formActionRevert,
+      label: 'Revert to this Revision',
+    });
+
+    const cancelButton = this.createFormButton({
+      className: 'submit delete',
+      onClick: this.formActionCloseReview,
+      label: 'Cancel Review Request',
+    });
+
+    const onCommentChange = type =>
+      evt => {
+        this.setState({
+          comment: {
+            ...this.state.comment,
+            [type]: evt.target.value,
+          },
+        });
+      };
+
+    const approveButton = (
+      <DropdownMenu
+        pinRight
+        useClick
+        trigger={this.createFormButton({
+          className: 'submit',
+          label: 'Approve',
+        })}
+      >
+        <div>
+          Approval comment section
+          <textarea
+            defaultValue={this.state.comment.approve}
+            onChange={onCommentChange('approve')}
+          />
+          <button
+            type="button"
+            onClick={this.formActionApprove}
+            disabled={!this.state.comment.approve}
+          >
+            Approve
+          </button>
+        </div>
+      </DropdownMenu>
+    );
+
+    const rejectButton = (
+      <DropdownMenu
+        pinRight
+        useClick
+        trigger={this.createFormButton({
+          className: 'submit',
+          label: 'Reject',
+        })}
+      >
+        <div>
+          Reject comment section
+          <textarea
+            defaultValue={this.state.comment.reject}
+            onChange={onCommentChange('reject')}
+          />
+          <button
+            type="button"
+            onClick={this.formActionReject}
+            disabled={!this.state.comment.reject}
+          >
+            Reject
+          </button>
+        </div>
+      </DropdownMenu>
+    );
+
+    const deleteButton = this.createFormButton({
+      disabled,
+      Element: Link,
+      className: 'delete',
+      to: `/control/recipe/${recipeId}/delete/`,
+      label: 'Delete',
+    });
+
+    const requestButton = this.createFormButton({
+      disabled,
+      className: 'submit',
+      onClick: this.formActionRequestReview,
+      label: 'Request Review',
+    });
+
+    const saveRevisionButton = this.createFormButton({
+      disabled,
+      className: 'submit',
+      label: 'Save Revision',
+      type: 'submit',
+    });
+
+    const newButton = this.createFormButton({
+      disabled,
+      className: 'submit',
+      label: 'Create New Recipe',
+      type: 'submit',
+    });
+
+
+    const isCloning = route && route.isCloning;
+    const isPristine = pristine;
+
+    const isViewingOutdated = this.getOutdatedStatus();
+    const isPendingApproval = !!getRecipeApprovalRequest(recipe);
+
+    const requestDetails = recipe && recipe.approval_request;
+    const currentUserID = requestDetails && requestDetails.creator.id;
+    const approvalRequestor = requestDetails && requestDetails.creator.id;
+
+    // revert button -  if viewing an outdated draft
+    const showRevertButton = isViewingOutdated;
+    // cancel button - if under approval and this user is that requested
+    const showCancelButton = !isViewingOutdated && isPendingApproval
+      && currentUserID === approvalRequestor;
+      // approve/reject if under approval and NOT the user that requested
+    const showAppRejButtons = isPendingApproval && currentUserID !== approvalRequestor;
+    // delete button - not viewing old, not under approval, is existing recipe,
+    // and user isn't cloning
+    const showDeleteButton = !isViewingOutdated && !isPendingApproval && recipeId && !isCloning;
+    // not viewing old, not already under approval, exists, not cloning, form has not been touched
+    const showRequestButton = !isViewingOutdated && !isPendingApproval && recipeId
+      && !isCloning && isPristine;
+    // not under approval, exists, not cloning, form HAS been touched - show 'save draft' button
+    const showSaveButton = !isPendingApproval && recipeId && !isCloning && !isPristine;
+    // not under approval, and is a new recipe - show 'save new' button
+    const showNewButton = !isPendingApproval && !recipeId;
+
+    const buttons = [
+      showRevertButton && revertButton,
+      showCancelButton && cancelButton,
+      showAppRejButtons && approveButton,
+      showAppRejButtons && rejectButton,
+      showDeleteButton && deleteButton,
+      showRequestButton && requestButton,
+      showSaveButton && saveRevisionButton,
+      showNewButton && newButton,
+    ].filter(x => x);
+
+    return (
+      <div className="form-actions">
+        { buttons.map(el => el) }
+      </div>
+    );
+  }
+
   render() {
     const {
       handleSubmit,
@@ -78,32 +403,53 @@ export class RecipeForm extends React.Component {
       submitting,
       recipe,
       recipeId,
-      route,
       recipeFields,
+      route,
     } = this.props;
     const noop = () => null;
     const ArgumentsFields = RecipeForm.argumentsFields[selectedAction] || noop;
 
     // Show a loading indicator if we haven't yet loaded the recipe.
     if (recipeId && !recipe) {
-      return (
-        <div className="recipe-form loading">
-          <i className="fa fa-spinner fa-spin fa-3x fa-fw" />
-          <p>Loading recipe...</p>
-        </div>
-      );
+      return RecipeForm.loadingElement;
     }
 
     const isCloning = route && route.isCloning;
 
-    const submitButtonCaption = recipeId && !isCloning ? 'Update Recipe' : 'Add New Recipe';
+    const isViewingOutdated = this.getOutdatedStatus();
+    const request = getRecipeApprovalRequest(recipe);
+    const isPendingApproval = !!request;
 
+    const hasDisabledFields = submitting || isViewingOutdated || isPendingApproval;
     return (
-      <form className="recipe-form" onSubmit={handleSubmit}>
+      <form
+        className="recipe-form"
+        onSubmit={handleSubmit}
+      >
         { this.renderCloningMessage() }
 
-        <ControlField label="Name" name="name" component="input" type="text" />
+        {
+          recipe && !isCloning &&
+            <div className="draft-history">
+              <DraftStatus
+                recipe={recipe}
+              />
+              <RecipeHistory
+                dispatch={this.props.dispatch}
+                recipe={recipe}
+                recipeId={recipeId}
+              />
+            </div>
+        }
+
         <ControlField
+          disabled={hasDisabledFields}
+          label="Name"
+          name="name"
+          component="input" type="text"
+        />
+        <ControlField
+          disabled={hasDisabledFields}
           label="Enabled"
           name="enabled"
           className="checkbox-field"
@@ -111,26 +457,28 @@ export class RecipeForm extends React.Component {
           type="checkbox"
         />
         <ControlField
+          disabled={hasDisabledFields}
           label="Filter Expression"
           name="filter_expression"
           component="textarea"
         />
-        <ControlField label="Action" name="action" component="select">
+        <ControlField
+          disabled={hasDisabledFields}
+          label="Action"
+          name="action"
+          component="select"
+        >
           <option value="">Choose an action...</option>
           <option value="console-log">Log to Console</option>
           <option value="show-heartbeat">Heartbeat Prompt</option>
         </ControlField>
-        <ArgumentsFields fields={recipeFields} />
-        <div className="form-actions">
-          {recipeId && !isCloning &&
-            <Link className="button delete" to={`/control/recipe/${recipeId}/delete/`}>
-              Delete
-            </Link>
-          }
-          <button className="button submit" type="submit" disabled={submitting}>
-            {submitButtonCaption}
-          </button>
-        </div>
+        <ArgumentsFields fields={recipeFields} disabled={hasDisabledFields} />
+        <DraftComment request={request} />
+        {
+          this.renderFormActionButtons({
+            disabled: submitting || isViewingOutdated || isPendingApproval,
+          })
+        }
       </form>
     );
   }
@@ -140,8 +488,9 @@ export class RecipeForm extends React.Component {
  * Redux-Form config for the RecipeForm.
  */
 export const formConfig = {
+  asyncBlurFields: ['extra_filter_expression'],
+  enableReinitialize: true,
   form: 'recipe',
-  asyncBlurFields: ['filter_expression'],
 
   async asyncValidate(values) {
     const errors = {};
@@ -226,6 +575,7 @@ const connector = connect(
   state => ({
     selectedAction: selector(state, 'action'),
     recipeFields: selector(state, 'arguments'),
+    recipeEntries: state.recipes.entries,
   }),
 
   // Bound functions for writing to the server.
@@ -242,6 +592,7 @@ const connector = connect(
       return dispatch(makeApiRequest('updateRecipe', { recipeId, recipe }))
       .then(response => dispatch(recipeUpdated(response)));
     },
+    dispatch,
   }),
 );
 

--- a/recipe-server/client/control/components/RecipeHistory.js
+++ b/recipe-server/client/control/components/RecipeHistory.js
@@ -1,15 +1,16 @@
 import React, { PropTypes as pt } from 'react';
-import { push } from 'react-router-redux';
-import moment from 'moment';
 
-import composeRecipeContainer from 'control/components/RecipeContainer';
 import { makeApiRequest } from 'control/actions/ControlActions';
 
-export class DisconnectedRecipeHistory extends React.Component {
+import composeRecipeContainer from 'control/components/RecipeContainer';
+import HistoryList from 'control/components/HistoryList';
+
+export default class RecipeHistory extends React.Component {
   static propTypes = {
     dispatch: pt.func.isRequired,
     recipe: pt.object.isRequired,
     recipeId: pt.number.isRequired,
+    isRecipeContainer: pt.bool,
   }
 
   constructor(props) {
@@ -36,103 +37,19 @@ export class DisconnectedRecipeHistory extends React.Component {
   }
 
   render() {
-    const { recipe, dispatch } = this.props;
+    const { recipe, isRecipeContainer, dispatch } = this.props;
     const { revisions } = this.state;
-    return <HistoryList recipe={recipe} dispatch={dispatch} revisions={revisions} />;
-  }
-}
-
-export function HistoryList({ recipe, revisions, dispatch }) {
-  return (
-    <div className="fluid-8 recipe-history">
-      <h3>Viewing revision log for: <b>{recipe ? recipe.name : ''}</b></h3>
-      <table>
-        <tbody>
-          {revisions.map(revision =>
-            <HistoryItem
-              key={revision.id}
-              revision={revision}
-              recipe={recipe}
-              dispatch={dispatch}
-            />
-          )}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-HistoryList.propTypes = {
-  dispatch: pt.func.isRequired,
-  recipe: pt.object.isRequired,
-  revisions: pt.arrayOf(pt.object).isRequired,
-};
-
-export class HistoryItem extends React.Component {
-  static propTypes = {
-    dispatch: pt.func.isRequired,
-    revision: pt.shape({
-      recipe: pt.shape({
-        revision_id: pt.number.isRequired,
-      }).isRequired,
-      date_created: pt.string.isRequired,
-      comment: pt.string.isRequired,
-    }).isRequired,
-    recipe: pt.shape({
-      revision_id: pt.number.isRequired,
-    }).isRequired,
-  }
-
-  constructor(props) {
-    super(props);
-    this.handleClick = ::this.handleClick;
-  }
-
-  /**
-   * When a revision is clicked, open the recipe form with changes from
-   * the clicked revision.
-   */
-  handleClick() {
-    const { dispatch, revision, recipe } = this.props;
-
-    // Do not include form state changes if the current revision was
-    // clicked.
-    if (revision.recipe.revision_id === recipe.revision_id) {
-      dispatch(push(`/control/recipe/${recipe.id}/`));
-    } else {
-      dispatch(push({
-        pathname: `/control/recipe/${recipe.id}/`,
-        query: { revisionId: `${revision.id}` },
-        state: { selectedRevision: revision.recipe },
-      }));
-    }
-  }
-
-  render() {
-    const { revision, recipe } = this.props;
-    const isCurrent = revision.recipe.revision_id === recipe.revision_id;
 
     return (
-      <tr className="history-item" onClick={this.handleClick}>
-        <td className="revision-number">#{revision.recipe.revision_id}</td>
-        <td className="revision-created">
-          <span className="label">Created On:</span>
-          {moment(revision.date_created).format('MMM Do YYYY - h:mmA')}
-        </td>
-        <td className="revision-comment">
-          <span className="label">Comment:</span>
-          {revision.comment || '--'}
-        </td>
-        <td>
-          {isCurrent && (
-            <div className="status-indicator green">
-              <i className="fa fa-circle pre" />
-              Current Revision
-            </div>
-          )}
-        </td>
-      </tr>
+      <HistoryList
+        recipe={recipe}
+        dispatch={dispatch}
+        revisions={revisions}
+        isRecipeContainer={isRecipeContainer}
+        direction={'asc'}
+      />
     );
   }
 }
 
-export default composeRecipeContainer(DisconnectedRecipeHistory);
+export const RecipeHistoryPage = composeRecipeContainer(RecipeHistory);

--- a/recipe-server/client/control/components/RecipeList.js
+++ b/recipe-server/client/control/components/RecipeList.js
@@ -16,7 +16,7 @@ import {
 import RecipeFilters from 'control/components/RecipeFilters';
 
 const BooleanIcon = props => {
-  const iconClass = props.value ? 'fa-check green' : 'fa-times red';
+  const iconClass = props.value ? 'fa-check color-green' : 'fa-times color-red';
   return <i className={`fa fa-lg ${iconClass}`}>&nbsp;</i>;
 };
 BooleanIcon.propTypes = {
@@ -170,6 +170,7 @@ class DisconnectedRecipeList extends React.Component {
 
       return (
         <Td
+          key={slug + displayValue}
           column={slug}
           data={displayValue}
         >

--- a/recipe-server/client/control/components/action_fields/ConsoleLogFields.js
+++ b/recipe-server/client/control/components/action_fields/ConsoleLogFields.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { PropTypes as pt } from 'react';
 
 import { ControlField } from 'control/components/Fields';
 
 /**
  * Form fields for the console-log action.
  */
-export default function ConsoleLogFields() {
+export default function ConsoleLogFields({ disabled }) {
   return (
     <div className="arguments-fields">
       <p className="info">Log a message to the console.</p>
@@ -14,7 +14,12 @@ export default function ConsoleLogFields() {
         name="arguments.message"
         component="input"
         type="text"
+        disabled={disabled}
       />
     </div>
   );
 }
+
+ConsoleLogFields.propTypes = {
+  disabled: pt.bool,
+};

--- a/recipe-server/client/control/components/action_fields/HeartbeatFields.js
+++ b/recipe-server/client/control/components/action_fields/HeartbeatFields.js
@@ -5,37 +5,42 @@ import { ControlField } from 'control/components/Fields';
 /**
  * Form fields for the show-heartbeat action.
  */
-export default function HeartbeatFields({ fields }) {
+export default function HeartbeatFields({ fields, disabled }) {
   return (
     <div className="arguments-fields">
       <p className="info">
         Shows a single message or survey prompt to the user.
       </p>
       <ControlField
+        disabled={disabled}
         label="Survey ID"
         name="arguments.surveyId"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Message"
         name="arguments.message"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Engagement Button Label"
         name="arguments.engagementButtonLabel"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Thanks Message"
         name="arguments.thanksMessage"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Post-Answer URL"
         name="arguments.postAnswerUrl"
         component="input"
@@ -43,12 +48,14 @@ export default function HeartbeatFields({ fields }) {
       />
 
       <ControlField
+        disabled={disabled}
         label="Learn More Message"
         name="arguments.learnMoreMessage"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Learn More URL"
         name="arguments.learnMoreUrl"
         component="input"
@@ -56,6 +63,7 @@ export default function HeartbeatFields({ fields }) {
       />
 
       <ControlField
+        disabled={disabled}
         label="How often should the prompt be shown?"
         name="arguments.repeatOption"
         component="select"
@@ -78,6 +86,7 @@ export default function HeartbeatFields({ fields }) {
         fields.repeatOption &&
         fields.repeatOption === 'xdays' &&
           <ControlField
+            disabled={disabled}
             label="Days before user is re-prompted"
             name="arguments.repeatEvery"
             component="input"
@@ -86,6 +95,7 @@ export default function HeartbeatFields({ fields }) {
       }
 
       <ControlField
+        disabled={disabled}
         label="Include unique user ID in Post-Answer URL (and Telemetry)"
         name="arguments.includeTelemetryUUID"
         component="input"
@@ -98,5 +108,6 @@ export default function HeartbeatFields({ fields }) {
 
 HeartbeatFields.propTypes = {
   fields: pt.object,
+  disabled: pt.bool,
 };
 

--- a/recipe-server/client/control/routes.js
+++ b/recipe-server/client/control/routes.js
@@ -3,7 +3,7 @@ import { IndexRedirect, IndexRoute, Route } from 'react-router';
 import ControlApp from 'control/components/ControlApp';
 import RecipeList from 'control/components/RecipeList';
 import RecipeForm from 'control/components/RecipeForm';
-import RecipeHistory from 'control/components/RecipeHistory';
+import { RecipeHistoryPage as RecipeHistory } from 'control/components/RecipeHistory';
 import RecipePreview from 'control/components/RecipePreview';
 import DeleteRecipe from 'control/components/DeleteRecipe';
 import NoMatch from 'control/components/NoMatch';
@@ -29,7 +29,7 @@ export default (
           ctaButtons={[
             { text: 'Clone', icon: 'files-o', link: 'clone/' },
             { text: 'Preview', icon: 'eye', link: 'preview/' },
-            { text: 'History', icon: 'history', link: 'history/' },
+            { text: 'Change Log', icon: 'history', link: 'history/' },
           ]}
         />
         <Route
@@ -55,6 +55,13 @@ export default (
           path="delete/"
           component={DeleteRecipe}
           name="Delete"
+        />
+        <Route
+          path=":revisionId/"
+          component={RecipeForm}
+          ctaButtons={[
+            { text: 'Change Log', icon: 'history', link: 'history/' },
+          ]}
         />
       </Route>
     </Route>

--- a/recipe-server/client/control/sass/partials/_colors.scss
+++ b/recipe-server/client/control/sass/partials/_colors.scss
@@ -16,5 +16,18 @@ $yellow: #F8F8C3;
 $grey: #777;
 
 
-.red { color: $red; }
-.green { color: $green; }
+/**
+ * Automatically generate a list of color classes
+ */
+$colors: (green, $green),
+  (red, $red),
+  (yellow, $yellow),
+  (grey, $grey),
+  (blue, $cta),
+  (cta, $cta);
+
+@each $colorClass, $colorVal in $colors {
+  .color-#{$colorClass} {
+    color: $colorVal;
+  }
+}

--- a/recipe-server/client/control/sass/partials/_common.scss
+++ b/recipe-server/client/control/sass/partials/_common.scss
@@ -206,7 +206,7 @@ thead {
 }
 
 tr:nth-child(even) {
-  background: rgba($cream, 0.5);
+  background: rgba($cream, 0.25);
 }
 
 td {
@@ -331,3 +331,113 @@ i {
   display: block;
   padding: 1em;
 }
+
+
+.history-item {
+  cursor: pointer;
+  display: block;
+  height: auto;
+  list-style: none;
+  list-style-type: none;
+  padding: 0.5em 0.5em 1.5em;
+  position: relative;
+
+  &:nth-child(2n) {
+    background: rgba($cream, 0.5);
+  }
+
+  &:last-child {
+    i.fa-long-arrow-up {
+      display: none;
+    }
+  }
+
+  i.fa-long-arrow-up {
+    font-size: 1.5em !important;
+    left: 0.45em;
+    opacity: 0.5;
+    position: absolute;
+    top: 100%;
+    transform: translateY(-50%);
+    z-index: 555;
+  }
+
+  .currently-viewing {
+    position: absolute;
+    right: 0.5em;
+    top: calc(50% - 0.5em);
+  }
+
+  .history-content {
+    display: block;
+    margin: 1em 1em 1em 2em;
+    position: relative;
+  }
+
+  .history-id {
+    display: block;
+    margin: 0 0 1em;
+
+    small {
+      display: block;
+    }
+  }
+
+  .draft-status-icon {
+    margin-left: -1.85em;
+    padding-right: 0.5em;
+    position: relative;
+    top: 0.65em;
+  }
+
+  .show-changes {
+    opacity: 0.5;
+  }
+
+  .change-list {
+    box-sizing: content-box;
+    list-style: none;
+    padding: 1em 2em;
+
+    li {
+      display: inline-block;
+      min-width: 230px;
+    }
+  }
+
+  .change-from,
+  .change-to {
+    background: #EEE;
+    border: 1px solid #DDD;
+    display: inline-block;
+    margin: 0.5em 0 1.5em 1em;
+    padding: 0.55em 1em;
+  }
+
+  .change-to {
+    margin-left: 0;
+  }
+
+  .change-label {
+    position: relative;
+
+    .fa {
+      left: -0.3em;
+      position: relative;
+    }
+  }
+}
+
+
+.draft-history {
+  float: right;
+  max-width: 48%;
+  width: 265px;
+
+  .recipe-history {
+    margin-top: 10px;
+    max-height: 280px;
+    overflow: auto;
+  }
+}
+

--- a/recipe-server/client/control/selectors/RecipesSelector.js
+++ b/recipe-server/client/control/selectors/RecipesSelector.js
@@ -1,0 +1,14 @@
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * Recipes selectors
+ */
+
+/**
+ * Given a recipe, returns its approval request, if any exists.
+ * @param  {Object} recipe Selected recipe to search for approval request.
+ * @return {[type]}        [description]
+ */
+export function getRecipeApprovalRequest(recipe) {
+  return recipe && recipe.approval_request;
+}

--- a/recipe-server/package.json
+++ b/recipe-server/package.json
@@ -21,6 +21,7 @@
     "babel-runtime": "6.11.6",
     "classnames": "2.2.5",
     "cssmin": "0.4.3",
+    "deep-diff": "0.3.4",
     "font-awesome": "4.6.3",
     "jexl": "1.1.4",
     "jquery": "3.1.0",
@@ -43,7 +44,8 @@
     "redux-thunk": "2.1.0",
     "sha.js": "2.4.5",
     "uglifyjs": "2.4.10",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "underscore.string": "3.3.4"
   },
   "devDependencies": {
     "babel-core": "6.14.0",


### PR DESCRIPTION
This has pieces of #492 (comment UI), #491 (revision history), #490 (revision status indicator), and #489 (ui for approval requests).

**This branch still requires some refactoring.** Specifically, I'm not thrilled with `RecipeForm#renderFormActionButtons`, though there are some other pieces that could be abstracted or simplified (thinking `HistoryItem` in particular).

At this point, the basic 'flow' should work:
- User can navigate revision history via new [UI component](https://cloud.githubusercontent.com/assets/2767162/23218888/c12f2010-f8da-11e6-93f3-5e64868aa655.png)
  - Diffs between revisions are visible on the "new" `Change Log` page
- Form buttons update based on the currently viewed revision/approval status.
- Approve/Reject buttons show comment fields on click
- API calls are actually made so users can request/close/approve/reject, with comments.

There are a handful of things I'm running into or need to be addressed:
- The revision navigator does _not_ correctly show which revision the user is currently viewing
- The way the buttons are created/shown (in `renderFormActionButtons`) feels really gross, but I've already refactored it down froms omething worse. Any thoughts on cleaning that up would be greatly appreciated.

Also in this PR:
- Split up `RecipeHistory` so its pieces are in separate files (e.g. `HistoryList`, `HistoryItem`)
- `color-` classes are generated in `_colors.scss`