### PR TITLE
Add `revision` property to Recipes store

### DIFF
--- a/recipe-server/client/control/actions/ControlActions.js
+++ b/recipe-server/client/control/actions/ControlActions.js
@@ -189,10 +189,9 @@ function singleRecipeReceived(recipe) {
   };
 }
 
-function singleRevisionReceived({ revision, recipeId }) {
+function singleRevisionReceived({ revision }) {
   return {
     type: SINGLE_REVISION_RECEIVED,
-    recipeId,
     revision,
   };
 }

--- a/recipe-server/client/control/actions/ControlActions.js
+++ b/recipe-server/client/control/actions/ControlActions.js
@@ -3,6 +3,7 @@ export const REQUEST_COMPLETE = 'REQUEST_COMPLETE';
 
 export const RECIPES_RECEIVED = 'RECIPES_RECEIVED';
 export const SINGLE_RECIPE_RECEIVED = 'SINGLE_RECIPE_RECEIVED';
+export const SINGLE_REVISION_RECEIVED = 'SINGLE_REVISION_RECEIVED';
 
 export const SET_SELECTED_RECIPE = 'SET_SELECTED_RECIPE';
 export const SHOW_NOTIFICATION = 'SHOW_NOTIFICATION';
@@ -188,6 +189,14 @@ function singleRecipeReceived(recipe) {
   };
 }
 
+function singleRevisionReceived({ revision, recipeId }) {
+  return {
+    type: SINGLE_REVISION_RECEIVED,
+    recipeId,
+    revision,
+  };
+}
+
 function recipeAdded(recipe) {
   return {
     type: RECIPE_ADDED,
@@ -270,6 +279,7 @@ export {
   userInfoReceived,
   recipesReceived,
   singleRecipeReceived,
+  singleRevisionReceived,
   setSelectedRecipe,
   showNotification,
   dismissNotification,

--- a/recipe-server/client/control/components/RecipeContainer.js
+++ b/recipe-server/client/control/components/RecipeContainer.js
@@ -1,7 +1,11 @@
 import React, { PropTypes as pt } from 'react';
 import { connect } from 'react-redux';
-import { makeApiRequest, singleRecipeReceived, setSelectedRecipe }
-  from 'control/actions/ControlActions';
+import {
+  makeApiRequest,
+  singleRecipeReceived,
+  singleRevisionReceived,
+  setSelectedRecipe,
+} from 'control/actions/ControlActions';
 
 export default function composeRecipeContainer(Component) {
   class RecipeContainer extends React.Component {
@@ -17,29 +21,46 @@ export default function composeRecipeContainer(Component) {
       }
     }
 
-    componentWillReceiveProps({ recipeId }) {
-      if (recipeId && recipeId !== this.props.recipeId) {
-        this.getRecipeData(recipeId);
+    componentWillReceiveProps({ recipeId, routeParams = {} }) {
+      const isRecipeChanging = recipeId !== this.props.recipeId;
+      const isRouteRevisionChanging =
+        routeParams.revisionId !== this.props.routeParams.revisionId;
+
+      if (recipeId && isRecipeChanging) {
+        this.getRecipeData(recipeId, routeParams && routeParams.revisionId);
+      }
+      if (routeParams.revisionId && isRouteRevisionChanging) {
+        this.getRecipeRevision(routeParams.revisionId);
       }
     }
 
-    getRecipeData(recipeId) {
-      const { dispatch, recipe, routeParams } = this.props;
+    getRecipeData(recipeId, revisionId) {
+      const { dispatch, routeParams, recipe } = this.props;
       if (!recipe) {
         dispatch(setSelectedRecipe(recipeId));
 
-        if (routeParams.revisionId) {
-          dispatch(makeApiRequest('fetchSingleRevision', { revisionId: routeParams.revisionId }))
-          .then(revision => {
-            dispatch(singleRecipeReceived(revision.recipe));
-          });
-        } else {
-          dispatch(makeApiRequest('fetchSingleRecipe', { recipeId }))
-          .then(newRecipe => {
-            dispatch(singleRecipeReceived(newRecipe));
-          });
-        }
+        // always get the latest
+        dispatch(makeApiRequest('fetchSingleRecipe', { recipeId }))
+        .then(newRecipe => {
+          dispatch(singleRecipeReceived(newRecipe));
+          // get a specific revision, if specified
+          if (revisionId || routeParams.revisionId) {
+            this.getRecipeRevision(revisionId || routeParams.revisionId);
+          }
+        });
       }
+    }
+
+    getRecipeRevision(revisionId) {
+      const { dispatch } = this.props;
+
+      return dispatch(makeApiRequest('fetchSingleRevision', { revisionId }))
+        .then(revision => {
+          dispatch(singleRevisionReceived({
+            revision,
+            recipeId: revision.recipe.id,
+          }));
+        });
     }
 
     render() {
@@ -49,14 +70,39 @@ export default function composeRecipeContainer(Component) {
 
   const mapStateToProps = (state, props) => {
     let recipeData = null;
-    if (state.recipes && state.recipes.list.length) {
-      recipeData = state.recipes.list
-        .find(recipe => recipe.id === state.recipes.selectedRecipe);
-    }
+    let revisionData = null;
+    const selectedRecipeId = state.recipes && state.recipes.selectedRecipe;
+    let selectedRevisionId = props.routeParams && props.routeParams.revisionId;
 
+    const revReference = state.recipes.revisions[selectedRecipeId] || {};
+
+    if (selectedRecipeId) {
+      recipeData = state.recipes.list
+        .find(recipe => recipe.id === selectedRecipeId);
+
+      // If there is a selected revision, attempt to pull that info.
+      if (!selectedRevisionId) {
+        // If there is _not_ a selected revision, default to the latest
+        let latestId = -1;
+
+        for (const revisionId in revReference) {
+          if (revReference[revisionId].id > latestId) {
+            latestId = revReference[revisionId].revision_id;
+          }
+        }
+        selectedRevisionId = revReference[latestId] && revReference[latestId].revision_id;
+      }
+
+      revisionData = revReference[selectedRevisionId];
+
+      if (!revisionData) {
+        recipeData = null;
+      }
+    }
     return {
       recipeId: state.recipes.selectedRecipe || parseInt(props.params.id, 10) || null,
       recipe: recipeData,
+      revision: revisionData,
       dispatch: props.dispatch,
     };
   };

--- a/recipe-server/client/control/components/RecipeContainer.js
+++ b/recipe-server/client/control/components/RecipeContainer.js
@@ -56,10 +56,7 @@ export default function composeRecipeContainer(Component) {
 
       return dispatch(makeApiRequest('fetchSingleRevision', { revisionId }))
         .then(revision => {
-          dispatch(singleRevisionReceived({
-            revision,
-            recipeId: revision.recipe.id,
-          }));
+          dispatch(singleRevisionReceived({ revision }));
         });
     }
 
@@ -69,40 +66,40 @@ export default function composeRecipeContainer(Component) {
   }
 
   const mapStateToProps = (state, props) => {
-    let recipeData = null;
-    let revisionData = null;
+    let recipe = null;
+    let revision = null;
     const selectedRecipeId = state.recipes && state.recipes.selectedRecipe;
     let selectedRevisionId = props.routeParams && props.routeParams.revisionId;
 
-    const revReference = state.recipes.revisions[selectedRecipeId] || {};
+    const recipeRevisions = state.recipes.revisions[selectedRecipeId] || {};
 
     if (selectedRecipeId) {
-      recipeData = state.recipes.list
-        .find(recipe => recipe.id === selectedRecipeId);
+      recipe = state.recipes.list
+        .find(rec => rec.id === selectedRecipeId);
 
       // If there is a selected revision, attempt to pull that info.
       if (!selectedRevisionId) {
         // If there is _not_ a selected revision, default to the latest
         let latestId = -1;
 
-        for (const revisionId in revReference) {
-          if (revReference[revisionId].id > latestId) {
-            latestId = revReference[revisionId].revision_id;
+        for (const revisionId in recipeRevisions) {
+          if (recipeRevisions[revisionId].id > latestId) {
+            latestId = recipeRevisions[revisionId].revision_id;
           }
         }
-        selectedRevisionId = revReference[latestId] && revReference[latestId].revision_id;
+        selectedRevisionId = recipeRevisions[latestId] && recipeRevisions[latestId].revision_id;
       }
 
-      revisionData = revReference[selectedRevisionId];
+      revision = recipeRevisions[selectedRevisionId];
 
-      if (!revisionData) {
-        recipeData = null;
+      if (!revision) {
+        recipe = null;
       }
     }
     return {
       recipeId: state.recipes.selectedRecipe || parseInt(props.params.id, 10) || null,
-      recipe: recipeData,
-      revision: revisionData,
+      recipe,
+      revision,
       dispatch: props.dispatch,
     };
   };

--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -386,15 +386,14 @@ export const formConfig = {
  */
 export function initialValuesWrapper(Component) {
   function Wrapped(props) {
-    const { recipe, location } = props;
-    let initialValues = recipe;
-    if (location.state && location.state.selectedRevision) {
-      initialValues = location.state.selectedRevision;
-    }
+    const { recipe, revision } = props;
+
+    const initialValues = revision || recipe;
     return <Component initialValues={initialValues} {...props} />;
   }
   Wrapped.propTypes = {
     recipe: pt.object,
+    revision: pt.object,
     location: locationShape,
   };
 

--- a/recipe-server/client/control/components/RecipeHistory.js
+++ b/recipe-server/client/control/components/RecipeHistory.js
@@ -99,10 +99,7 @@ export class HistoryItem extends React.Component {
     if (revision.recipe.revision_id === recipe.revision_id) {
       dispatch(push(`/control/recipe/${recipe.id}/`));
     } else {
-      dispatch(push({
-        pathname: `/control/recipe/${recipe.id}/${revision.id}/`,
-        state: { selectedRevision: revision.recipe },
-      }));
+      dispatch(push(`/control/recipe/${recipe.id}/revision/${revision.id}/`));
     }
   }
 

--- a/recipe-server/client/control/reducers/RecipesReducer.js
+++ b/recipe-server/client/control/reducers/RecipesReducer.js
@@ -22,43 +22,57 @@ const dedupe = arr => {
 };
 
 function recipesReducer(state = initialState, action) {
-  let newRevisions = {};
-
   switch (action.type) {
     case RECIPES_RECEIVED: {
-      [].concat(action.recipes).forEach(recipe => {
-        newRevisions[recipe.id] = {};
-        newRevisions[recipe.id][recipe.revision_id] = { ...recipe };
+      let revisions = { ...state.revisions };
+
+      action.recipes.forEach(recipe => {
+        revisions = {
+          ...revisions,
+          [recipe.id]: {
+            ...revisions[recipe.id],
+            [recipe.revision_id]: { ...recipe },
+          },
+        };
       });
+
       return {
         ...state,
         list: [].concat(action.recipes),
-        revisions: newRevisions,
         recipeListNeedsFetch: false,
+        revisions,
       };
     }
     case SINGLE_RECIPE_RECEIVED: {
-      newRevisions = { ...state.revisions };
-      newRevisions[action.recipe.id] = newRevisions[action.recipe.id] || {};
-      newRevisions[action.recipe.id][action.recipe.revision_id] = { ...action.recipe };
-
       return {
         ...state,
         list: dedupe([action.recipe].concat(state.list)),
-        revisions: newRevisions,
         recipeListNeedsFetch: true,
         selectedRecipe: action.recipe.id,
+        revisions: {
+          ...state.revisions,
+          [action.recipe.id]: {
+            ...state.revisions[action.recipe.id],
+            [action.recipe.revision_id]: {
+              ...action.recipe,
+            },
+          },
+        },
       };
     }
 
     case SINGLE_REVISION_RECEIVED: {
-      newRevisions = { ...state.revisions };
-      newRevisions[action.recipeId] = newRevisions[action.recipeId] || {};
-      newRevisions[action.recipeId][action.revision.id] = { ...action.revision.recipe };
-
       return {
         ...state,
-        revisions: newRevisions,
+        revisions: {
+          ...state.revisions,
+          [action.revision.recipe.id]: {
+            ...state.revisions[action.revision.recipe.id],
+            [action.revision.id]: {
+              ...action.revision.recipe,
+            },
+          },
+        },
       };
     }
 
@@ -72,6 +86,15 @@ function recipesReducer(state = initialState, action) {
       return {
         ...state,
         list: dedupe([action.recipe].concat(state.list)),
+        revisions: {
+          ...state.revisions,
+          [action.recipe.id]: {
+            ...state.revisions[action.recipe.id],
+            [action.recipe.revision_id]: {
+              ...action.recipe,
+            },
+          },
+        },
       };
     case RECIPE_UPDATED:
       return {
@@ -82,6 +105,15 @@ function recipesReducer(state = initialState, action) {
           }
           return recipe;
         }),
+        revisions: {
+          ...state.revisions,
+          [action.recipe.id]: {
+            ...state.revisions[action.recipe.id],
+            [action.recipe.revision_id]: {
+              ...action.recipe,
+            },
+          },
+        },
       };
     case RECIPE_DELETED:
       return {

--- a/recipe-server/client/control/routes.js
+++ b/recipe-server/client/control/routes.js
@@ -33,6 +33,16 @@ export default (
           ]}
         />
         <Route
+          path="revision/:revisionId"
+          component={RecipeForm}
+          name="Revision"
+          ctaButtons={[
+            { text: 'Clone', icon: 'files-o', link: '../../clone/' },
+            { text: 'Preview', icon: 'eye', link: '../../preview/' },
+            { text: 'History', icon: 'history', link: '../../history/' },
+          ]}
+        />
+        <Route
           path="clone/"
           component={RecipeForm}
           name="Clone"

--- a/recipe-server/client/control/tests/components/test_RecipeForm.js
+++ b/recipe-server/client/control/tests/components/test_RecipeForm.js
@@ -163,7 +163,7 @@ describe('<RecipeForm>', () => {
       const Component = ({ initialValues }) => <div>{initialValues}</div>;
       const WrappedComponent = initialValuesWrapper(Component);
       const wrapper = shallow(
-        <WrappedComponent recipe="fakerecipe" location={{}} />
+        <WrappedComponent recipe={'fakerecipe'} location={{}} />
       );
 
       expect(wrapper.find(Component).prop('initialValues')).toBe('fakerecipe');
@@ -172,9 +172,8 @@ describe('<RecipeForm>', () => {
     it('should pass the selected revision as initialValues when available', () => {
       const Component = ({ initialValues }) => <div>{initialValues}</div>;
       const WrappedComponent = initialValuesWrapper(Component);
-      const location = { state: { selectedRevision: 'fakerevision' } };
       const wrapper = shallow(
-        <WrappedComponent recipe="fakerecipe" location={location} />
+        <WrappedComponent recipe={'fakerecipe'} revision={'fakerevision'} />
       );
 
       expect(wrapper.find(Component).prop('initialValues')).toBe('fakerevision');

--- a/recipe-server/client/control/tests/fixtures.js
+++ b/recipe-server/client/control/tests/fixtures.js
@@ -1,8 +1,46 @@
 export const fixtureRecipes = [
-  { id: 1, name: 'Lorem Ipsum', enabled: true },
-  { id: 2, name: 'Dolor set amet', enabled: true },
-  { id: 3, name: 'Consequitar adipscing', enabled: false },
+  { id: 1, name: 'Lorem Ipsum', enabled: true, revision_id: 'abc' },
+  { id: 2, name: 'Dolor set amet', enabled: true, revision_id: 'def' },
+  { id: 3, name: 'Consequitar adipscing', enabled: false, revision_id: 'ghi' },
 ];
+
+export const fixtureStoredSingleRevision = {
+  1: {
+    abc: {
+      id: 1,
+      name: 'Lorem Ipsum',
+      enabled: true,
+      revision_id: 'abc',
+    },
+  },
+};
+
+export const fixtureStoredRevisions = {
+  1: {
+    abc: {
+      id: 1,
+      name: 'Lorem Ipsum',
+      enabled: true,
+      revision_id: 'abc',
+    },
+  },
+  2: {
+    def: {
+      id: 2,
+      name: 'Dolor set amet',
+      enabled: true,
+      revision_id: 'def',
+    },
+  },
+  3: {
+    ghi: {
+      id: 3,
+      name: 'Consequitar adipscing',
+      enabled: false,
+      revision_id: 'ghi',
+    },
+  },
+};
 
 export const initialState = {
   user: {},

--- a/recipe-server/client/control/tests/fixtures.js
+++ b/recipe-server/client/control/tests/fixtures.js
@@ -11,6 +11,7 @@ export const initialState = {
   },
   recipes: {
     list: [],
+    revisions: {},
     selectedRecipe: null,
     recipeListNeedsFetch: true,
   },

--- a/recipe-server/client/control/tests/reducers/test_controlAppReducer.js
+++ b/recipe-server/client/control/tests/reducers/test_controlAppReducer.js
@@ -40,6 +40,7 @@ describe('controlApp reducer', () => {
       ...initialState,
       recipes: {
         list: fixtureRecipes,
+        revisions: {},
         selectedRecipe: null,
         recipeListNeedsFetch: false,
       },
@@ -54,6 +55,7 @@ describe('controlApp reducer', () => {
       ...initialState,
       recipes: {
         list: [fixtureRecipes[0]],
+        revisions: {},
         selectedRecipe: 1,
         recipeListNeedsFetch: true,
       },
@@ -68,6 +70,7 @@ describe('controlApp reducer', () => {
       ...initialState,
       recipes: {
         list: [],
+        revisions: {},
         selectedRecipe: 2,
         recipeListNeedsFetch: true,
       },

--- a/recipe-server/client/control/tests/reducers/test_controlAppReducer.js
+++ b/recipe-server/client/control/tests/reducers/test_controlAppReducer.js
@@ -2,6 +2,8 @@ import appReducer from 'control/reducers';
 import * as actions from 'control/actions/ControlActions';
 import {
   fixtureRecipes,
+  fixtureStoredRevisions,
+  fixtureStoredSingleRevision,
   initialState,
 } from 'control/tests/fixtures';
 
@@ -40,7 +42,7 @@ describe('controlApp reducer', () => {
       ...initialState,
       recipes: {
         list: fixtureRecipes,
-        revisions: {},
+        revisions: fixtureStoredRevisions,
         selectedRecipe: null,
         recipeListNeedsFetch: false,
       },
@@ -55,7 +57,7 @@ describe('controlApp reducer', () => {
       ...initialState,
       recipes: {
         list: [fixtureRecipes[0]],
-        revisions: {},
+        revisions: fixtureStoredSingleRevision,
         selectedRecipe: 1,
         recipeListNeedsFetch: true,
       },
@@ -140,19 +142,12 @@ describe('controlApp reducer', () => {
   it('should handle RECIPE_ADDED', () => {
     expect(appReducer(initialState, {
       type: actions.RECIPE_ADDED,
-      recipe: {
-        id: 4,
-        name: 'Villis stebulum',
-        enabled: false,
-      },
+      recipe: fixtureRecipes[0],
     })).toEqual({
       ...initialState,
       recipes: {
-        list: [{
-          id: 4,
-          name: 'Villis stebulum',
-          enabled: false,
-        }],
+        list: [fixtureRecipes[0]],
+        revisions: fixtureStoredSingleRevision,
         selectedRecipe: null,
         recipeListNeedsFetch: true,
       },
@@ -160,36 +155,39 @@ describe('controlApp reducer', () => {
   });
 
   it('should handle RECIPE_UPDATED', () => {
+    const updatedRecipe = {
+      id: 3,
+      name: 'Updated recipe name',
+      enabled: true,
+      revision_id: 'ghi',
+    };
+
     expect(appReducer({
       ...initialState,
       recipes: {
         ...initialState.recipes,
         list: fixtureRecipes,
+        revisions: fixtureStoredRevisions,
       },
     }, {
       type: actions.RECIPE_UPDATED,
-      recipe: {
-        id: 3,
-        name: 'Updated recipe name',
-        enabled: true,
-      },
+      recipe: updatedRecipe,
     })).toEqual({
       ...initialState,
       recipes: {
         ...initialState.recipes,
-        list: [{
-          id: 1,
-          name: 'Lorem Ipsum',
-          enabled: true,
-        }, {
-          id: 2,
-          name: 'Dolor set amet',
-          enabled: true,
-        }, {
-          id: 3,
-          name: 'Updated recipe name',
-          enabled: true,
-        }],
+        list: [
+          { id: 1, name: 'Lorem Ipsum', enabled: true, revision_id: 'abc' },
+          { id: 2, name: 'Dolor set amet', enabled: true, revision_id: 'def' },
+          updatedRecipe,
+        ],
+        revisions: {
+          ...fixtureStoredRevisions,
+          3: {
+            ...fixtureStoredRevisions[3],
+            ghi: updatedRecipe,
+          },
+        },
         selectedRecipe: null,
         recipeListNeedsFetch: true,
       },
@@ -197,28 +195,23 @@ describe('controlApp reducer', () => {
   });
 
   it('should handle RECIPE_DELETED', () => {
+    const testId = 3;
     expect(appReducer({
       ...initialState,
       recipes: {
         ...initialState.recipes,
         list: fixtureRecipes,
+        revisions: fixtureStoredRevisions,
       },
     }, {
       type: actions.RECIPE_DELETED,
-      recipeId: 3,
+      recipeId: testId,
     })).toEqual({
       ...initialState,
       recipes: {
         ...initialState.recipes,
-        list: [{
-          id: 1,
-          name: 'Lorem Ipsum',
-          enabled: true,
-        }, {
-          id: 2,
-          name: 'Dolor set amet',
-          enabled: true,
-        }],
+        list: fixtureRecipes.filter(rec => rec.id !== testId),
+        revisions: fixtureStoredRevisions,
         selectedRecipe: null,
         recipeListNeedsFetch: true,
       },


### PR DESCRIPTION
There's an issue in the front end code where the term `recipe` is used ambiguously. When a revision is selected, `recipe` objects totally inherit the revision, and from there it's tough to discern whether the user is looking at the most recent draft, if there's an approval request open, etc.

This patch:
  - Adds a `revisions` object to the Recipes redux store.
    - The `list` (`entries` on master) is the list of the most current recipe data, whereas the `revisions` is a collection of arrays keyed on recipe id.
  - Adds `recipe/:id/revision/:revisionId` route

ex:
 ```
const latestRecipeId = state.recipes.list[0].id;
const someRevisionId = 'abc123';

const selectedRevision = state.recipes.revisions[latestRecipeId][someRevisionId];
```

This is a concise example, but you get the idea.

Currently, there are **3** tests that are failing with this. I'm poking around to determine what the issue is but for now this is ready for feedback!