### PR TITLE
recipe-server: Optionally accept remote authentication

### DIFF
--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -222,12 +222,12 @@ in other Django projects.
 
    .. warning::
 
-      If this feature is enabled, the proxy server providing authentcation
-      *must* sanitize the headers passed along to Normandy. Specifcially, the
+      If this feature is enabled, the proxy server providing authentication
+      *must* sanitize the headers passed along to Normandy. Specifically, the
       header defined in :envvar:`DJANGO_OIDC_REMOTE_AUTH_HEADER` must not be
       passed on from the user.
 
-      Failing to do this will result from any client being able to authenticate
+      Failing to do this will result in any client being able to authenticate
       as any user, with no checks.
 
 .. envvar:: DJANGO_OIDC_REMOTE_AUTH_HEADER
@@ -235,20 +235,16 @@ in other Django projects.
    :default: ``HTTP_REMOTE_USER``
 
    If :envvar:`DJANGO_USE_OIDC` is ``True``, this is the source of the user to
-   authenticate. This is subject to the Django header normalization, i.e.
-   the header will be capitalized, dashes replaced with underscores, and it will
-   be prefixed with ``HTTP_``.
+   authenticate. This must match Django header normalization, i.e. it must be
+   capitalized, dashes replaced with underscores, and be prefixed with ``HTTP_``.
 
-.. envvar:: DJANGO_OIDC_LOGOUT_IF_NO_HEADER
+   For example, the header ``OIDC-Claim-User-Profile-Email`` becomes
+   ``HTTP_OIDC_CLAIM_USER_PROFILE_EMAIL``.
 
-   :default: ``True``
+.. envvar:: DJANGO_OIDC_LOGOUT_URL
 
-   If set to ``False``, users will stayed logged in as long as their session
-   remains live. This is useful if only some URLs pass the
-   :envvar:`DJANGO_OIDC_REMOTE_AUTH_HEADER` (for example, authentication pages).
-
-   If set to ``True``, users will be logged out in Django's session when they
-   send a request without the appropriate headers.
+   If :envvar:`DJANGO_USE_OIDC` is set to ``True``, this settings must be set to
+   the URL that a user can visit to logout. It may be a relative URL.
 
 Gunicorn settings
 -----------------

--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -192,19 +192,63 @@ in other Django projects.
 
 .. envvar:: DJANGO_CDN_URL
 
-  :default: ``None``
+   :default: ``None``
 
-  The URL of a CDN that is backed by Normandy, if one is in use. This is used to
-  enforce that immutable content is routed through the CDN. Must end with a
-  slash (``/``).
+   The URL of a CDN that is backed by Normandy, if one is in use. This is used to
+   enforce that immutable content is routed through the CDN. Must end with a
+   slash (``/``).
 
 .. envvar:: DJANGO_APP_SERVER_URL
 
-  :default: ``None``
+   :default: ``None``
 
-  The URL that allows direct access to Normandy, bypassing any CDNs. This
-  is used for content that cannot be cached. If not specified, Normandy will
-  assume direct access. Must end with a slash (``/``).
+   The URL that allows direct access to Normandy, bypassing any CDNs. This
+   is used for content that cannot be cached. If not specified, Normandy will
+   assume direct access. Must end with a slash (``/``).
+
+.. envvar:: DJANGO_USE_OIDC
+
+   :default: ``False``
+
+   If enabled, Normandy will authenticate users by reading a header in requests.
+   The expectation is that a proxy server, such as Nginx, will perform
+   authentication using Open ID Connect, and then pass the unique ID of the user
+   in a header.
+
+   .. seealso::
+
+      :envvar:`DJANGO_OIDC_REMOTE_AUTH_HEADER` for which header Normandy
+      reads this value from.
+
+   .. warning::
+
+      If this feature is enabled, the proxy server providing authentcation
+      *must* sanitize the headers passed along to Normandy. Specifcially, the
+      header defined in :envvar:`DJANGO_OIDC_REMOTE_AUTH_HEADER` must not be
+      passed on from the user.
+
+      Failing to do this will result from any client being able to authenticate
+      as any user, with no checks.
+
+.. envvar:: DJANGO_OIDC_REMOTE_AUTH_HEADER
+
+   :default: ``HTTP_REMOTE_USER``
+
+   If :envvar:`DJANGO_USE_OIDC` is ``True``, this is the source of the user to
+   authenticate. This is subject to the Django header normalization, i.e.
+   the header will be capitalized, dashes replaced with underscores, and it will
+   be prefixed with ``HTTP_``.
+
+.. envvar:: DJANGO_OIDC_LOGOUT_IF_NO_HEADER
+
+   :default: ``True``
+
+   If set to ``False``, users will stayed logged in as long as their session
+   remains live. This is useful if only some URLs pass the
+   :envvar:`DJANGO_OIDC_REMOTE_AUTH_HEADER` (for example, authentication pages).
+
+   If set to ``True``, users will be logged out in Django's session when they
+   send a request without the appropriate headers.
 
 Gunicorn settings
 -----------------

--- a/recipe-server/normandy/base/auth_backends.py
+++ b/recipe-server/normandy/base/auth_backends.py
@@ -14,14 +14,12 @@ class LoggingAuthBackendMixin(object):
     """
     Authentication backend mixin that logs the results of login attempts.
     """
+    def get_username(self, **kwargs):
+        raise NotImplemented()
+
     def authenticate(self, **kwargs):
         result = super().authenticate(**kwargs)
-
-        username = None
-        if 'username' in kwargs:
-            username = kwargs['username']
-        elif 'remote_user' in kwargs:
-            username = kwargs['remote_user']
+        username = self.get_username(**kwargs)
 
         if result is None:
             if username is not None:
@@ -46,9 +44,13 @@ class LoggingModelBackend(LoggingAuthBackendMixin, ModelBackend):
     """
     Model-backed authentication backend that logs the results of login attempts.
     """
+    def get_username(self, username=None, **kwargs):
+        return username
 
 
 class LoggingRemoteUserBackend(LoggingAuthBackendMixin, RemoteUserBackend):
     """
     Remote-user backend that logs the results of login attempts.
     """
+    def get_username(self, remote_user=None, **kwargs):
+        return remote_user

--- a/recipe-server/normandy/base/checks.py
+++ b/recipe-server/normandy/base/checks.py
@@ -8,6 +8,7 @@ ERROR_MISCONFIGURED_CDN_URL_SLASH = 'normandy.base.E001'
 ERROR_MISCONFIGURED_CDN_URL_HTTPS = 'normandy.base.E002'
 ERROR_MISCONFIGURED_APP_SERVER_URL_SLASH = 'normandy.base.E003'
 ERROR_MISCONFIGURED_APP_SERVER_URL_HTTPS = 'normandy.base.E004'
+ERROR_MISCONFIGURED_OIDC_LOGOUT_URL = 'normandy.base.E005'
 
 
 def setting_cdn_url(app_configs, **kwargs):
@@ -50,7 +51,18 @@ def setting_oidc_remote_auth_header(app_configs, **kwargs):
     return errors
 
 
+def setting_oidc_logout_url(app_configs, **kwargs):
+    errors = []
+
+    if settings.USE_OIDC and settings.OIDC_LOGOUT_URL is None:
+        msg = 'The setting OIDC_LOGOUT_URL must be set when USE_OIDC=True'
+        errors.append(Error(msg, id=ERROR_MISCONFIGURED_OIDC_LOGOUT_URL))
+
+    return errors
+
+
 def register():
     register_check(setting_cdn_url)
     register_check(setting_app_server_url)
     register_check(setting_oidc_remote_auth_header)
+    register_check(setting_oidc_logout_url)

--- a/recipe-server/normandy/base/checks.py
+++ b/recipe-server/normandy/base/checks.py
@@ -1,6 +1,8 @@
 from django.conf import settings
-from django.core.checks import Warning, register as register_check
+from django.core.checks import Error, Warning, register as register_check
 
+
+WARNING_MISCONFIGURED_OIDC_REMOTE_AUTH_HEADER_PREFIX = 'normandy.base.W001'
 
 ERROR_MISCONFIGURED_CDN_URL_SLASH = 'normandy.base.E001'
 ERROR_MISCONFIGURED_CDN_URL_HTTPS = 'normandy.base.E002'
@@ -14,11 +16,11 @@ def setting_cdn_url(app_configs, **kwargs):
     if settings.CDN_URL is not None:
         if settings.CDN_URL[-1] != '/':
             msg = 'The setting CDN_URL must end in a slash'
-            errors.append(Warning(msg, id=ERROR_MISCONFIGURED_CDN_URL_SLASH))
+            errors.append(Error(msg, id=ERROR_MISCONFIGURED_CDN_URL_SLASH))
 
         if not settings.CDN_URL.startswith('https://'):
             msg = 'The setting CDN_URL must be an https URL'
-            errors.append(Warning(msg, id=ERROR_MISCONFIGURED_CDN_URL_HTTPS))
+            errors.append(Error(msg, id=ERROR_MISCONFIGURED_CDN_URL_HTTPS))
 
     return errors
 
@@ -29,14 +31,26 @@ def setting_app_server_url(app_configs, **kwargs):
     if settings.APP_SERVER_URL is not None:
         if settings.APP_SERVER_URL[-1] != '/':
             msg = 'The setting APP_SERVER_URL must end in a slash'
-            errors.append(Warning(msg, id=ERROR_MISCONFIGURED_APP_SERVER_URL_SLASH))
+            errors.append(Error(msg, id=ERROR_MISCONFIGURED_APP_SERVER_URL_SLASH))
 
         if not settings.APP_SERVER_URL.startswith('https://'):
             msg = 'The setting APP_SERVER_URL must be an https URL'
-            errors.append(Warning(msg, id=ERROR_MISCONFIGURED_APP_SERVER_URL_HTTPS))
+            errors.append(Error(msg, id=ERROR_MISCONFIGURED_APP_SERVER_URL_HTTPS))
+
+    return errors
+
+
+def setting_oidc_remote_auth_header(app_configs, **kwargs):
+    errors = []
+
+    if not settings.OIDC_REMOTE_AUTH_HEADER.startswith('HTTP_'):
+        msg = 'The setting OIDC_REMOTE_AUTH_HEADER should start with HTTP_'
+        errors.append(Warning(msg, id=WARNING_MISCONFIGURED_OIDC_REMOTE_AUTH_HEADER_PREFIX))
 
     return errors
 
 
 def register():
     register_check(setting_cdn_url)
+    register_check(setting_app_server_url)
+    register_check(setting_oidc_remote_auth_header)

--- a/recipe-server/normandy/base/middleware.py
+++ b/recipe-server/normandy/base/middleware.py
@@ -43,14 +43,3 @@ class ConfigurableRemoteUserMiddleware(RemoteUserMiddleware):
         prefixed with "HTTP_".
         """
         return settings.OIDC_REMOTE_AUTH_HEADER
-
-    @property
-    def force_logout_if_no_header(self):
-        """
-        If True, don't log the user out when the remote user header is not found.
-
-        Useful for setups when the external authentication is only
-        expected to happen on some "logon" URL and the rest of the
-        application wants to use Django's authentication mechanism.
-        """
-        return settings.OIDC_LOGOUT_IF_NO_HEADER

--- a/recipe-server/normandy/base/middleware.py
+++ b/recipe-server/normandy/base/middleware.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
+from django.contrib.auth.middleware import RemoteUserMiddleware
 
 from mozilla_cloud_services_logger.django.middleware import (
     RequestSummaryLogger as OriginalRequestSummaryLogger
@@ -24,3 +26,31 @@ class RequestSummaryLogger(MiddlewareMixin, OriginalRequestSummaryLogger):
     Adapt mozilla_cloud_services_logger's request logger to Django 1.10 new-style middleware.
     """
     pass
+
+
+class ConfigurableRemoteUserMiddleware(RemoteUserMiddleware):
+    """
+    Makes RemoteUserMiddleware customizable via settings.
+    """
+
+    @property
+    def header(self):
+        """
+        Name of request header to grab username from.
+
+        This will be the key as used in the request.META dictionary. To
+        reference HTTP headers, this value should be all upper case and
+        prefixed with "HTTP_".
+        """
+        return settings.OIDC_REMOTE_AUTH_HEADER
+
+    @property
+    def force_logout_if_no_header(self):
+        """
+        If True, don't log the user out when the remote user header is not found.
+
+        Useful for setups when the external authentication is only
+        expected to happen on some "logon" URL and the rest of the
+        application wants to use Django's authentication mechanism.
+        """
+        return settings.OIDC_LOGOUT_IF_NO_HEADER

--- a/recipe-server/normandy/control/templates/control/admin/base.html
+++ b/recipe-server/normandy/control/templates/control/admin/base.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load render_bundle from normandy_webpack_loader %}
+{% load logout_button from normandy_logout_button %}
 <!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
 
@@ -20,7 +21,7 @@
         {% if user.is_authenticated %}
           <span>
             {% firstof user.get_short_name user.get_username %} //
-            <a href="{% url 'control:logout' %}">Log Out <i class="fa fa-sign-out post"></i></a>
+            {% logout_button %}
           </span>
         {% endif %}
       </div>

--- a/recipe-server/normandy/control/templatetags/normandy_logout_button.py
+++ b/recipe-server/normandy/control/templatetags/normandy_logout_button.py
@@ -1,0 +1,17 @@
+from django import template
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.utils.safestring import mark_safe
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def logout_button():
+    if settings.USE_OIDC:
+        logout_url = settings.OIDC_LOGOUT_URL
+    else:
+        logout_url = reverse('control:logout')
+
+    return mark_safe(f'<a href="{logout_url}">Log Out <i class="fa fa-sign-out post"></i></a>')

--- a/recipe-server/normandy/control/tests/test_templatetags.py
+++ b/recipe-server/normandy/control/tests/test_templatetags.py
@@ -1,0 +1,18 @@
+from django.core.urlresolvers import reverse
+
+from normandy.control.templatetags.normandy_logout_button import logout_button
+
+
+class TestLogoutButton(object):
+    def test_without_oidc(self, settings):
+        settings.USE_OIDC = False
+        html = logout_button()
+        assert reverse('control:logout') in html
+        assert 'None' not in html
+
+    def test_with_oidc(self, settings):
+        settings.USE_OIDC = True
+        settings.OIDC_LOGOUT_URL = 'https://example.com/auth/logout'
+        html = logout_button()
+        assert settings.OIDC_LOGOUT_URL in html
+        assert reverse('control:logout') not in html

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -155,7 +155,7 @@ class Base(Core):
             return ['normandy.base.auth_backends.LoggingModelBackend']
 
     OIDC_REMOTE_AUTH_HEADER = values.Value('HTTP_REMOTE_USER')
-    OIDC_LOGOUT_IF_NO_HEADER = values.BooleanValue(True)
+    OIDC_LOGOUT_URL = values.Value(None)
 
     # Middleware that _most_ environments will need. Subclasses can override this list.
     EXTRA_MIDDLEWARE = [


### PR DESCRIPTION
This enables Django's remote user authentication system, with some modifications. Specifically, we can customize it via settings instead of having certain values hard coded.

To test this: enable the OIDC settings, and then pass the `Remote-User: your_username` while making requests via the API. You should magically be authenticated. To test the web interface, you'll need to configure a proxy server to pass that header for you. Adding `proxy_set_header Remote-User mythmon;` to the Nginx config in the Compose setup worked nicely for me.

@relud Can you look over these docs and make sure this will work with your Auth0 things? I expect you'll need to modify the `DJANGO_OIDC_REMOTE_AUTH_HEADER` to match the environment.

Part of #526.