### PR TITLE
Add missing filter expression context to add-on.

### DIFF
--- a/docs/dev/driver.rst
+++ b/docs/dev/driver.rst
@@ -120,19 +120,6 @@ The driver object contains the following attributes:
       collision with other actions using the storage.
    :returns: :js:class:`Storage`
 
-.. js:function:: location()
-
-   Retrieves information about where the user is located.
-
-   :returns: A Promise that resolves with a location object.
-
-   The location object has the following fields:
-
-   countryCode
-      ISO 3166-1 country code for the country the user has been geolocated to.
-
-.. _Input Documentation: http://fjord.readthedocs.org/en/latest/hb_api.html
-
 .. js:function:: client()
 
    Retrieves information about the user's browser.

--- a/docs/dev/feature-experiments.rst
+++ b/docs/dev/feature-experiments.rst
@@ -1,0 +1,19 @@
+Feature Experiments
+===================
+This document describes the feature experiments that are currently implemented
+across the Normandy project, and how to enable them.
+
+Recipe Client Add-on
+--------------------
+
+Lazy Client Classification
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+By default, the recipe client makes a request to an endpoint on the recipe
+server to calculate some info about the user that we don't trust the client to
+determine, such as geolocation or the current server time. Normally, this
+happens on startup; enabling this experiment makes the client only make the
+classification request if a recipe actually uses the info for filtering.
+
+To enable, create a new boolean preference called
+``extensions.shield-recipe-client.experiments.lazy_classify`` and set it to
+true.

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -16,3 +16,4 @@ development environment for it.
    functional-tests
    mock-recipe-server
    code-style
+   feature-experiments

--- a/docs/user/filter_expressions.rst
+++ b/docs/user/filter_expressions.rst
@@ -206,6 +206,10 @@ filter expressions.
    .. _Telemetry: http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/index.html
    .. _Telemetry data documentation: http://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/data/index.html
 
+.. js:attribute:: normandy.doNotTrack
+
+   Boolean specifying whether the user has enabled Do Not Track.
+
 Transforms
 ----------
 This section describes the transforms available to filter expressions, and what

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -78,7 +78,7 @@ this.shutdown = function(data, reason) {
 
   const modules = [
     "lib/CleanupManager.jsm",
-    "lib/EnvExpressions.jsm",
+    "lib/FilterExpressions.jsm",
     "lib/EventEmitter.jsm",
     "lib/Heartbeat.jsm",
     "lib/LogManager.jsm",

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -78,6 +78,7 @@ this.shutdown = function(data, reason) {
 
   const modules = [
     "lib/CleanupManager.jsm",
+    "lib/ClientEnvironment.jsm",
     "lib/FilterExpressions.jsm",
     "lib/EventEmitter.jsm",
     "lib/Heartbeat.jsm",

--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -22,14 +22,22 @@ this.EXPORTED_SYMBOLS = ["ClientEnvironment"];
 // Cached API request for client attributes that are determined by the Normandy
 // service.
 let _classifyRequest = null;
-const getClientClassification = Task.async(function *() {
-  if (!_classifyRequest) {
-    _classifyRequest = NormandyApi.classifyClient();
-  }
-  return yield _classifyRequest;
-});
 
 this.ClientEnvironment = {
+  /**
+   * Fetches information about the client that is calculated on the server,
+   * like geolocation and the current time.
+   *
+   * The server request is made lazily and is cached for the entire browser
+   * session.
+   */
+  getClientClassification: Task.async(function *() {
+    if (!_classifyRequest) {
+      _classifyRequest = NormandyApi.classifyClient();
+    }
+    return yield _classifyRequest;
+  }),
+
   /**
    * Test wrapper that mocks the server request for classifying the client.
    * @param  {Object}   data          Fake server data to use
@@ -69,11 +77,13 @@ this.ClientEnvironment = {
     });
 
     XPCOMUtils.defineLazyGetter(environment, "country", () => {
-      return getClientClassification().then(classification => classification.country);
+      return ClientEnvironment.getClientClassification()
+        .then(classification => classification.country);
     });
 
     XPCOMUtils.defineLazyGetter(environment, "request_time", () => {
-      return getClientClassification().then(classification => classification.request_time);
+      return ClientEnvironment.getClientClassification()
+        .then(classification => classification.request_time);
     });
 
     XPCOMUtils.defineLazyGetter(environment, "distribution", () => {

--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -6,10 +6,10 @@
 
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 Cu.import("resource://gre/modules/Preferences.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Task.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "Services", "resource:///modules/Services.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "ShellService", "resource:///modules/ShellService.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "AddonManager", "resource://gre/modules/AddonManager.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "TelemetryArchive", "resource://gre/modules/TelemetryArchive.jsm");

--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+Cu.import("resource://gre/modules/Preferences.jsm");
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/Task.jsm");
+Cu.import("resource://gre/modules/TelemetryArchive.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm");
+
+const {generateUUID} = Cc["@mozilla.org/uuid-generator;1"].getService(Ci.nsIUUIDGenerator);
+
+this.EXPORTED_SYMBOLS = ["ClientEnvironment"];
+
+const prefs = Services.prefs.getBranch("extensions.shield-recipe-client.");
+
+// Cached API request for client attributes that are determined by the Normandy
+// service.
+let _classifyRequest = null;
+const getClientClassification = Task.async(function *() {
+  if (!_classifyRequest) {
+    _classifyRequest = NormandyApi.classifyClient();
+  }
+  return yield _classifyRequest;
+});
+
+this.ClientEnvironment = {
+  /**
+   * Test wrapper that mocks the server request for classifying the client.
+   * @param  {Object}   data          Fake server data to use
+   * @param  {Function} testGenerator Test generator to execute while mock data is in effect.
+   */
+  withMockClassify(data, testGenerator) {
+    return function* inner() {
+      const oldRequest = _classifyRequest;
+      _classifyRequest = Promise.resolve(data);
+      yield testGenerator();
+      _classifyRequest = oldRequest;
+    };
+  },
+
+  /**
+   * Create an object that provides general information about the client application.
+   *
+   * RecipeRunner.jsm uses this as part of the context for filter expressions,
+   * so avoid adding non-getter functions as attributes, as filter expressions
+   * cannot execute functions.
+   *
+   * Also note that, because filter expressions implicitly resolve promises, you
+   * can add getter functions that return promises for async data.
+   * @return {Object}
+   */
+  getEnvironment() {
+    const environment = {};
+
+    XPCOMUtils.defineLazyGetter(environment, "userId", () => {
+      let id = prefs.getCharPref("user_id");
+      if (id === "") {
+        // generateUUID adds leading and trailing "{" and "}". strip them off.
+        id = generateUUID().toString().slice(1, -1);
+        prefs.setCharPref("user_id", id);
+      }
+      return id;
+    });
+
+    XPCOMUtils.defineLazyGetter(environment, "country", () => {
+      return getClientClassification().then(classification => classification.country);
+    });
+
+    XPCOMUtils.defineLazyGetter(environment, "request_time", () => {
+      return getClientClassification().then(classification => classification.request_time);
+    });
+
+    XPCOMUtils.defineLazyGetter(environment, "distribution", () => {
+      return Preferences.get("distribution.id", "default");
+    });
+
+    XPCOMUtils.defineLazyGetter(environment, "telemetry", () => {
+      return Task.spawn(function *() {
+        const pings = yield TelemetryArchive.promiseArchivedPingList();
+
+        // get most recent ping per type
+        const mostRecentPings = {};
+        for (const ping of pings) {
+          if (ping.type in mostRecentPings) {
+            if (mostRecentPings[ping.type].timeStampCreated < ping.timeStampCreated) {
+              mostRecentPings[ping.type] = ping;
+            }
+          } else {
+            mostRecentPings[ping.type] = ping;
+          }
+        }
+
+        const telemetry = {};
+        for (const key in mostRecentPings) {
+          const ping = mostRecentPings[key];
+          telemetry[ping.type] = yield TelemetryArchive.promiseArchivedPingById(ping.id);
+        }
+        return telemetry;
+      });
+    });
+
+    return environment;
+  },
+};

--- a/recipe-client-addon/lib/FilterExpressions.jsm
+++ b/recipe-client-addon/lib/FilterExpressions.jsm
@@ -14,7 +14,7 @@ Cu.import("resource://shield-recipe-client/lib/Sampling.jsm");
 
 const {generateUUID} = Cc["@mozilla.org/uuid-generator;1"].getService(Ci.nsIUUIDGenerator);
 
-this.EXPORTED_SYMBOLS = ["EnvExpressions"];
+this.EXPORTED_SYMBOLS = ["FilterExpressions"];
 
 const prefs = Services.prefs.getBranch("extensions.shield-recipe-client.");
 
@@ -39,7 +39,7 @@ XPCOMUtils.defineLazyGetter(this, "jexl", () => {
   return jexl;
 });
 
-this.EnvExpressions = {
+this.FilterExpressions = {
   getLatestTelemetry: Task.async(function *() {
     const pings = yield TelemetryArchive.promiseArchivedPingList();
 
@@ -77,10 +77,10 @@ this.EnvExpressions = {
     // First clone the extra context
     const context = Object.assign({normandy: {}}, extraContext);
     // jexl handles promises, so it is fine to include them in this data.
-    context.telemetry = EnvExpressions.getLatestTelemetry();
+    context.telemetry = FilterExpressions.getLatestTelemetry();
 
     context.normandy = Object.assign(context.normandy, {
-      userId: EnvExpressions.getUserId(),
+      userId: FilterExpressions.getUserId(),
       distribution: Preferences.get("distribution.id", "default"),
     });
 

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -127,11 +127,6 @@ this.NormandyDriver = function(sandboxManager, extraContext = {}) {
       return storage;
     },
 
-    location() {
-      const location = Cu.cloneInto({countryCode: extraContext.country}, sandbox);
-      return sandbox.Promise.resolve(location);
-    },
-
     setTimeout(cb, time) {
       if (typeof cb !== "function") {
         throw new sandbox.Error(`setTimeout must be called with a function, got "${typeof cb}"`);

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -15,7 +15,7 @@ Cu.import("resource://gre/modules/Timer.jsm"); /* globals setTimeout, clearTimeo
 Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 Cu.import("resource://shield-recipe-client/lib/Storage.jsm");
 Cu.import("resource://shield-recipe-client/lib/Heartbeat.jsm");
-Cu.import("resource://shield-recipe-client/lib/EnvExpressions.jsm");
+Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm");
 
 const {generateUUID} = Cc["@mozilla.org/uuid-generator;1"].getService(Ci.nsIUUIDGenerator);
 
@@ -40,7 +40,7 @@ this.NormandyDriver = function(sandboxManager, extraContext = {}) {
     },
 
     get userId() {
-      return EnvExpressions.getUserId();
+      return FilterExpressions.getUserId();
     },
 
     log(message, level = "debug") {

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -16,6 +16,7 @@ Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 Cu.import("resource://shield-recipe-client/lib/Storage.jsm");
 Cu.import("resource://shield-recipe-client/lib/Heartbeat.jsm");
 Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm");
+Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm");
 
 const {generateUUID} = Cc["@mozilla.org/uuid-generator;1"].getService(Ci.nsIUUIDGenerator);
 
@@ -24,7 +25,7 @@ this.EXPORTED_SYMBOLS = ["NormandyDriver"];
 const log = LogManager.getLogger("normandy-driver");
 const actionLog = LogManager.getLogger("normandy-driver.actions");
 
-this.NormandyDriver = function(sandboxManager, extraContext = {}) {
+this.NormandyDriver = function(sandboxManager) {
   if (!sandboxManager) {
     throw new Error("sandboxManager is required");
   }
@@ -40,7 +41,7 @@ this.NormandyDriver = function(sandboxManager, extraContext = {}) {
     },
 
     get userId() {
-      return FilterExpressions.getUserId();
+      return ClientEnvironment.getEnvironment().userId;
     },
 
     log(message, level = "debug") {

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -14,7 +14,10 @@ Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm");
 Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm");
 Cu.import("resource://shield-recipe-client/lib/SandboxManager.jsm");
 Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["fetch"]); /* globals fetch */
+
+XPCOMUtils.defineLazyModuleGetter(this, "Preferences", "resource://gre/modules/Preferences.jsm");
 
 this.EXPORTED_SYMBOLS = ["RecipeRunner"];
 
@@ -60,6 +63,11 @@ this.RecipeRunner = {
   },
 
   start: Task.async(function* () {
+    // Unless lazy classification is enabled, prep the classify cache.
+    if (!Preferences.get("extensions.shield-recipe-client.experiments.lazy_classify", false)) {
+      yield ClientEnvironment.getClientClassification();
+    }
+
     let recipes;
     try {
       recipes = yield NormandyApi.fetchRecipes({enabled: true});

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -10,7 +10,7 @@ Cu.import("resource://gre/modules/Timer.jsm"); /* globals setTimeout */
 Cu.import("resource://gre/modules/Task.jsm");
 Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 Cu.import("resource://shield-recipe-client/lib/NormandyDriver.jsm");
-Cu.import("resource://shield-recipe-client/lib/EnvExpressions.jsm");
+Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm");
 Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm");
 Cu.import("resource://shield-recipe-client/lib/SandboxManager.jsm");
 Cu.importGlobalProperties(["fetch"]); /* globals fetch */
@@ -111,7 +111,7 @@ this.RecipeRunner = {
    * @return {boolean} The result of evaluating the filter, cast to a bool.
    */
   checkFilter(recipe, extraContext) {
-    return EnvExpressions.eval(recipe.filter_expression, extraContext)
+    return FilterExpressions.eval(recipe.filter_expression, extraContext)
       .then(result => {
         return !!result;
       })

--- a/recipe-client-addon/test/browser/.eslintrc.js
+++ b/recipe-client-addon/test/browser/.eslintrc.js
@@ -9,5 +9,10 @@ module.exports = {
     SpecialPowers: false,
     SimpleTest: false,
     registerCleanupFunction: false,
+    window: false,
+    sinon: false,
+    Cu: false,
+    Ci: false,
+    Cc: false,
   },
 };

--- a/recipe-client-addon/test/browser/Utils.jsm
+++ b/recipe-client-addon/test/browser/Utils.jsm
@@ -27,48 +27,4 @@ this.Utils = {
       yield testGenerator(driver);
     });
   },
-
-  /**
-   * Test wrapper that replaces a property on an object with another value for
-   * the duration of the test. The test generator is passed the replaced value.
-   */
-  withPatch(object, propertyName, patchValue, testGenerator) {
-    return function* inner() {
-      const original = object[propertyName];
-      object[propertyName] = patchValue;
-      yield testGenerator(patchValue);
-      object[propertyName] = original;
-    };
-  },
-
-  /**
-   * Creates a wrapper function that tracks whether it has been called.
-   */
-  createMock(wrapped) {
-    const mock = function(...args) {
-      mock.called = true;
-      if ("returnValue" in mock) {
-        return mock.returnValue;
-      }
-      return wrapped(...args);
-    };
-    mock.called = false;
-    mock.reset = function() {
-      mock.called = false;
-    };
-
-    return mock;
-  },
-
-  /**
-   * Test wrapper that wraps a function on an object with a mock value.
-   */
-  withMock(object, propertyName, testGenerator) {
-    return this.withPatch(
-      object,
-      propertyName,
-      this.createMock(object[propertyName]),
-      testGenerator
-    );
-  },
 };

--- a/recipe-client-addon/test/browser/browser.ini
+++ b/recipe-client-addon/test/browser/browser.ini
@@ -5,3 +5,4 @@
 [browser_Heartbeat.js]
 [browser_RecipeRunner.js]
 [browser_LogManager.js]
+[browser_ClientEnvironment.js]

--- a/recipe-client-addon/test/browser/browser.ini
+++ b/recipe-client-addon/test/browser/browser.ini
@@ -1,5 +1,5 @@
 [browser_NormandyDriver.js]
-[browser_EnvExpressions.js]
+[browser_FilterExpressions.js]
 [browser_EventEmitter.js]
 [browser_Storage.js]
 [browser_Heartbeat.js]

--- a/recipe-client-addon/test/browser/browser.ini
+++ b/recipe-client-addon/test/browser/browser.ini
@@ -1,3 +1,5 @@
+[DEFAULT]
+head = head.js
 [browser_NormandyDriver.js]
 [browser_FilterExpressions.js]
 [browser_EventEmitter.js]

--- a/recipe-client-addon/test/browser/browser_ClientEnvironment.js
+++ b/recipe-client-addon/test/browser/browser_ClientEnvironment.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.import("resource://gre/modules/TelemetryController.jsm", this);
 Cu.import("resource://gre/modules/Task.jsm", this);

--- a/recipe-client-addon/test/browser/browser_ClientEnvironment.js
+++ b/recipe-client-addon/test/browser/browser_ClientEnvironment.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const {utils: Cu} = Components;
+Cu.import("resource://gre/modules/Preferences.jsm");
+Cu.import("resource://gre/modules/TelemetryController.jsm", this);
+Cu.import("resource://gre/modules/Task.jsm", this);
+
+Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm", this);
+Cu.import("resource://shield-recipe-client/test/browser/Utils.jsm", this);
+
+add_task(function* testTelemetry() {
+  // setup
+  yield TelemetryController.submitExternalPing("testfoo", {foo: 1});
+  yield TelemetryController.submitExternalPing("testbar", {bar: 2});
+  const environment = ClientEnvironment.getEnvironment();
+
+  // Test it can access telemetry
+  const telemetry = yield environment.telemetry;
+  is(typeof telemetry, "object", "Telemetry is accesible");
+
+  // Test it reads different types of telemetry
+  is(telemetry.testfoo.payload.foo, 1, "value 'foo' is in mock telemetry");
+  is(telemetry.testbar.payload.bar, 2, "value 'bar' is in mock telemetry");
+});
+
+add_task(function* testUserId() {
+  let environment = ClientEnvironment.getEnvironment();
+
+  // Test that userId is available
+  ok(Utils.UUID_REGEX.test(environment.userId), "userId available");
+
+  // test that it pulls from the right preference
+  yield SpecialPowers.pushPrefEnv({set: [["extensions.shield-recipe-client.user_id", "fake id"]]});
+  environment = ClientEnvironment.getEnvironment();
+  is(environment.userId, "fake id", "userId is pulled from preferences");
+});
+
+add_task(function* testDistribution() {
+  let environment = ClientEnvironment.getEnvironment();
+
+  // distribution id defaults to "default"
+  is(environment.distribution, "default", "distribution has a default value");
+
+  // distribution id is read from a preference
+  yield SpecialPowers.pushPrefEnv({set: [["distribution.id", "funnelcake"]]});
+  environment = ClientEnvironment.getEnvironment();
+  is(environment.distribution, "funnelcake", "distribution is read from preferences");
+});
+
+const mockClassify = {country: "FR", request_time: new Date(2017, 1, 1)};
+add_task(ClientEnvironment.withMockClassify(mockClassify, function* testCountryRequestTime() {
+  const environment = ClientEnvironment.getEnvironment();
+
+  // Test that country and request_time pull their data from the server.
+  is(yield environment.country, mockClassify.country, "country is read from the server API");
+  is(
+    yield environment.request_time, mockClassify.request_time,
+    "request_time is read from the server API"
+  );
+}));

--- a/recipe-client-addon/test/browser/browser_ClientEnvironment.js
+++ b/recipe-client-addon/test/browser/browser_ClientEnvironment.js
@@ -58,3 +58,33 @@ add_task(ClientEnvironment.withMockClassify(mockClassify, function* testCountryR
     "request_time is read from the server API"
   );
 }));
+
+add_task(function* testSync() {
+  let environment = ClientEnvironment.getEnvironment();
+  is(environment.syncMobileDevices, 0, "syncMobileDevices defaults to zero");
+  is(environment.syncDesktopDevices, 0, "syncDesktopDevices defaults to zero");
+  is(environment.syncTotalDevices, 0, "syncTotalDevices defaults to zero");
+  yield SpecialPowers.pushPrefEnv({
+    set: [
+      ["services.sync.numClients", 9],
+      ["services.sync.clients.devices.mobile", 5],
+      ["services.sync.clients.devices.desktop", 4],
+    ],
+  });
+  environment = ClientEnvironment.getEnvironment();
+  is(environment.syncMobileDevices, 5, "syncMobileDevices is read when set");
+  is(environment.syncDesktopDevices, 4, "syncDesktopDevices is read when set");
+  is(environment.syncTotalDevices, 9, "syncTotalDevices is read when set");
+});
+
+add_task(function* testDoNotTrack() {
+  let environment = ClientEnvironment.getEnvironment();
+
+  // doNotTrack defaults to false
+  ok(!environment.doNotTrack, "doNotTrack has a default value");
+
+  // doNotTrack is read from a preference
+  yield SpecialPowers.pushPrefEnv({set: [["privacy.donottrackheader.enabled", true]]});
+  environment = ClientEnvironment.getEnvironment();
+  ok(environment.doNotTrack, "doNotTrack is read from preferences");
+});

--- a/recipe-client-addon/test/browser/browser_EventEmitter.js
+++ b/recipe-client-addon/test/browser/browser_EventEmitter.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const {utils: Cu} = Components;
 Cu.import("resource://shield-recipe-client/test/browser/Utils.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/EventEmitter.jsm", this);
 

--- a/recipe-client-addon/test/browser/browser_FilterExpressions.js
+++ b/recipe-client-addon/test/browser/browser_FilterExpressions.js
@@ -5,7 +5,7 @@ Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.import("resource://gre/modules/TelemetryController.jsm", this);
 Cu.import("resource://gre/modules/Task.jsm", this);
 
-Cu.import("resource://shield-recipe-client/lib/EnvExpressions.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm", this);
 Cu.import("resource://shield-recipe-client/test/browser/Utils.jsm", this);
 
 add_task(function* () {
@@ -15,11 +15,11 @@ add_task(function* () {
 
   let val;
   // Test that basic expressions work
-  val = yield EnvExpressions.eval("2+2");
+  val = yield FilterExpressions.eval("2+2");
   is(val, 4, "basic expression works");
 
   // Test that multiline expressions work
-  val = yield EnvExpressions.eval(`
+  val = yield FilterExpressions.eval(`
     2
     +
     2
@@ -27,68 +27,68 @@ add_task(function* () {
   is(val, 4, "multiline expression works");
 
   // Test it can access telemetry
-  val = yield EnvExpressions.eval("telemetry");
+  val = yield FilterExpressions.eval("telemetry");
   is(typeof val, "object", "Telemetry is accesible");
 
   // Test it reads different types of telemetry
-  val = yield EnvExpressions.eval("telemetry");
+  val = yield FilterExpressions.eval("telemetry");
   is(val.testfoo.payload.foo, 1, "value 'foo' is in mock telemetry");
   is(val.testbar.payload.bar, 2, "value 'bar' is in mock telemetry");
 
   // Test has a date transform
-  val = yield EnvExpressions.eval('"2016-04-22"|date');
+  val = yield FilterExpressions.eval('"2016-04-22"|date');
   const d = new Date(Date.UTC(2016, 3, 22)); // months are 0 based
   is(val.toString(), d.toString(), "Date transform works");
 
   // Test dates are comparable
   const context = {someTime: Date.UTC(2016, 0, 1)};
-  val = yield EnvExpressions.eval('"2015-01-01"|date < someTime', context);
+  val = yield FilterExpressions.eval('"2015-01-01"|date < someTime', context);
   ok(val, "dates are comparable with less-than");
-  val = yield EnvExpressions.eval('"2017-01-01"|date > someTime', context);
+  val = yield FilterExpressions.eval('"2017-01-01"|date > someTime', context);
   ok(val, "dates are comparable with greater-than");
 
   // Test stable sample returns true for matching samples
-  val = yield EnvExpressions.eval('["test"]|stableSample(1)');
+  val = yield FilterExpressions.eval('["test"]|stableSample(1)');
   is(val, true, "Stable sample returns true for 100% sample");
 
   // Test stable sample returns true for matching samples
-  val = yield EnvExpressions.eval('["test"]|stableSample(0)');
+  val = yield FilterExpressions.eval('["test"]|stableSample(0)');
   is(val, false, "Stable sample returns false for 0% sample");
 
   // Test stable sample for known samples
-  val = yield EnvExpressions.eval('["test-1"]|stableSample(0.5)');
+  val = yield FilterExpressions.eval('["test-1"]|stableSample(0.5)');
   is(val, true, "Stable sample returns true for a known sample");
-  val = yield EnvExpressions.eval('["test-4"]|stableSample(0.5)');
+  val = yield FilterExpressions.eval('["test-4"]|stableSample(0.5)');
   is(val, false, "Stable sample returns false for a known sample");
 
   // Test bucket sample for known samples
-  val = yield EnvExpressions.eval('["test-1"]|bucketSample(0, 5, 10)');
+  val = yield FilterExpressions.eval('["test-1"]|bucketSample(0, 5, 10)');
   is(val, true, "Bucket sample returns true for a known sample");
-  val = yield EnvExpressions.eval('["test-4"]|bucketSample(0, 5, 10)');
+  val = yield FilterExpressions.eval('["test-4"]|bucketSample(0, 5, 10)');
   is(val, false, "Bucket sample returns false for a known sample");
 
   // Test that userId is available
-  val = yield EnvExpressions.eval("normandy.userId");
+  val = yield FilterExpressions.eval("normandy.userId");
   ok(Utils.UUID_REGEX.test(val), "userId available");
 
   // test that it pulls from the right preference
   yield SpecialPowers.pushPrefEnv({set: [["extensions.shield-recipe-client.user_id", "fake id"]]});
-  val = yield EnvExpressions.eval("normandy.userId");
+  val = yield FilterExpressions.eval("normandy.userId");
   Assert.equal(val, "fake id", "userId is pulled from preferences");
 
   // test that it merges context correctly, `userId` comes from the default context, and
   // `injectedValue` comes from us. Expect both to be on the final `normandy` object.
-  val = yield EnvExpressions.eval(
+  val = yield FilterExpressions.eval(
     "[normandy.userId, normandy.injectedValue]",
     {normandy: {injectedValue: "injected"}});
   Assert.deepEqual(val, ["fake id", "injected"], "context is correctly merged");
 
   // distribution id defaults to "default"
-  val = yield EnvExpressions.eval("normandy.distribution");
+  val = yield FilterExpressions.eval("normandy.distribution");
   Assert.equal(val, "default", "distribution has a default value");
 
   // distribution id is in the context
   yield SpecialPowers.pushPrefEnv({set: [["distribution.id", "funnelcake"]]});
-  val = yield EnvExpressions.eval("normandy.distribution");
+  val = yield FilterExpressions.eval("normandy.distribution");
   Assert.equal(val, "funnelcake", "distribution is read from preferences");
 });

--- a/recipe-client-addon/test/browser/browser_FilterExpressions.js
+++ b/recipe-client-addon/test/browser/browser_FilterExpressions.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const {utils: Cu} = Components;
 Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm", this);
 
 add_task(function* () {

--- a/recipe-client-addon/test/browser/browser_Heartbeat.js
+++ b/recipe-client-addon/test/browser/browser_Heartbeat.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const {utils: Cu} = Components;
-
 Cu.import("resource://gre/modules/Services.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/Heartbeat.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/SandboxManager.jsm", this);

--- a/recipe-client-addon/test/browser/browser_LogManager.js
+++ b/recipe-client-addon/test/browser/browser_LogManager.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const {utils: Cu} = Components;
-
 Cu.import("resource://gre/modules/Log.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/LogManager.jsm", this);
 

--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const {utils: Cu} = Components;
 Cu.import("resource://shield-recipe-client/test/browser/Utils.jsm", this);
 Cu.import("resource://gre/modules/Console.jsm", this);
 

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const {utils: Cu} = Components;
-Cu.import("resource://shield-recipe-client/test/browser/Utils.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/RecipeRunner.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm", this);
 
@@ -125,27 +123,26 @@ add_task(function* checkFilter() {
   ok(yield check("[1, 2, 3]"), "Non-boolean filter expressions return true");
 });
 
-add_task(
-  Utils.withMock(ClientEnvironment, "getClientClassification",
-    function* testStart(mockGet) {
-      mockGet.returnValue = Promise.resolve(false);
+add_task(function* testStart() {
+  const getStub = sinon.stub(ClientEnvironment, "getClientClassification")
+    .returns(Promise.resolve(false));
 
-      // When the experiment pref is false, eagerly call getClientClassification.
-      yield SpecialPowers.pushPrefEnv({set: [
-        ["extensions.shield-recipe-client.experiments.lazy_classify", false],
-      ]});
-      ok(!mockGet.called, "getClientClassification hasn't been called");
-      yield RecipeRunner.start();
-      ok(mockGet.called, "getClientClassfication was called eagerly");
+  // When the experiment pref is false, eagerly call getClientClassification.
+  yield SpecialPowers.pushPrefEnv({set: [
+    ["extensions.shield-recipe-client.experiments.lazy_classify", false],
+  ]});
+  ok(!getStub.called, "getClientClassification hasn't been called");
+  yield RecipeRunner.start();
+  ok(getStub.called, "getClientClassfication was called eagerly");
 
-      // When the experiment pref is true, do not eagerly call getClientClassification.
-      yield SpecialPowers.pushPrefEnv({set: [
-        ["extensions.shield-recipe-client.experiments.lazy_classify", true],
-      ]});
-      mockGet.reset();
-      ok(!mockGet.called, "getClientClassification hasn't been called");
-      yield RecipeRunner.start();
-      ok(!mockGet.called, "getClientClassfication was not called eagerly");
-    }
-  )
-);
+  // When the experiment pref is true, do not eagerly call getClientClassification.
+  yield SpecialPowers.pushPrefEnv({set: [
+    ["extensions.shield-recipe-client.experiments.lazy_classify", true],
+  ]});
+  getStub.reset();
+  ok(!getStub.called, "getClientClassification hasn't been called");
+  yield RecipeRunner.start();
+  ok(!getStub.called, "getClientClassfication was not called eagerly");
+
+  getStub.restore();
+});

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -91,11 +91,22 @@ add_task(function* getFilterContext() {
 
   // Test for expected properties in the filter expression context.
   const expectedNormandyKeys = [
+    "channel",
     "country",
     "distribution",
+    "doNotTrack",
+    "isDefaultBrowser",
+    "locale",
+    "plugins",
     "request_time",
+    "searchEngine",
+    "syncDesktopDevices",
+    "syncMobileDevices",
+    "syncSetup",
+    "syncTotalDevices",
     "telemetry",
     "userId",
+    "version",
   ];
   for (const key of expectedNormandyKeys) {
     ok(key in context.normandy, `normandy.${key} is available`);

--- a/recipe-client-addon/test/browser/browser_Storage.js
+++ b/recipe-client-addon/test/browser/browser_Storage.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const {utils: Cu} = Components;
 Cu.import("resource://shield-recipe-client/lib/Storage.jsm", this);
 
 const fakeSandbox = {Promise};

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -1,0 +1,13 @@
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+
+// Load mocking/stubbing library, sinon
+// docs: http://sinonjs.org/docs/
+const loader = Cc["@mozilla.org/moz/jssubscript-loader;1"].getService(Ci.mozIJSSubScriptLoader);
+loader.loadSubScript("resource://testing-common/sinon-1.16.1.js");
+
+registerCleanupFunction(function*() {
+  // Cleanup window or the test runner will throw an error
+  delete window.sinon;
+  delete window.setImmediate;
+  delete window.clearImmediate;
+});

--- a/recipe-server/client/actions/show-heartbeat/index.js
+++ b/recipe-server/client/actions/show-heartbeat/index.js
@@ -247,7 +247,6 @@ export default class ShowHeartbeatAction extends Action {
       return;
     }
 
-    this.location = await this.normandy.location();
     this.client = await this.normandy.client();
 
     // pull some data to attach to the telemetry business

--- a/recipe-server/client/selfrepair/normandy_driver.js
+++ b/recipe-server/client/selfrepair/normandy_driver.js
@@ -142,11 +142,6 @@ export default class NormandyDriver {
     this._testingOverride = value;
   }
 
-  _location = { countryCode: null };
-  location() {
-    return Promise.resolve(this._location);
-  }
-
   log(message, level = 'debug') {
     if (level === 'debug' && !this.testing) {
       return;


### PR DESCRIPTION
So #539 and #540 only point out two of them, but the add-on is missing a significant amount of client environment info in the filter expression context. Luckily all of them are already implemented in the driver, so I just had to steal them from there.

When I started on this, I couldn't figure out where I wanted to add all this new data to the filter expression context, which led to the first three commits, which refactor things so that:

- `FilterExpressions.jsm` (formerly `EnvExpressions.jsm`) doesn't provide any default context, and only cares about evaluating expressions. Well, okay, there's still the filter functions, but we can handle that in another PR.
- The logic for figuring out info about the client environment is separated into the `ClientEnvironment.jsm` file.

The last commit actually adds the missing info to the filter expression context. I tried to add tests for most of them, but I'm stumped on how to mock some of them (like plugins). Others (like the appinfo stuff) don't seem to have a meaningful test. I'm pretty sure this PR still net-increases our test coverage, but suggestions on this are welcome.

One potential side effect of this PR is that it makes it so that clients don't hit the classify-client endpoint if there aren't any recipes enabled that use country or request_time filters. Which means a single database change can have a huge effect on our traffic. @relud: Are large swings in traffic to the classify endpoint something we specifically want to avoid? I can change this to consistently hit the server even if we're not using the data from it.