### PR TITLE
Add basic UI for Review Requests

### DIFF
--- a/recipe-server/client/control/actions/ControlActions.js
+++ b/recipe-server/client/control/actions/ControlActions.js
@@ -12,6 +12,8 @@ export const RECIPE_ADDED = 'RECIPE_ADDED';
 export const RECIPE_UPDATED = 'RECIPE_UPDATED';
 export const RECIPE_DELETED = 'RECIPE_DELETED';
 
+export const RECEIVED_USER_INFO = 'RECEIVED_USER_INFO';
+
 
 const BASE_API_URL = '/api/v1/';
 
@@ -25,6 +27,15 @@ const API_REQUEST_SETTINGS = {
 };
 
 const apiRequestMap = {
+  getCurrentUser() {
+    return {
+      url: `${BASE_API_URL}user/me`,
+      settings: {
+        method: 'GET',
+      },
+      errorNotification: 'Error retrieving user info.',
+    };
+  },
   fetchAllRecipes() {
     return {
       url: `${BASE_API_URL}recipe/`,
@@ -160,6 +171,12 @@ const apiRequestMap = {
   },
 };
 
+function userInfoReceived(user) {
+  return {
+    type: RECEIVED_USER_INFO,
+    user,
+  };
+}
 
 function requestInProgress() {
   return {
@@ -268,9 +285,9 @@ function makeApiRequest(requestType, requestData) {
   };
 }
 
-
 export {
   makeApiRequest,
+  userInfoReceived,
   recipesReceived,
   singleRecipeReceived,
   setSelectedRecipe,

--- a/recipe-server/client/control/actions/ControlActions.js
+++ b/recipe-server/client/control/actions/ControlActions.js
@@ -29,7 +29,7 @@ const API_REQUEST_SETTINGS = {
 const apiRequestMap = {
   getCurrentUser() {
     return {
-      url: `${BASE_API_URL}user/me`,
+      url: `${BASE_API_URL}user/me/`,
       settings: {
         method: 'GET',
       },
@@ -63,26 +63,6 @@ const apiRequestMap = {
         method: 'GET',
       },
       errorNotification: 'Error fetching recipe revision.',
-    };
-  },
-
-  getApprovalRequests() {
-    return {
-      url: `${BASE_API_URL}approval_request/`,
-      settings: {
-        method: 'GET',
-      },
-      errorNotification: 'Error fetching approval requests.',
-    };
-  },
-
-  getApprovalRequestInfo({ requestId }) {
-    return {
-      url: `${BASE_API_URL}approval_request/${requestId}/`,
-      settings: {
-        method: 'GET',
-      },
-      errorNotification: 'Error fetching approval request info.',
     };
   },
 

--- a/recipe-server/client/control/actions/ControlActions.js
+++ b/recipe-server/client/control/actions/ControlActions.js
@@ -47,7 +47,7 @@ const apiRequestMap = {
 
   fetchSingleRevision(recipeInfo) {
     return {
-      url: `${BASE_API_URL}recipe_version/${recipeInfo.revisionId}/`,
+      url: `${BASE_API_URL}recipe_revision/${recipeInfo.revisionId}/`,
       settings: {
         method: 'GET',
       },
@@ -55,9 +55,72 @@ const apiRequestMap = {
     };
   },
 
-  fetchRecipeHistory(recipeInfo) {
+  getApprovalRequests() {
     return {
-      url: `${BASE_API_URL}recipe/${recipeInfo.recipeId}/history/`,
+      url: `${BASE_API_URL}approval_request/`,
+      settings: {
+        method: 'GET',
+      },
+      errorNotification: 'Error fetching approval requests.',
+    };
+  },
+
+  getApprovalRequestInfo({ requestId }) {
+    return {
+      url: `${BASE_API_URL}approval_request/${requestId}/`,
+      settings: {
+        method: 'GET',
+      },
+      errorNotification: 'Error fetching approval request info.',
+    };
+  },
+
+  openApprovalRequest({ revisionId }) {
+    return {
+      url: `${BASE_API_URL}recipe_revision/${revisionId}/request_approval/`,
+      settings: {
+        method: 'POST',
+        body: JSON.stringify({ revisionId }),
+      },
+      errorNotification: 'Error creating new approval request.',
+    };
+  },
+
+  acceptApprovalRequest({ requestId, comment = '' }) {
+    return {
+      url: `${BASE_API_URL}approval_request/${requestId}/approve/`,
+      settings: {
+        method: 'POST',
+        body: JSON.stringify({ comment }),
+      },
+      errorNotification: 'Error accepting recipe approval.',
+    };
+  },
+
+  rejectApprovalRequest({ requestId, comment = '' }) {
+    return {
+      url: `${BASE_API_URL}approval_request/${requestId}/reject/`,
+      settings: {
+        method: 'POST',
+        body: JSON.stringify({ comment }),
+      },
+      errorNotification: 'Error rejecting recipe approval.',
+    };
+  },
+
+  closeApprovalRequest({ requestId }) {
+    return {
+      url: `${BASE_API_URL}approval_request/${requestId}/close/`,
+      settings: {
+        method: 'POST',
+      },
+      errorNotification: 'Error closing recipe approval request.',
+    };
+  },
+
+  fetchRecipeHistory({ recipeId }) {
+    return {
+      url: `${BASE_API_URL}recipe/${recipeId}/history/`,
       settings: {
         method: 'GET',
       },
@@ -65,11 +128,11 @@ const apiRequestMap = {
     };
   },
 
-  addRecipe(recipeInfo) {
+  addRecipe({ recipe }) {
     return {
       url: `${BASE_API_URL}recipe/`,
       settings: {
-        body: JSON.stringify(recipeInfo.recipe),
+        body: JSON.stringify(recipe),
         method: 'POST',
       },
     };

--- a/recipe-server/client/control/components/RecipeContainer.js
+++ b/recipe-server/client/control/components/RecipeContainer.js
@@ -7,8 +7,8 @@ export default function composeRecipeContainer(Component) {
   class RecipeContainer extends React.Component {
     static propTypes = {
       dispatch: pt.func.isRequired,
-      location: pt.object.isRequired,
       recipe: pt.object.isRequired,
+      routeParams: pt.object.isRequired,
     }
 
     componentWillMount() {
@@ -24,12 +24,12 @@ export default function composeRecipeContainer(Component) {
     }
 
     getRecipeData(recipeId) {
-      const { dispatch, location, recipe } = this.props;
+      const { dispatch, recipe, routeParams } = this.props;
       if (!recipe) {
         dispatch(setSelectedRecipe(recipeId));
 
-        if (location.query.revisionId) {
-          dispatch(makeApiRequest('fetchSingleRevision', { revisionId: location.query.revisionId }))
+        if (routeParams.revisionId) {
+          dispatch(makeApiRequest('fetchSingleRevision', { revisionId: routeParams.revisionId }))
           .then(revision => {
             dispatch(singleRecipeReceived(revision.recipe));
           });

--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -96,7 +96,7 @@ export class RecipeForm extends React.Component {
       dispatch,
     } = this.props;
 
-    if (!user.id) {
+    if (!user || !user.id) {
       dispatch(makeApiRequest('getCurrentUser'))
         .then(receivedUser => dispatch(userInfoReceived(receivedUser)));
     }
@@ -144,7 +144,7 @@ export class RecipeForm extends React.Component {
    * Form action buttons remotely fire this handler with a (string) action type,
    * which then triggers the appropriate API requests/etc.
    *
-   * @param  {string} action Action type to trigger. ex: 'close', 'approve', 'reject'
+   * @param  {string} action Action type to trigger. ex: 'cancel', 'approve', 'reject'
    */
   handleFormAction(action) {
     const {
@@ -153,7 +153,7 @@ export class RecipeForm extends React.Component {
     } = this.props;
 
     switch (action) {
-      case 'close': {
+      case 'cancel': {
         dispatch(makeApiRequest('closeApprovalRequest', {
           requestId: recipe.approval_request.id,
         })).then(() => {

--- a/recipe-server/client/control/components/RecipeFormActions.js
+++ b/recipe-server/client/control/components/RecipeFormActions.js
@@ -1,0 +1,159 @@
+import React, {
+  PropTypes as pt,
+} from 'react';
+import { Link } from 'react-router';
+import cx from 'classnames';
+
+export const FormButton = ({
+    className,
+    label,
+    element = 'button',
+    type = 'button',
+    onClick,
+    display,
+    ...props,
+  }) => {
+  if (!display) {
+    return null;
+  }
+
+  // need titlecase for JSX
+  const Element = element;
+  return (
+    <Element
+      className={cx('button', className)}
+      onClick={onClick}
+      children={label}
+      type={type}
+      key={label + className}
+      {...props}
+    />
+  );
+};
+FormButton.propTypes = {
+  display: pt.bool.isRequired,
+  className: pt.string,
+  label: pt.string,
+  element: pt.any,
+  type: pt.string,
+  onClick: pt.func,
+};
+
+export default class RecipeFormActions extends React.Component {
+  static propTypes = {
+    onAction: pt.func.isRequired,
+    isUserViewingOutdated: pt.bool,
+    isPendingApproval: pt.bool,
+    isUserRequestor: pt.bool,
+    isAlreadySaved: pt.bool,
+    isFormPristine: pt.bool,
+    isCloning: pt.bool,
+    isFormDisabled: pt.bool,
+    recipeId: pt.number,
+  };
+
+  getActions({
+    isUserViewingOutdated,
+    isPendingApproval,
+    isUserRequestor,
+    isAlreadySaved,
+    isFormPristine,
+    isCloning,
+    isFormDisabled,
+    recipeId,
+  }) {
+    return [
+      // revert
+      <FormButton
+        display={isUserViewingOutdated && isFormPristine}
+        disabled={isFormDisabled}
+        className={'submit'}
+        type={'submit'}
+        label={'Revert to this Revision'}
+      />,
+      // cancel
+      <FormButton
+        display={!isUserViewingOutdated && isPendingApproval && isUserRequestor}
+        className={'submit delete'}
+        onClick={this.createActionEmitter('close')}
+        label={'Cancel Review Request'}
+      />,
+      // back to latest
+      <FormButton
+        display={isUserViewingOutdated && !isCloning}
+        element={Link}
+        to={`/control/recipe/${recipeId}/`}
+        label={`Back to ${isPendingApproval ? 'Review' : 'Latest'}`}
+      />,
+      // approve
+      <FormButton
+        display={!isUserViewingOutdated && isPendingApproval && !isCloning && !isUserRequestor}
+        className={'submit'}
+        onClick={this.createActionEmitter('approve')}
+        label={'Approve'}
+      />,
+      // reject
+      <FormButton
+        display={!isUserViewingOutdated && isPendingApproval && !isCloning && !isUserRequestor}
+        className={'submit delete'}
+        onClick={this.createActionEmitter('reject')}
+        label={'Reject'}
+      />,
+      // delete
+      <FormButton
+        display={!isUserViewingOutdated && !isPendingApproval && isAlreadySaved && !isCloning}
+        className={'delete'}
+        label={'Delete'}
+        element={Link}
+        to={`/control/recipe/${recipeId}/delete/`}
+      />,
+      // request
+      <FormButton
+        display={!isUserViewingOutdated && !isPendingApproval && isAlreadySaved
+          && !isCloning && isFormPristine}
+        className={'submit'}
+        onClick={this.createActionEmitter('request')}
+        label={'Request Approval'}
+      />,
+      // save
+      <FormButton
+        display={!isPendingApproval && isAlreadySaved && !isCloning && !isFormPristine
+          && !isUserViewingOutdated}
+        className={'submit'}
+        type={'submit'}
+        label={'Save New Draft'}
+      />,
+      // new
+      <FormButton
+        display={(!isCloning && !isPendingApproval && !isAlreadySaved)
+          || (isUserViewingOutdated && !isFormPristine)}
+        className={'submit'}
+        type={'submit'}
+        label={'Save New Draft'}
+      />,
+    ];
+  }
+
+  createActionEmitter(type) {
+    this.actionCache = this.actionCache || {};
+
+    if (!this.actionCache[type]) {
+      this.actionCache[type] = () => {
+        this.props.onAction(type);
+      };
+    }
+
+    return this.actionCache[type];
+  }
+
+  /**
+   * Render
+   */
+  render() {
+    return (
+      <div className="form-actions">
+        {this.getActions(this.props)}
+      </div>
+    );
+  }
+}

--- a/recipe-server/client/control/components/RecipeFormActions.js
+++ b/recipe-server/client/control/components/RecipeFormActions.js
@@ -67,42 +67,43 @@ export default class RecipeFormActions extends React.Component {
       <FormButton
         display={isUserViewingOutdated && isFormPristine}
         disabled={isFormDisabled}
-        className={'submit'}
+        className={'action-revert submit'}
         type={'submit'}
         label={'Revert to this Revision'}
       />,
       // cancel
       <FormButton
         display={!isUserViewingOutdated && isPendingApproval && isUserRequestor}
-        className={'submit delete'}
-        onClick={this.createActionEmitter('close')}
+        className={'action-cancel submit delete'}
+        onClick={this.createActionEmitter('cancel')}
         label={'Cancel Review Request'}
       />,
       // back to latest
       <FormButton
         display={isUserViewingOutdated && !isCloning}
         element={Link}
+        className={'action-back'}
         to={`/control/recipe/${recipeId}/`}
         label={`Back to ${isPendingApproval ? 'Review' : 'Latest'}`}
       />,
       // approve
       <FormButton
         display={!isUserViewingOutdated && isPendingApproval && !isCloning && !isUserRequestor}
-        className={'submit'}
+        className={'action-approve submit'}
         onClick={this.createActionEmitter('approve')}
         label={'Approve'}
       />,
       // reject
       <FormButton
         display={!isUserViewingOutdated && isPendingApproval && !isCloning && !isUserRequestor}
-        className={'submit delete'}
+        className={'action-reject submit delete'}
         onClick={this.createActionEmitter('reject')}
         label={'Reject'}
       />,
       // delete
       <FormButton
         display={!isUserViewingOutdated && !isPendingApproval && isAlreadySaved && !isCloning}
-        className={'delete'}
+        className={'action-delete delete'}
         label={'Delete'}
         element={Link}
         to={`/control/recipe/${recipeId}/delete/`}
@@ -111,7 +112,7 @@ export default class RecipeFormActions extends React.Component {
       <FormButton
         display={!isUserViewingOutdated && !isPendingApproval && isAlreadySaved
           && !isCloning && isFormPristine}
-        className={'submit'}
+        className={'action-request submit'}
         onClick={this.createActionEmitter('request')}
         label={'Request Approval'}
       />,
@@ -119,17 +120,17 @@ export default class RecipeFormActions extends React.Component {
       <FormButton
         display={!isPendingApproval && isAlreadySaved && !isCloning && !isFormPristine
           && !isUserViewingOutdated}
-        className={'submit'}
+        className={'action-save submit'}
         type={'submit'}
-        label={'Save New Draft'}
+        label={'Save Draft'}
       />,
       // new
       <FormButton
         display={(!isCloning && !isPendingApproval && !isAlreadySaved)
           || (isUserViewingOutdated && !isFormPristine)}
-        className={'submit'}
+        className={'action-new submit'}
         type={'submit'}
-        label={'Save New Draft'}
+        label={'Save New Recipe'}
       />,
     ];
   }
@@ -152,7 +153,10 @@ export default class RecipeFormActions extends React.Component {
   render() {
     return (
       <div className="form-actions">
-        {this.getActions(this.props)}
+        {this.getActions(this.props).map((Action, idx) =>
+          // Need to key the action buttons to satisfy a React warning
+          React.cloneElement(Action, { key: idx })
+        )}
       </div>
     );
   }

--- a/recipe-server/client/control/components/RecipeFormActions.js
+++ b/recipe-server/client/control/components/RecipeFormActions.js
@@ -49,6 +49,9 @@ export default class RecipeFormActions extends React.Component {
     isFormPristine: pt.bool,
     isCloning: pt.bool,
     isFormDisabled: pt.bool,
+    isAccepted: pt.bool,
+    isRejected: pt.bool,
+    hasApprovalRequest: pt.bool,
     recipeId: pt.number,
   };
 
@@ -60,77 +63,66 @@ export default class RecipeFormActions extends React.Component {
     isFormPristine,
     isCloning,
     isFormDisabled,
+    hasApprovalRequest,
     recipeId,
   }) {
     return [
-      // revert
-      <FormButton
-        display={isUserViewingOutdated && isFormPristine}
-        disabled={isFormDisabled}
-        className={'action-revert submit'}
-        type={'submit'}
-        label={'Revert to this Revision'}
-      />,
-      // cancel
-      <FormButton
-        display={!isUserViewingOutdated && isPendingApproval && isUserRequestor}
-        className={'action-cancel submit delete'}
-        onClick={this.createActionEmitter('cancel')}
-        label={'Cancel Review Request'}
-      />,
-      // back to latest
-      <FormButton
-        display={isUserViewingOutdated && !isCloning}
-        element={Link}
-        className={'action-back'}
-        to={`/control/recipe/${recipeId}/`}
-        label={`Back to ${isPendingApproval ? 'Review' : 'Latest'}`}
-      />,
-      // approve
-      <FormButton
-        display={!isUserViewingOutdated && isPendingApproval && !isCloning && !isUserRequestor}
-        className={'action-approve submit'}
-        onClick={this.createActionEmitter('approve')}
-        label={'Approve'}
-      />,
-      // reject
-      <FormButton
-        display={!isUserViewingOutdated && isPendingApproval && !isCloning && !isUserRequestor}
-        className={'action-reject submit delete'}
-        onClick={this.createActionEmitter('reject')}
-        label={'Reject'}
-      />,
       // delete
       <FormButton
-        display={!isUserViewingOutdated && !isPendingApproval && isAlreadySaved && !isCloning}
-        className={'action-delete delete'}
-        label={'Delete'}
+        display={isAlreadySaved && !isCloning}
+        disabled={isFormDisabled}
+        className="action-delete delete"
+        label="Delete"
         element={Link}
         to={`/control/recipe/${recipeId}/delete/`}
       />,
-      // request
-      <FormButton
-        display={!isUserViewingOutdated && !isPendingApproval && isAlreadySaved
-          && !isCloning && isFormPristine}
-        className={'action-request submit'}
-        onClick={this.createActionEmitter('request')}
-        label={'Request Approval'}
-      />,
       // save
       <FormButton
-        display={!isPendingApproval && isAlreadySaved && !isCloning && !isFormPristine
-          && !isUserViewingOutdated}
-        className={'action-save submit'}
-        type={'submit'}
-        label={'Save Draft'}
+        disabled={isFormPristine}
+        display={isAlreadySaved && !isCloning}
+        className="action-save submit"
+        type="submit"
+        label="Save Draft"
       />,
       // new
       <FormButton
-        display={(!isCloning && !isPendingApproval && !isAlreadySaved)
-          || (isUserViewingOutdated && !isFormPristine)}
-        className={'action-new submit'}
-        type={'submit'}
-        label={'Save New Recipe'}
+        disabled={isFormPristine}
+        display={!isAlreadySaved || isCloning}
+        className="action-new submit"
+        type="submit"
+        label="Save New Recipe"
+      />,
+      // cancel
+      <FormButton
+        display={!isUserViewingOutdated && isPendingApproval}
+        className="action-cancel submit delete"
+        onClick={this.createActionEmitter('cancel')}
+        label="Cancel Review Request"
+      />,
+      // approve
+      <FormButton
+        display={!isUserViewingOutdated && isPendingApproval && !isCloning}
+        disabled={isUserRequestor}
+        className="action-approve submit"
+        onClick={this.createActionEmitter('approve')}
+        label="Approve"
+      />,
+      // reject
+      <FormButton
+        display={!isUserViewingOutdated && isPendingApproval && !isCloning}
+        disabled={isUserRequestor}
+        className="action-reject submit delete"
+        onClick={this.createActionEmitter('reject')}
+        label="Reject"
+      />,
+      // request
+      <FormButton
+        display={!isUserViewingOutdated && !hasApprovalRequest
+          && !isPendingApproval && isAlreadySaved && !isCloning}
+        disabled={!isFormPristine}
+        className="action-request submit"
+        onClick={this.createActionEmitter('request')}
+        label="Request Approval"
       />,
     ];
   }

--- a/recipe-server/client/control/components/RecipeHistory.js
+++ b/recipe-server/client/control/components/RecipeHistory.js
@@ -100,8 +100,7 @@ export class HistoryItem extends React.Component {
       dispatch(push(`/control/recipe/${recipe.id}/`));
     } else {
       dispatch(push({
-        pathname: `/control/recipe/${recipe.id}/`,
-        query: { revisionId: `${revision.id}` },
+        pathname: `/control/recipe/${recipe.id}/${revision.id}/`,
         state: { selectedRevision: revision.recipe },
       }));
     }

--- a/recipe-server/client/control/components/action_fields/ConsoleLogFields.js
+++ b/recipe-server/client/control/components/action_fields/ConsoleLogFields.js
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, { PropTypes as pt } from 'react';
 
 import { ControlField } from 'control/components/Fields';
 
 /**
  * Form fields for the console-log action.
  */
-export default function ConsoleLogFields() {
+export default function ConsoleLogFields({ disabled }) {
   return (
     <div className="arguments-fields">
       <p className="info">Log a message to the console.</p>
       <ControlField
+        disabled={disabled}
         label="Message"
         name="arguments.message"
         component="input"
@@ -18,3 +19,7 @@ export default function ConsoleLogFields() {
     </div>
   );
 }
+
+ConsoleLogFields.propTypes = {
+  disabled: pt.bool,
+};

--- a/recipe-server/client/control/components/action_fields/HeartbeatFields.js
+++ b/recipe-server/client/control/components/action_fields/HeartbeatFields.js
@@ -5,37 +5,42 @@ import { ControlField } from 'control/components/Fields';
 /**
  * Form fields for the show-heartbeat action.
  */
-export default function HeartbeatFields({ fields }) {
+export default function HeartbeatFields({ disabled, fields }) {
   return (
     <div className="arguments-fields">
       <p className="info">
         Shows a single message or survey prompt to the user.
       </p>
       <ControlField
+        disabled={disabled}
         label="Survey ID"
         name="arguments.surveyId"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Message"
         name="arguments.message"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Engagement Button Label"
         name="arguments.engagementButtonLabel"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Thanks Message"
         name="arguments.thanksMessage"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Post-Answer URL"
         name="arguments.postAnswerUrl"
         component="input"
@@ -43,12 +48,14 @@ export default function HeartbeatFields({ fields }) {
       />
 
       <ControlField
+        disabled={disabled}
         label="Learn More Message"
         name="arguments.learnMoreMessage"
         component="input"
         type="text"
       />
       <ControlField
+        disabled={disabled}
         label="Learn More URL"
         name="arguments.learnMoreUrl"
         component="input"
@@ -56,6 +63,7 @@ export default function HeartbeatFields({ fields }) {
       />
 
       <ControlField
+        disabled={disabled}
         label="How often should the prompt be shown?"
         name="arguments.repeatOption"
         component="select"
@@ -78,6 +86,7 @@ export default function HeartbeatFields({ fields }) {
         fields.repeatOption &&
         fields.repeatOption === 'xdays' &&
           <ControlField
+            disabled={disabled}
             label="Days before user is re-prompted"
             name="arguments.repeatEvery"
             component="input"
@@ -86,6 +95,7 @@ export default function HeartbeatFields({ fields }) {
       }
 
       <ControlField
+        disabled={disabled}
         label="Include unique user ID in Post-Answer URL (and Telemetry)"
         name="arguments.includeTelemetryUUID"
         component="input"
@@ -97,6 +107,7 @@ export default function HeartbeatFields({ fields }) {
 }
 
 HeartbeatFields.propTypes = {
+  disabled: pt.bool,
   fields: pt.object,
 };
 

--- a/recipe-server/client/control/reducers/RecipesReducer.js
+++ b/recipe-server/client/control/reducers/RecipesReducer.js
@@ -9,18 +9,28 @@ const initialState = {
   recipeListNeedsFetch: true,
 };
 
+// This is unnecessary once landed in master
+const dedupe = arr => {
+  const seen = {};
+  return arr.filter(({ id }) => {
+    const hasSeen = seen[id];
+    seen[id] = true;
+    return !hasSeen;
+  });
+};
+
 function recipesReducer(state = initialState, action) {
   switch (action.type) {
     case RECIPES_RECEIVED:
       return {
         ...state,
-        list: [].concat(state.list).concat(action.recipes),
+        list: dedupe(action.recipes.concat(state.list)),
         recipeListNeedsFetch: false,
       };
     case SINGLE_RECIPE_RECEIVED:
       return {
         ...state,
-        list: [].concat(state.list).concat([action.recipe]),
+        list: dedupe([action.recipe].concat(state.list)),
         recipeListNeedsFetch: true,
         selectedRecipe: action.recipe.id,
       };
@@ -34,10 +44,7 @@ function recipesReducer(state = initialState, action) {
     case RECIPE_ADDED:
       return {
         ...state,
-        list: [].concat(state.list).concat([
-          ...state.list || [],
-          action.recipe,
-        ]),
+        list: dedupe([action.recipe].concat(state.list)),
       };
     case RECIPE_UPDATED:
       return {

--- a/recipe-server/client/control/reducers/UserReducer.js
+++ b/recipe-server/client/control/reducers/UserReducer.js
@@ -1,0 +1,18 @@
+import {
+  RECEIVED_USER_INFO,
+} from 'control/actions/ControlActions';
+
+const initialState = {};
+
+function userReducer(state = initialState, action) {
+  switch (action.type) {
+
+    case RECEIVED_USER_INFO:
+      return { ...action.user };
+
+    default:
+      return state;
+  }
+}
+
+export default userReducer;

--- a/recipe-server/client/control/reducers/index.js
+++ b/recipe-server/client/control/reducers/index.js
@@ -9,12 +9,14 @@ import controlAppReducer from 'control/reducers/ControlAppReducer';
 import columnReducer from 'control/reducers/ColumnReducer';
 import recipesReducer from 'control/reducers/RecipesReducer';
 import notificationReducer from 'control/reducers/NotificationReducer';
+import userReducer from 'control/reducers/UserReducer';
 
 export default combineReducers({
   controlApp: controlAppReducer,
   recipes: recipesReducer,
   columns: columnReducer,
   notifications: notificationReducer,
+  user: userReducer,
   form: formReducer,
   routing: routerReducer,
 });

--- a/recipe-server/client/control/routes.js
+++ b/recipe-server/client/control/routes.js
@@ -56,6 +56,13 @@ export default (
           component={DeleteRecipe}
           name="Delete"
         />
+        <Route
+          path=":revisionId/"
+          component={RecipeForm}
+          ctaButtons={[
+            { text: 'History', icon: 'history', link: '../history/' },
+          ]}
+        />
       </Route>
     </Route>
     <Route path="*" component={NoMatch} />

--- a/recipe-server/client/control/sass/control.scss
+++ b/recipe-server/client/control/sass/control.scss
@@ -174,13 +174,8 @@
     padding: 30px 15px 15px;
 
     .delete {
-      background-color: $red;
       display: inline-block;
       float: left;
-
-      &:hover {
-        background-color: $redHover;
-      }
     }
 
     .submit {

--- a/recipe-server/client/control/sass/control.scss
+++ b/recipe-server/client/control/sass/control.scss
@@ -221,10 +221,12 @@
 
   .revision-number {
     font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     /* Force table cell to smallest width */
-    white-space: nowrap;
-    width: 1px;
+    width: 91px;
   }
 
   .status-indicator {

--- a/recipe-server/client/control/sass/partials/_common.scss
+++ b/recipe-server/client/control/sass/partials/_common.scss
@@ -123,11 +123,22 @@ a.button {
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.1);
   text-transform: uppercase;
 
+  &:disabled,
+  &:disabled:hover {
+    background-color: #7F9497;
+    color: $cream;
+  }
+
   &.delete {
     background-color: $red;
 
     &:hover {
       background-color: $redHover;
+    }
+
+    &:disabled,
+    &:disabled:hover {
+      background-color: #B58F8F;
     }
   }
 }
@@ -147,7 +158,7 @@ input[type="button"]:hover {
 
 .button:disabled {
   background: $grey;
-  cursor: wait;
+  cursor: not-allowed;
 }
 
 

--- a/recipe-server/client/control/sass/partials/_common.scss
+++ b/recipe-server/client/control/sass/partials/_common.scss
@@ -116,6 +116,7 @@ a.button {
   border: 0;
   border-radius: 0;
   color: #FFF;
+  display: inline-block;
   font: normal normal 600 13px/30px $OpenSans;
   padding: 10px 40px;
   text-align: center;
@@ -124,7 +125,6 @@ a.button {
 
   &.delete {
     background-color: $red;
-    display: inline-block;
 
     &:hover {
       background-color: $redHover;

--- a/recipe-server/client/control/tests/actions/test_controlActions.js
+++ b/recipe-server/client/control/tests/actions/test_controlActions.js
@@ -83,11 +83,11 @@ describe('controlApp Actions', () => {
   });
 
   it('makes a proper API request for fetchSingleRevision', () => {
-    fetchMock.get('/api/v1/recipe_version/169/', fixtureRecipes[0]);
+    fetchMock.get('/api/v1/recipe_revision/169/', fixtureRecipes[0]);
 
     return store.dispatch(actionTypes.makeApiRequest('fetchSingleRevision', { revisionId: 169 }))
     .then(() => {
-      expect(fetchMock.calls('/api/v1/recipe_version/169/').length).toEqual(1);
+      expect(fetchMock.calls('/api/v1/recipe_revision/169/').length).toEqual(1);
     });
   });
 

--- a/recipe-server/client/control/tests/actions/test_controlActions.js
+++ b/recipe-server/client/control/tests/actions/test_controlActions.js
@@ -64,6 +64,58 @@ describe('controlApp Actions', () => {
     });
   });
 
+  it('makes a proper API request for getCurrentUser', () => {
+    fetchMock.get('/api/v1/user/me/', {});
+
+    return store.dispatch(actionTypes.makeApiRequest('getCurrentUser'))
+    .then(() => {
+      expect(fetchMock.calls('/api/v1/user/me/').length).toEqual(1);
+    });
+  });
+
+  it('makes a proper API request for openApprovalRequest', () => {
+    fetchMock.post('/api/v1/recipe_revision/123/request_approval/', {});
+    return store.dispatch(actionTypes.makeApiRequest('openApprovalRequest', {
+      revisionId: 123,
+    }))
+      .then(() => {
+        expect(fetchMock.calls('/api/v1/recipe_revision/123/request_approval/').length).toEqual(1);
+      });
+  });
+
+  it('makes a proper API request for acceptApprovalRequest', () => {
+    fetchMock.post('/api/v1/approval_request/123/approve/', {});
+
+    return store.dispatch(actionTypes.makeApiRequest('acceptApprovalRequest', {
+      requestId: 123,
+    }))
+      .then(() => {
+        expect(fetchMock.calls('/api/v1/approval_request/123/approve/').length).toEqual(1);
+      });
+  });
+
+  it('makes a proper API request for rejectApprovalRequest', () => {
+    fetchMock.post('/api/v1/approval_request/123/reject/', {});
+
+    return store.dispatch(actionTypes.makeApiRequest('rejectApprovalRequest', {
+      requestId: 123,
+    }))
+      .then(() => {
+        expect(fetchMock.calls('/api/v1/approval_request/123/reject/').length).toEqual(1);
+      });
+  });
+
+  it('makes a proper API request for closeApprovalRequest', () => {
+    fetchMock.post('/api/v1/approval_request/123/close/', {});
+
+    return store.dispatch(actionTypes.makeApiRequest('closeApprovalRequest', {
+      requestId: 123,
+    }))
+      .then(() => {
+        expect(fetchMock.calls('/api/v1/approval_request/123/close/').length).toEqual(1);
+      });
+  });
+
   it('makes a proper API request for fetchAllRecipes', () => {
     fetchMock.get('/api/v1/recipe/', fixtureRecipes);
 

--- a/recipe-server/client/control/tests/components/test_RecipeForm.js
+++ b/recipe-server/client/control/tests/components/test_RecipeForm.js
@@ -13,7 +13,9 @@ import { recipeFactory } from '../../../tests/utils.js';
 function propFactory(props = {}) {
   return {
     handleSubmit: () => undefined,
+    dispatch: () => Promise.resolve(),
     submitting: false,
+    user: {},
     ...props,
   };
 }
@@ -31,21 +33,6 @@ describe('<RecipeForm>', () => {
     expect(wrapper.find(ConsoleLogFields).length).toBe(1);
   });
 
-  it('should render a delete button if editing an existing recipe', () => {
-    const recipe = recipeFactory();
-    const wrapper = shallow(
-      <RecipeForm recipeId={recipe.id} recipe={recipe} {...propFactory()} />
-    );
-    expect(wrapper.find('.delete').length).toBe(1);
-  });
-
-  it('should not render a delete button if creating a new recipe', () => {
-    const wrapper = shallow(
-      <RecipeForm {...propFactory()} />
-    );
-    expect(wrapper.find('.delete').length).toBe(0);
-  });
-
   it('should render a clone message if user is cloning', () => {
     const recipe = recipeFactory();
     const wrapper = shallow(
@@ -58,20 +45,6 @@ describe('<RecipeForm>', () => {
     );
     // message should exist
     expect(wrapper.find('.cloning-message').length).toBe(1);
-  });
-
-  it('should disable the submit button if currently submitting the form', () => {
-    const wrapper = shallow(
-      <RecipeForm {...propFactory({ submitting: true })} />
-    );
-    expect(wrapper.find('.submit').prop('disabled')).toBe(true);
-  });
-
-  it('should enable the submit button if not currently submitting the form', () => {
-    const wrapper = shallow(
-      <RecipeForm {...propFactory({ submitting: false })} />
-    );
-    expect(wrapper.find('.submit').prop('disabled')).toBe(false);
   });
 
   describe('asyncValidate', () => {

--- a/recipe-server/client/control/tests/components/test_RecipeFormActions.js
+++ b/recipe-server/client/control/tests/components/test_RecipeFormActions.js
@@ -12,7 +12,6 @@ const propFactory = props => ({
   isAlreadySaved: false,
   isFormPristine: false,
   isCloning: false,
-  isFormDisabled: false,
   recipeId: 12345,
   ...props,
 });
@@ -23,46 +22,10 @@ describe('<RecipeFormActions>', () => {
     expect(wrapper).not.toThrow();
   });
 
-
-  describe('Revert button', () => {
-    const displayCriteria = {
-      isUserViewingOutdated: true,
-      isFormPristine: true,
-    };
-
-    it('should NOT display when user is viewing a current revision', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isUserViewingOutdated: false,
-        })}
-      />);
-      expect(wrapper.find('.action-revert').length).toBe(0);
-    });
-
-    it('should NOT display when user is viewing an outdated revision with changes', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isUserViewingOutdated: true,
-          isFormPristine: false,
-        })}
-      />);
-      expect(wrapper.find('.action-revert').length).toBe(0);
-    });
-
-    it('should display when user is viewing an outdated, pristine revision', () => {
-      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
-      expect(wrapper.find('.action-revert').length).toBe(1);
-    });
-  });
-
-
   describe('Cancel button', () => {
     const displayCriteria = {
       isUserViewingOutdated: false,
       isPendingApproval: true,
-      isUserRequestor: true,
     };
 
     it('should fire a `cancel` action', () => {
@@ -97,82 +60,17 @@ describe('<RecipeFormActions>', () => {
       expect(wrapper.find('.action-cancel').length).toBe(0);
     });
 
-    it('should NOT display if user is not the approval requestor', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isUserRequestor: false,
-        })}
-      />);
-      expect(wrapper.find('.action-cancel').length).toBe(0);
-    });
-
     it('should display with proper criteria', () => {
       const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
       expect(wrapper.find('.action-cancel').length).toBe(1);
     });
   });
 
-
-  describe('Back to Latest/Review button', () => {
-    const displayCriteria = {
-      isUserViewingOutdated: true,
-      isCloning: false,
-    };
-
-    it('should NOT display when viewing the current revision', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isUserViewingOutdated: false,
-        })}
-      />);
-      expect(wrapper.find('.action-back').length).toBe(0);
-    });
-
-    it('should NOT display when user is cloning a recipe', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isCloning: true,
-        })}
-      />);
-      expect(wrapper.find('.action-back').length).toBe(0);
-    });
-
-    it('should display when viewing an outdated revision and NOT cloning', () => {
-      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
-      expect(wrapper.find('.action-back').length).toBe(1);
-    });
-
-    it('should read `Back to Latest` if no approval request is open', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isPendingApproval: false,
-        })}
-      />);
-      expect(wrapper.find('.action-back').text()).toBe('Back to Latest');
-    });
-
-    it('should read `Back to Review` if an approval request is open', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isPendingApproval: true,
-        })}
-      />);
-      expect(wrapper.find('.action-back').text()).toBe('Back to Review');
-    });
-  });
-
-
   describe('Approve + Reject Buttons', () => {
     const displayCriteria = {
       isUserViewingOutdated: false,
       isPendingApproval: true,
       isCloning: false,
-      isUserRequestor: false,
     };
 
     it('should fire an `approve` action', () => {
@@ -232,15 +130,15 @@ describe('<RecipeFormActions>', () => {
       expect(wrapper.find('.action-reject').length).toBe(0);
     });
 
-    it('should NOT display when user is the approval requestor', () => {
+    it('should NOT be enabled when user is the approval requestor', () => {
       const wrapper = mount(<RecipeFormActions
         {...propFactory({
           ...displayCriteria,
           isUserRequestor: true,
         })}
       />);
-      expect(wrapper.find('.action-approve').length).toBe(0);
-      expect(wrapper.find('.action-reject').length).toBe(0);
+      expect(wrapper.find('.action-approve').prop('disabled')).toBe(true);
+      expect(wrapper.find('.action-reject').prop('disabled')).toBe(true);
     });
 
     it('should display with proper criteria', () => {
@@ -253,31 +151,9 @@ describe('<RecipeFormActions>', () => {
 
   describe('Delete button', () => {
     const displayCriteria = {
-      isUserViewingOutdated: false,
-      isPendingApproval: false,
       isAlreadySaved: true,
       isCloning: false,
     };
-
-    it('should NOT display when viewing an outdated revision', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isUserViewingOutdated: true,
-        })}
-      />);
-      expect(wrapper.find('.action-delete').length).toBe(0);
-    });
-
-    it('should NOT display when there is an approval request open', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isPendingApproval: true,
-        })}
-      />);
-      expect(wrapper.find('.action-delete').length).toBe(0);
-    });
 
     it('should NOT display if the recipe is brand new and has not been saved yet', () => {
       const wrapper = mount(<RecipeFormActions
@@ -336,11 +212,11 @@ describe('<RecipeFormActions>', () => {
       expect(wrapper.find('.action-request').length).toBe(0);
     });
 
-    it('should NOT display when there is an approval request open', () => {
+    it('should NOT display when there is an approval request, at all', () => {
       const wrapper = mount(<RecipeFormActions
         {...propFactory({
           ...displayCriteria,
-          isPendingApproval: true,
+          hasApprovalRequest: true,
         })}
       />);
       expect(wrapper.find('.action-request').length).toBe(0);
@@ -366,14 +242,14 @@ describe('<RecipeFormActions>', () => {
       expect(wrapper.find('.action-request').length).toBe(0);
     });
 
-    it('should NOT display if user has edited the recipe form', () => {
+    it('should NOT be enabled if user has edited the recipe form', () => {
       const wrapper = mount(<RecipeFormActions
         {...propFactory({
           ...displayCriteria,
           isFormPristine: false,
         })}
       />);
-      expect(wrapper.find('.action-request').length).toBe(0);
+      expect(wrapper.find('.action-request').props().disabled).toBe(true);
     });
 
     it('should display with proper criteria', () => {
@@ -384,32 +260,9 @@ describe('<RecipeFormActions>', () => {
 
   describe('Save Draft button', () => {
     const displayCriteria = {
-      isUserViewingOutdated: false,
-      isPendingApproval: false,
       isAlreadySaved: true,
       isCloning: false,
-      isFormPristine: false,
     };
-
-    it('should NOT display when viewing an outdated revision', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isUserViewingOutdated: true,
-        })}
-      />);
-      expect(wrapper.find('.action-save').length).toBe(0);
-    });
-
-    it('should NOT display when there is an approval request open', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isPendingApproval: true,
-        })}
-      />);
-      expect(wrapper.find('.action-save').length).toBe(0);
-    });
 
     it('should NOT display if the recipe is brand new and has not been saved yet', () => {
       const wrapper = mount(<RecipeFormActions
@@ -421,7 +274,7 @@ describe('<RecipeFormActions>', () => {
       expect(wrapper.find('.action-save').length).toBe(0);
     });
 
-    it('should NOT display when user is cloning a recipe', () => {
+    it('should not display when user is cloning a recipe', () => {
       const wrapper = mount(<RecipeFormActions
         {...propFactory({
           ...displayCriteria,
@@ -431,14 +284,22 @@ describe('<RecipeFormActions>', () => {
       expect(wrapper.find('.action-save').length).toBe(0);
     });
 
-    it('should NOT display if user has NOT edited the recipe form', () => {
-      const wrapper = mount(<RecipeFormActions
+    it('should NOT be enabled if user has NOT edited the recipe form', () => {
+      let wrapper = mount(<RecipeFormActions
         {...propFactory({
           ...displayCriteria,
           isFormPristine: true,
         })}
       />);
-      expect(wrapper.find('.action-save').length).toBe(0);
+      expect(wrapper.find('.action-save').props().disabled).toBe(true);
+
+      wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isFormPristine: false,
+        })}
+      />);
+      expect(wrapper.find('.action-save').props().disabled).toBe(false);
     });
 
     it('should display with proper criteria', () => {
@@ -449,38 +310,15 @@ describe('<RecipeFormActions>', () => {
 
   describe('New Recipe button', () => {
     const displayCriteria = {
-      isCloning: false,
-      isPendingApproval: false,
       isAlreadySaved: false,
-      // include the negation of the second criteria to prevent accidental passes
-      isUserViewingOutdated: false,
-      isFormPristine: true,
-    };
-    // - or -
-    const otherDisplayCriteria = {
-      isUserViewingOutdated: true,
-      isFormPristine: false,
-      // include the negation of the first criteria to prevent accidental passes
       isCloning: true,
-      isPendingApproval: true,
-      isAlreadySaved: true,
     };
 
-    it('should NOT display when user is cloning a recipe', () => {
+    it('should NOT display when user is NOT cloning a recipe', () => {
       const wrapper = mount(<RecipeFormActions
         {...propFactory({
-          ...displayCriteria,
-          isCloning: true,
-        })}
-      />);
-      expect(wrapper.find('.action-new').length).toBe(0);
-    });
-
-    it('should NOT display when there is an approval request open', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isPendingApproval: true,
+          isAlreadySaved: true,
+          isCloning: false,
         })}
       />);
       expect(wrapper.find('.action-new').length).toBe(0);
@@ -489,39 +327,15 @@ describe('<RecipeFormActions>', () => {
     it('should NOT display if the recipe already exists in the DB', () => {
       const wrapper = mount(<RecipeFormActions
         {...propFactory({
-          ...displayCriteria,
           isAlreadySaved: true,
+          isCloning: false,
         })}
       />);
       expect(wrapper.find('.action-new').length).toBe(0);
     });
 
-    // other criteria
-    it('should NOT display when user is viewing a current revision', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...otherDisplayCriteria,
-          isUserViewingOutdated: false,
-        })}
-      />);
-      expect(wrapper.find('.action-new').length).toBe(0);
-    });
-
-    it('should NOT display when user has not edited the form', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...otherDisplayCriteria,
-          isFormPristine: true,
-        })}
-      />);
-      expect(wrapper.find('.action-new').length).toBe(0);
-    });
-
-    it('should display if either display criteria is met', () => {
-      let wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
-      expect(wrapper.find('.action-new').length).toBe(1);
-
-      wrapper = mount(<RecipeFormActions {...propFactory(otherDisplayCriteria)} />);
+    it('should display if display criteria is met', () => {
+      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
       expect(wrapper.find('.action-new').length).toBe(1);
     });
   });

--- a/recipe-server/client/control/tests/components/test_RecipeFormActions.js
+++ b/recipe-server/client/control/tests/components/test_RecipeFormActions.js
@@ -1,0 +1,528 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { mount } from 'enzyme';
+
+import RecipeFormActions from 'control/components/RecipeFormActions';
+
+const propFactory = props => ({
+  onAction: () => {},
+  isUserViewingOutdated: false,
+  isPendingApproval: false,
+  isUserRequestor: false,
+  isAlreadySaved: false,
+  isFormPristine: false,
+  isCloning: false,
+  isFormDisabled: false,
+  recipeId: 12345,
+  ...props,
+});
+
+describe('<RecipeFormActions>', () => {
+  it('should work', () => {
+    const wrapper = () => mount(<RecipeFormActions {...propFactory()} />);
+    expect(wrapper).not.toThrow();
+  });
+
+
+  describe('Revert button', () => {
+    const displayCriteria = {
+      isUserViewingOutdated: true,
+      isFormPristine: true,
+    };
+
+    it('should NOT display when user is viewing a current revision', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserViewingOutdated: false,
+        })}
+      />);
+      expect(wrapper.find('.action-revert').length).toBe(0);
+    });
+
+    it('should NOT display when user is viewing an outdated revision with changes', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserViewingOutdated: true,
+          isFormPristine: false,
+        })}
+      />);
+      expect(wrapper.find('.action-revert').length).toBe(0);
+    });
+
+    it('should display when user is viewing an outdated, pristine revision', () => {
+      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
+      expect(wrapper.find('.action-revert').length).toBe(1);
+    });
+  });
+
+
+  describe('Cancel button', () => {
+    const displayCriteria = {
+      isUserViewingOutdated: false,
+      isPendingApproval: true,
+      isUserRequestor: true,
+    };
+
+    it('should fire a `cancel` action', () => {
+      let firedType;
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          onAction: type => { firedType = type; },
+        })}
+      />);
+      wrapper.find('.action-cancel').simulate('click');
+      expect(firedType).toBe('cancel');
+    });
+
+    it('should NOT display when viewing outdated revision', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserViewingOutdated: true,
+        })}
+      />);
+      expect(wrapper.find('.action-cancel').length).toBe(0);
+    });
+
+    it('should NOT display when no approval request exists', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isPendingApproval: false,
+        })}
+      />);
+      expect(wrapper.find('.action-cancel').length).toBe(0);
+    });
+
+    it('should NOT display if user is not the approval requestor', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserRequestor: false,
+        })}
+      />);
+      expect(wrapper.find('.action-cancel').length).toBe(0);
+    });
+
+    it('should display with proper criteria', () => {
+      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
+      expect(wrapper.find('.action-cancel').length).toBe(1);
+    });
+  });
+
+
+  describe('Back to Latest/Review button', () => {
+    const displayCriteria = {
+      isUserViewingOutdated: true,
+      isCloning: false,
+    };
+
+    it('should NOT display when viewing the current revision', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserViewingOutdated: false,
+        })}
+      />);
+      expect(wrapper.find('.action-back').length).toBe(0);
+    });
+
+    it('should NOT display when user is cloning a recipe', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isCloning: true,
+        })}
+      />);
+      expect(wrapper.find('.action-back').length).toBe(0);
+    });
+
+    it('should display when viewing an outdated revision and NOT cloning', () => {
+      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
+      expect(wrapper.find('.action-back').length).toBe(1);
+    });
+
+    it('should read `Back to Latest` if no approval request is open', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isPendingApproval: false,
+        })}
+      />);
+      expect(wrapper.find('.action-back').text()).toBe('Back to Latest');
+    });
+
+    it('should read `Back to Review` if an approval request is open', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isPendingApproval: true,
+        })}
+      />);
+      expect(wrapper.find('.action-back').text()).toBe('Back to Review');
+    });
+  });
+
+
+  describe('Approve + Reject Buttons', () => {
+    const displayCriteria = {
+      isUserViewingOutdated: false,
+      isPendingApproval: true,
+      isCloning: false,
+      isUserRequestor: false,
+    };
+
+    it('should fire an `approve` action', () => {
+      let firedType;
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          onAction: type => { firedType = type; },
+        })}
+      />);
+      wrapper.find('.action-approve').simulate('click');
+      expect(firedType).toBe('approve');
+    });
+
+    it('should fire a `reject` action', () => {
+      let firedType;
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          onAction: type => { firedType = type; },
+        })}
+      />);
+      wrapper.find('.action-reject').simulate('click');
+      expect(firedType).toBe('reject');
+    });
+
+    it('should NOT display when viewing an outdated revision', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserViewingOutdated: true,
+        })}
+      />);
+      expect(wrapper.find('.action-approve').length).toBe(0);
+      expect(wrapper.find('.action-reject').length).toBe(0);
+    });
+
+    it('should NOT display when there is no approval request open', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isPendingApproval: false,
+        })}
+      />);
+      expect(wrapper.find('.action-approve').length).toBe(0);
+      expect(wrapper.find('.action-reject').length).toBe(0);
+    });
+
+    it('should NOT display when user is cloning a recipe', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isCloning: true,
+        })}
+      />);
+      expect(wrapper.find('.action-approve').length).toBe(0);
+      expect(wrapper.find('.action-reject').length).toBe(0);
+    });
+
+    it('should NOT display when user is the approval requestor', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserRequestor: true,
+        })}
+      />);
+      expect(wrapper.find('.action-approve').length).toBe(0);
+      expect(wrapper.find('.action-reject').length).toBe(0);
+    });
+
+    it('should display with proper criteria', () => {
+      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
+      expect(wrapper.find('.action-approve').length).toBe(1);
+      expect(wrapper.find('.action-reject').length).toBe(1);
+    });
+  });
+
+
+  describe('Delete button', () => {
+    const displayCriteria = {
+      isUserViewingOutdated: false,
+      isPendingApproval: false,
+      isAlreadySaved: true,
+      isCloning: false,
+    };
+
+    it('should NOT display when viewing an outdated revision', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserViewingOutdated: true,
+        })}
+      />);
+      expect(wrapper.find('.action-delete').length).toBe(0);
+    });
+
+    it('should NOT display when there is an approval request open', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isPendingApproval: true,
+        })}
+      />);
+      expect(wrapper.find('.action-delete').length).toBe(0);
+    });
+
+    it('should NOT display if the recipe is brand new and has not been saved yet', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isAlreadySaved: false,
+        })}
+      />);
+      expect(wrapper.find('.action-delete').length).toBe(0);
+    });
+
+    it('should NOT display when user is cloning a recipe', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isCloning: true,
+        })}
+      />);
+      expect(wrapper.find('.action-delete').length).toBe(0);
+    });
+
+    it('should display with proper criteria', () => {
+      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
+      expect(wrapper.find('.action-delete').length).toBe(1);
+    });
+  });
+
+  describe('Request Approval button', () => {
+    const displayCriteria = {
+      isUserViewingOutdated: false,
+      isPendingApproval: false,
+      isAlreadySaved: true,
+      isCloning: false,
+      isFormPristine: true,
+    };
+
+    it('should fire a `request` action', () => {
+      let firedType;
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          onAction: type => { firedType = type; },
+        })}
+      />);
+      wrapper.find('.action-request').simulate('click');
+      expect(firedType).toBe('request');
+    });
+
+    it('should NOT display when viewing an outdated revision', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserViewingOutdated: true,
+        })}
+      />);
+      expect(wrapper.find('.action-request').length).toBe(0);
+    });
+
+    it('should NOT display when there is an approval request open', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isPendingApproval: true,
+        })}
+      />);
+      expect(wrapper.find('.action-request').length).toBe(0);
+    });
+
+    it('should NOT display if the recipe is brand new and has not been saved yet', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isAlreadySaved: false,
+        })}
+      />);
+      expect(wrapper.find('.action-request').length).toBe(0);
+    });
+
+    it('should NOT display when user is cloning a recipe', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isCloning: true,
+        })}
+      />);
+      expect(wrapper.find('.action-request').length).toBe(0);
+    });
+
+    it('should NOT display if user has edited the recipe form', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isFormPristine: false,
+        })}
+      />);
+      expect(wrapper.find('.action-request').length).toBe(0);
+    });
+
+    it('should display with proper criteria', () => {
+      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
+      expect(wrapper.find('.action-request').length).toBe(1);
+    });
+  });
+
+  describe('Save Draft button', () => {
+    const displayCriteria = {
+      isUserViewingOutdated: false,
+      isPendingApproval: false,
+      isAlreadySaved: true,
+      isCloning: false,
+      isFormPristine: false,
+    };
+
+    it('should NOT display when viewing an outdated revision', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isUserViewingOutdated: true,
+        })}
+      />);
+      expect(wrapper.find('.action-save').length).toBe(0);
+    });
+
+    it('should NOT display when there is an approval request open', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isPendingApproval: true,
+        })}
+      />);
+      expect(wrapper.find('.action-save').length).toBe(0);
+    });
+
+    it('should NOT display if the recipe is brand new and has not been saved yet', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isAlreadySaved: false,
+        })}
+      />);
+      expect(wrapper.find('.action-save').length).toBe(0);
+    });
+
+    it('should NOT display when user is cloning a recipe', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isCloning: true,
+        })}
+      />);
+      expect(wrapper.find('.action-save').length).toBe(0);
+    });
+
+    it('should NOT display if user has NOT edited the recipe form', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isFormPristine: true,
+        })}
+      />);
+      expect(wrapper.find('.action-save').length).toBe(0);
+    });
+
+    it('should display with proper criteria', () => {
+      const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
+      expect(wrapper.find('.action-save').length).toBe(1);
+    });
+  });
+
+  describe('New Recipe button', () => {
+    const displayCriteria = {
+      isCloning: false,
+      isPendingApproval: false,
+      isAlreadySaved: false,
+      // include the negation of the second criteria to prevent accidental passes
+      isUserViewingOutdated: false,
+      isFormPristine: true,
+    };
+    // - or -
+    const otherDisplayCriteria = {
+      isUserViewingOutdated: true,
+      isFormPristine: false,
+      // include the negation of the first criteria to prevent accidental passes
+      isCloning: true,
+      isPendingApproval: true,
+      isAlreadySaved: true,
+    };
+
+    it('should NOT display when user is cloning a recipe', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isCloning: true,
+        })}
+      />);
+      expect(wrapper.find('.action-new').length).toBe(0);
+    });
+
+    it('should NOT display when there is an approval request open', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isPendingApproval: true,
+        })}
+      />);
+      expect(wrapper.find('.action-new').length).toBe(0);
+    });
+
+    it('should NOT display if the recipe already exists in the DB', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...displayCriteria,
+          isAlreadySaved: true,
+        })}
+      />);
+      expect(wrapper.find('.action-new').length).toBe(0);
+    });
+
+    // other criteria
+    it('should NOT display when user is viewing a current revision', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...otherDisplayCriteria,
+          isUserViewingOutdated: false,
+        })}
+      />);
+      expect(wrapper.find('.action-new').length).toBe(0);
+    });
+
+    it('should NOT display when user has not edited the form', () => {
+      const wrapper = mount(<RecipeFormActions
+        {...propFactory({
+          ...otherDisplayCriteria,
+          isFormPristine: true,
+        })}
+      />);
+      expect(wrapper.find('.action-new').length).toBe(0);
+    });
+
+    it('should display if either display criteria is met', () => {
+      let wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);
+      expect(wrapper.find('.action-new').length).toBe(1);
+
+      wrapper = mount(<RecipeFormActions {...propFactory(otherDisplayCriteria)} />);
+      expect(wrapper.find('.action-new').length).toBe(1);
+    });
+  });
+});

--- a/recipe-server/client/control/tests/fixtures.js
+++ b/recipe-server/client/control/tests/fixtures.js
@@ -5,6 +5,7 @@ export const fixtureRecipes = [
 ];
 
 export const initialState = {
+  user: {},
   controlApp: {
     isFetching: false,
   },

--- a/recipe-server/client/control/tests/reducers/test_userReducer.js
+++ b/recipe-server/client/control/tests/reducers/test_userReducer.js
@@ -1,0 +1,31 @@
+import appReducer from 'control/reducers';
+import { RECEIVED_USER_INFO } from 'control/actions/ControlActions';
+
+import {
+  initialState,
+} from 'control/tests/fixtures';
+
+/**
+ * Column reducer tests
+ */
+describe('User reducer', () => {
+  it('should return initial state by default', () => {
+    expect(appReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle RECEIVED_USER_INFO', () => {
+    const exampleUser = {
+      id: 2716057,
+      first_name: 'Bender',
+      last_name: 'Rodriguez',
+    };
+
+    expect(appReducer(undefined, {
+      type: RECEIVED_USER_INFO,
+      user: exampleUser,
+    })).toEqual({
+      ...initialState,
+      user: exampleUser,
+    });
+  });
+});


### PR DESCRIPTION
Related to #489 

- Adds "action buttons" to recipe form based on current user/draft state (is user viewing old draft, is there a review open, is the user the one that opened the review, etc)
  - Adds `RecipeFormActions`, `FormButton` components
  - `RecipeFormActions` reports events to `RecipeForm`, which carries out the selected action
- Adds API calls for managing reviews
- Removes `?revisionId=...` query param business, replaces with proper route (`/recipe/:id/:revisionId`)
- Disables form fields when appropriate (form is actively submitting, viewing an in-review recipe)

Caveats:
- The app is often confused over what is the 'latest' draft. Loading a recipe directly (e.g. `/recipe/10`) is fine, but when loading a revision directly (`/recipe/10/e642b6...`) the app sets the recipe's "current revision" to whatever was loaded. *Note:* this will be resolved in another PR, in which revisions are saved to the redux store
- ~Tests are failing~
- ~Current user ID is not being looked up yet~