### PR TITLE
Fix #544: Correctly send parameters passed to NormandyApi.

### DIFF
--- a/recipe-client-addon/lib/NormandyApi.jsm
+++ b/recipe-client-addon/lib/NormandyApi.jsm
@@ -24,7 +24,7 @@ this.NormandyApi = {
     method = method.toLowerCase();
 
     let body = undefined;
-    if (data !== undefined) {
+    if (data) {
       if (method === "get") {
         for (const key of Object.keys(data)) {
           url.searchParams.set(key, data[key]);

--- a/recipe-client-addon/lib/NormandyApi.jsm
+++ b/recipe-client-addon/lib/NormandyApi.jsm
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-/* globals URLSearchParams */
 
 "use strict";
 
@@ -20,25 +19,23 @@ const prefs = Services.prefs.getBranch("extensions.shield-recipe-client.");
 let indexPromise;
 
 this.NormandyApi = {
-  apiCall(method, url, data = {}) {
+  apiCall(method, endpoint, data = {}) {
+    const url = new URL(endpoint);
     method = method.toLowerCase();
 
-    if (method === "get") {
-      if (data === {}) {
-        const paramObj = new URLSearchParams();
-        for (const key in data) {
-          paramObj.append(key, data[key]);
+    let body = undefined;
+    if (data !== undefined) {
+      if (method === "get") {
+        for (const key of Object.keys(data)) {
+          url.searchParams.set(key, data[key]);
         }
-        url += "?" + paramObj.toString();
+      } else if (method === "post") {
+        body = JSON.stringify(data);
       }
-      data = undefined;
     }
 
     const headers = {"Accept": "application/json"};
-    return fetch(url, {
-      body: JSON.stringify(data),
-      headers,
-    });
+    return fetch(url.href, {method, body, headers});
   },
 
   get(endpoint, data) {

--- a/recipe-client-addon/lib/NormandyApi.jsm
+++ b/recipe-client-addon/lib/NormandyApi.jsm
@@ -42,6 +42,10 @@ this.NormandyApi = {
     return this.apiCall("get", endpoint, data);
   },
 
+  post(endpoint, data) {
+    return this.apiCall("post", endpoint, data);
+  },
+
   absolutify(url) {
     const apiBase = prefs.getCharPref("api_url");
     const server = new URL(apiBase).origin;

--- a/recipe-client-addon/test/browser/test_server.sjs
+++ b/recipe-client-addon/test/browser/test_server.sjs
@@ -1,8 +1,0 @@
-function handleRequest(request, response) {
-  // Allow cross-origin, so you can XHR to it!
-  response.setHeader("Access-Control-Allow-Origin", "*", false);
-  // Avoid confusing cache behaviors
-  response.setHeader("Cache-Control", "no-cache", false);
-  response.setHeader("Content-Type", "application/json", false);
-  response.write(JSON.stringify({test: "data"}))
-}

--- a/recipe-client-addon/test/unit/test_NormandyApi.js
+++ b/recipe-client-addon/test/unit/test_NormandyApi.js
@@ -112,3 +112,37 @@ add_task(withServer(function* test_fetchAction() {
   const action = yield NormandyApi.fetchAction("show-heartbeat");
   equal(action.name, "show-heartbeat");
 }));
+
+add_task(function* () {
+  // Point the add-on to the test server.
+  const prefManager = new PrefManager();
+  prefManager.setCharPref(
+    "extensions.shield-recipe-client.api_url",
+    "http://test/browser/browser/extensions/shield-recipe-client/test"
+  );
+
+  try {
+    // Test that NormandyApi can fetch from the test server.
+    let response = yield NormandyApi.get("unit/test_server.sjs");
+    let data = yield response.json();
+    Assert.deepEqual(data, {queryString: {}, body: {}}, "NormandyApi returned incorrect server data.");
+
+    // Test that NormandyApi can send query string parameters to the test server.
+    response = yield NormandyApi.get("unit/test_server.sjs", {foo: "bar", baz: "biff"});
+    data = yield response.json();
+    Assert.deepEqual(
+      data, {queryString: {foo: "bar", baz: "biff"}, body: {}},
+      "NormandyApi sent an incorrect query string."
+    );
+
+    // Test that NormandyApi can POST JSON-formatted data to the test server.
+    response = yield NormandyApi.post("unit/test_server.sjs", {foo: "bar", baz: "biff"});
+    data = yield response.json();
+    Assert.deepEqual(
+      data, {queryString: {}, body: {foo: "bar", baz: "biff"}},
+      "NormandyApi sent an incorrect query string."
+    );
+  } finally {
+    prefManager.cleanup();
+  }
+});

--- a/recipe-client-addon/test/unit/test_NormandyApi.js
+++ b/recipe-client-addon/test/unit/test_NormandyApi.js
@@ -21,8 +21,8 @@ class PrefManager {
   }
 
   cleanup() {
-    for (const name of this.oldValues) {
-      Services.setCharPref(name, this.oldValues[name]);
+    for (const name of Object.keys(this.oldValues)) {
+      Services.prefs.setCharPref(name, this.oldValues[name]);
     }
   }
 }

--- a/recipe-client-addon/test/unit/test_NormandyApi.js
+++ b/recipe-client-addon/test/unit/test_NormandyApi.js
@@ -27,9 +27,8 @@ class PrefManager {
   }
 }
 
-function withServer(task) {
+function withServer(server, task) {
   return function* inner() {
-    const server = makeMockApiServer();
     const serverUrl = `http://localhost:${server.identity.primaryPort}`;
     const prefManager = new PrefManager();
     prefManager.setCharPref("extensions.shield-recipe-client.api_url", `${serverUrl}/api/v1`);
@@ -46,6 +45,18 @@ function withServer(task) {
       yield new Promise(resolve => server.stop(resolve));
     }
   };
+}
+
+function makeScriptServer(scriptPath) {
+  const server = new HttpServer();
+  server.registerContentType("sjs", "sjs");
+  server.registerFile("/", do_get_file(scriptPath));
+  server.start(-1);
+  return server;
+}
+
+function withScriptServer(scriptPath, task) {
+  return withServer(makeScriptServer(scriptPath), task);
 }
 
 function makeMockApiServer() {
@@ -80,27 +91,31 @@ function makeMockApiServer() {
   return server;
 }
 
-add_task(withServer(function* test_get(serverUrl) {
+function withMockApiServer(task) {
+  return withServer(makeMockApiServer(), task);
+}
+
+add_task(withMockApiServer(function* test_get(serverUrl) {
   // Test that NormandyApi can fetch from the test server.
   const response = yield NormandyApi.get(`${serverUrl}/api/v1`);
   const data = yield response.json();
   equal(data["recipe-list"], "/api/v1/recipe/", "Expected data in response");
 }));
 
-add_task(withServer(function* test_getApiUrl(serverUrl) {
+add_task(withMockApiServer(function* test_getApiUrl(serverUrl) {
   const apiBase = `${serverUrl}/api/v1`;
   // Test that NormandyApi can use the self-describing API's index
   const recipeListUrl = yield NormandyApi.getApiUrl("action-list");
   equal(recipeListUrl, `${apiBase}/action/`, "Can retrieve action-list URL from API");
 }));
 
-add_task(withServer(function* test_fetchRecipes() {
+add_task(withMockApiServer(function* test_fetchRecipes() {
   const recipes = yield NormandyApi.fetchRecipes();
   equal(recipes.length, 1);
   equal(recipes[0].name, "system-addon-test");
 }));
 
-add_task(withServer(function* test_classifyClient() {
+add_task(withMockApiServer(function* test_classifyClient() {
   const classification = yield NormandyApi.classifyClient();
   Assert.deepEqual(classification, {
     country: "US",
@@ -108,41 +123,34 @@ add_task(withServer(function* test_classifyClient() {
   });
 }));
 
-add_task(withServer(function* test_fetchAction() {
+add_task(withMockApiServer(function* test_fetchAction() {
   const action = yield NormandyApi.fetchAction("show-heartbeat");
   equal(action.name, "show-heartbeat");
 }));
 
-add_task(function* () {
-  // Point the add-on to the test server.
-  const prefManager = new PrefManager();
-  prefManager.setCharPref(
-    "extensions.shield-recipe-client.api_url",
-    "http://test/browser/browser/extensions/shield-recipe-client/test"
+add_task(withScriptServer("test_server.sjs", function* test_getTestServer(serverUrl) {
+  // Test that NormandyApi can fetch from the test server.
+  const response = yield NormandyApi.get(serverUrl);
+  const data = yield response.json();
+  Assert.deepEqual(data, {queryString: {}, body: {}}, "NormandyApi returned incorrect server data.");
+}));
+
+add_task(withScriptServer("test_server.sjs", function* test_getQueryString(serverUrl) {
+  // Test that NormandyApi can send query string parameters to the test server.
+  const response = yield NormandyApi.get(serverUrl, {foo: "bar", baz: "biff"});
+  const data = yield response.json();
+  Assert.deepEqual(
+    data, {queryString: {foo: "bar", baz: "biff"}, body: {}},
+    "NormandyApi sent an incorrect query string."
   );
+}));
 
-  try {
-    // Test that NormandyApi can fetch from the test server.
-    let response = yield NormandyApi.get("unit/test_server.sjs");
-    let data = yield response.json();
-    Assert.deepEqual(data, {queryString: {}, body: {}}, "NormandyApi returned incorrect server data.");
-
-    // Test that NormandyApi can send query string parameters to the test server.
-    response = yield NormandyApi.get("unit/test_server.sjs", {foo: "bar", baz: "biff"});
-    data = yield response.json();
-    Assert.deepEqual(
-      data, {queryString: {foo: "bar", baz: "biff"}, body: {}},
-      "NormandyApi sent an incorrect query string."
-    );
-
-    // Test that NormandyApi can POST JSON-formatted data to the test server.
-    response = yield NormandyApi.post("unit/test_server.sjs", {foo: "bar", baz: "biff"});
-    data = yield response.json();
-    Assert.deepEqual(
-      data, {queryString: {}, body: {foo: "bar", baz: "biff"}},
-      "NormandyApi sent an incorrect query string."
-    );
-  } finally {
-    prefManager.cleanup();
-  }
-});
+add_task(withScriptServer("test_server.sjs", function* test_postData(serverUrl) {
+  // Test that NormandyApi can POST JSON-formatted data to the test server.
+  const response = yield NormandyApi.post(serverUrl,  {foo: "bar", baz: "biff"});
+  const data = yield response.json();
+  Assert.deepEqual(
+    data, {queryString: {}, body: {foo: "bar", baz: "biff"}},
+    "NormandyApi sent an incorrect query string."
+  );
+}));

--- a/recipe-client-addon/test/unit/test_server.sjs
+++ b/recipe-client-addon/test/unit/test_server.sjs
@@ -1,0 +1,30 @@
+const CC = Components.Constructor;
+const BinaryInputStream = CC("@mozilla.org/binaryinputstream;1", "nsIBinaryInputStream", "setInputStream");
+
+// Returns a JSON string containing the query string arguments and the
+// request body parsed as JSON.
+function handleRequest(request, response) {
+  // Allow cross-origin, so you can XHR to it!
+  response.setHeader("Access-Control-Allow-Origin", "*", false);
+  // Avoid confusing cache behaviors
+  response.setHeader("Cache-Control", "no-cache", false);
+  response.setHeader("Content-Type", "application/json", false);
+
+  // Read request body
+  const inputStream = new BinaryInputStream(request.bodyInputStream);
+  const bytes = [];
+  let available;
+  while ((available = inputStream.available()) > 0) {
+    Array.prototype.push.apply(bytes, inputStream.readByteArray(available));
+  }
+  const body = String.fromCharCode.apply(null, bytes);
+
+  // Write response body
+  const data = {queryString: {}, body: body ? JSON.parse(body) : {}};
+  const params = request.queryString.split("&");
+  for (const param of params) {
+    const [key, value] = param.split("=");
+    data.queryString[key] = value;
+  }
+  response.write(JSON.stringify(data));
+}

--- a/recipe-client-addon/test/unit/test_server.sjs
+++ b/recipe-client-addon/test/unit/test_server.sjs
@@ -12,10 +12,10 @@ function handleRequest(request, response) {
 
   // Read request body
   const inputStream = new BinaryInputStream(request.bodyInputStream);
-  const bytes = [];
+  let bytes = [];
   let available;
   while ((available = inputStream.available()) > 0) {
-    Array.prototype.push.apply(bytes, inputStream.readByteArray(available));
+    bytes = bytes.concat(inputStream.readByteArray(available));
   }
   const body = String.fromCharCode.apply(null, bytes);
 

--- a/recipe-client-addon/test/unit/xpcshell.ini
+++ b/recipe-client-addon/test/unit/xpcshell.ini
@@ -2,6 +2,7 @@
 head = xpc_head.js
 support-files =
   mock_api/**
+  test_server.sjs
 
 [test_NormandyApi.js]
 [test_Sampling.js]


### PR DESCRIPTION
Updates NormandyApi.jsm to send request parameters correctly as query
string arguments for GET requests and as JSON-encoded data in the
request body for POST requests.