### PR TITLE
recipe-client-addon: Log events with no listener as DEBUG, not INFO

### DIFF
--- a/recipe-client-addon/lib/EventEmitter.jsm
+++ b/recipe-client-addon/lib/EventEmitter.jsm
@@ -27,7 +27,7 @@ this.EventEmitter = function(sandboxManager) {
       Promise.resolve()
         .then(() => {
           if (!(eventName in listeners)) {
-            log.info(`EventEmitter: Event fired with no listeners: ${eventName}`);
+            log.debug(`EventEmitter: Event fired with no listeners: ${eventName}`);
             return;
           }
           // Clone callbacks array to avoid problems with mutation while iterating


### PR DESCRIPTION
Fixes #542