### PR TITLE
Fix long show-heartbeat messages

### DIFF
--- a/recipe-client-addon/lib/Heartbeat.jsm
+++ b/recipe-client-addon/lib/Heartbeat.jsm
@@ -167,6 +167,9 @@ this.Heartbeat = class {
       frag.appendChild(ratingContainer);
     }
 
+    const details = this.chromeWindow.document.getAnonymousElementByAttribute(this.notice, "anonid", "details");
+    details.style.overflow = "hidden";
+
     this.messageImage = this.chromeWindow.document.getAnonymousElementByAttribute(this.notice, "anonid", "messageImage");
     this.messageImage.classList.add("heartbeat", "pulse-onshow");
 


### PR DESCRIPTION
The first commit fixes an issue with the mock-recipe server and how we were saving the URLs in the API index. I needed that to be able to run the long message test.

The second commit fixes the overflow issues by hiding overflow in the details element in the notification bar, which specifically does _not_ contain the close button. With this patch, the bar now looks like this:

<img width="1071" alt="screen shot 2017-03-01 at 3 03 00 pm" src="https://cloud.githubusercontent.com/assets/193106/23485443/483b961e-fe90-11e6-965b-4bbf89cab708.png">

I'm not sure directly modifying the style attribute is the best way to fix this, but given that in #331 we're probably going to rewrite our implementation to not use XUL at all, I don't think it'll be an issue.