### PR TITLE
Django 1.10

### DIFF
--- a/recipe-server/normandy/base/middleware.py
+++ b/recipe-server/normandy/base/middleware.py
@@ -1,10 +1,26 @@
 from django.utils import timezone
+from django.utils.deprecation import MiddlewareMixin
+
+from mozilla_cloud_services_logger.django.middleware import (
+    RequestSummaryLogger as OriginalRequestSummaryLogger
+)
 
 
-class RequestReceivedAtMiddleware(object):
+def request_received_at_middleware(get_response):
     """
     Adds a 'received_at' property to requests with a datetime showing
     when the request was received by Django.
     """
-    def process_request(self, request):
+
+    def middleware(request):
         request.received_at = timezone.now()
+        return get_response(request)
+
+    return middleware
+
+
+class RequestSummaryLogger(MiddlewareMixin, OriginalRequestSummaryLogger):
+    """
+    Adapt mozilla_cloud_services_logger's request logger to Django 1.10 new-style middleware.
+    """
+    pass

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -33,8 +33,9 @@ class Core(Configuration):
 
     # Middleware that ALL environments must have. See the Base class for
     # details.
-    MIDDLEWARE_CLASSES = [
-        'normandy.base.middleware.RequestReceivedAtMiddleware',
+    MIDDLEWARE = [
+        'normandy.base.middleware.request_received_at_middleware',
+        'normandy.base.middleware.RequestSummaryLogger',
         'django.middleware.security.SecurityMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -54,7 +55,7 @@ class Core(Configuration):
                     'django.template.context_processors.request',
                     'django.contrib.auth.context_processors.auth',
                     'django.contrib.messages.context_processors.messages',
-                    'django.core.context_processors.static',
+                    'django.template.context_processors.static',
                 ],
             },
         },
@@ -151,21 +152,20 @@ class Base(Core):
 
     # Middleware that _most_ environments will need. Subclasses can
     # override this list.
-    EXTRA_MIDDLEWARE_CLASSES = [
+    EXTRA_MIDDLEWARE = [
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
-        'mozilla_cloud_services_logger.django.middleware.RequestSummaryLogger',
     ]
 
-    def MIDDLEWARE_CLASSES(self):
+    def MIDDLEWARE(self):
         """
         Determine middleware by combining the core set and
         per-environment set.
         """
-        return Core.MIDDLEWARE_CLASSES + self.EXTRA_MIDDLEWARE_CLASSES
+        return Core.MIDDLEWARE + self.EXTRA_MIDDLEWARE
 
     LOGGING_USE_JSON = values.BooleanValue(False)
 
@@ -330,9 +330,8 @@ class ProductionReadOnly(Production):
     Settings for a production environment that is read-only. This is
     used on public-facing webheads.
     """
-    EXTRA_MIDDLEWARE_CLASSES = [
+    EXTRA_MIDDLEWARE = [
         # No need for sessions, so removing those middlewares helps us go fast
-        'mozilla_cloud_services_logger.django.middleware.RequestSummaryLogger',
     ]
     ADMIN_ENABLED = values.BooleanValue(False)
     SILENCED_SYSTEM_CHECKS = values.ListValue(['security.W003'])  # CSRF check

--- a/recipe-server/requirements/default.txt
+++ b/recipe-server/requirements/default.txt
@@ -10,17 +10,17 @@ dj-database-url==0.3.0 \
     --hash=sha256:ca01768fdecde134301f3170743226f60edff5c3935f12437378ebd911506353
 dj-inmemorystorage==1.4.0 \
     --hash=sha256:35a37fac5955c3d9519fcab0cc7d88b43dc9bc95ffd2a6312badfa489ed30fd2
-django==1.9.11 \
-    --hash=sha256:bec3e58d9458e3121180adf9c33dedae0091ef6e73f79b2f9a0f8c0a34925429 \
-    --hash=sha256:dadcfd8b03dfbf472c2d88c12202d9d015af68fb6561099992bc2d91aeab7d9d
+Django==1.10.5 \
+    --hash=sha256:4541a60834f28f308ee7b6e96400feca905fb0de473eb9dad6847e98a36d86d4 \
+    --hash=sha256:0db89374b691b9c8b057632a6cd64b18d08db2f4d63b4d4af6024267ab965f8b
 django-configurations==1.0 \
     --hash=sha256:98a14951cd0870d0343fe9c243172dc110353b430c3e06a87a90dc7bc82b0b75 \
     --hash=sha256:93f4a09134145f4388c2ec2183ce623b1b57fd04e3e0d2a2cf3b32fadc8f9464
 django-countries==3.4.1 \
     --hash=sha256:5bdda9d2c3473b519371428d88517f29befad7e35dfc489e8b0f95cb2aa941dc \
     --hash=sha256:23c6b5455a2e68ed02601cee0d3c80481965d0c3a6bd2f07ca56902b0a4c55a6
-django-dirtyfields==0.8.2 \
-    --hash=sha256:90a60223a373ec563c0e6b013121a2d965233498384af0cf132b1622d0d8aa19
+django-dirtyfields==1.2.1 \
+    --hash=sha256:6f2e988121323cd8a15cef3035f5ea5942d3e41f76c3b2e1de0b81761a000c94
 django-filter==1.0.1 \
     --hash=sha256:03ab2895e086aa579110a8945d7d9c5d28c4b57060cfc697cb5c74a18021fec4 \
     --hash=sha256:7cca9dab22c72df734ba24fb81ca018fdb6d2020c840e758d473dcedd341aa7b
@@ -65,9 +65,9 @@ gevent==1.2.1 \
 gunicorn==19.4.5 \
     --hash=sha256:c57f1b005a4b90933303c8deed9bedeb509331aa6a0a990023a5796e52bd8988 \
     --hash=sha256:53b58044764ad79d732af18c580b1a54b724adf4d290ec19c4ca78ab22a1ee0d
-hashin==0.4.2 \
-    --hash=sha256:4675a60ccb93b4bf2b3625dcd4617b9f7bdb64c6dd463b4a2d39ea6cc03815d3 \
-    --hash=sha256:5da3d92f8698ad8c2906b14a421af160014daf55f1d352cac081898ed47aa96a
+hashin==0.7.2 \
+    --hash=sha256:28213aa9cc1cbce1d33f813877e079f1c963a95c9f76c501faacb1a80723e114 \
+    --hash=sha256:dd38d9356e2810ccae928de8fa1aa023d885566a7f3c4b6840ba55ecd7d7bd35
 jsonschema==2.5.1 \
     --hash=sha256:71e7b3bcf9fca408bcb65bb60892f375d3abdd2e4f296eeeb8fe0bbbfcde598e \
     --hash=sha256:36673ac378feed3daa5956276a829699056523d7961027911f064b52255ead41 \


### PR DESCRIPTION
I've been meaning to to do this for a while, and some of the Auth0 stuff I'm looking at for #526 requires Django 1.10.

I stole d7e8fa8 from #510. That will probably merge before this. If so, I'll take that commit out of this branch. In the meantime, it is needed because DRF 3.3 isn't compatible with Django 1.10.

PS: The plan here is to update to Django 1.11 shortly after it comes out, and stay there for the foreseeable futures, since it is an LTS release.