### PR TITLE
mock-recipe-server: Add tests to validate generated data

### DIFF
--- a/mock-recipe-server/bin/ci/test
+++ b/mock-recipe-server/bin/ci/test
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -eu
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd)"
+
+compose () {
+    docker-compose \
+        -p mockrecipeserver \
+        -f "$REPO_DIR/compose/docker-compose.yml" \
+        -f "$REPO_DIR/mock-recipe-server/docker-compose.yml" \
+        $@
+}
+
+# Shut down docker even if we error out.
+function finish {
+    compose stop
+}
+trap finish EXIT
+
+# MOCK_SERVER_ARTIFACTS is exported so the docker-compose config can
+# use it to mount the artifact volume.
+export MOCK_SERVER_ARTIFACTS
+
+# Generate mock server files
+echo "Verifying mock server files"
+compose run testgen /mock-server/test.py /build

--- a/mock-recipe-server/test.py
+++ b/mock-recipe-server/test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""
+Tests that make assertions about the test cases.
+"""
+import json
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+
+tests = []
+
+
+def main():
+    """
+    Load each test case from build_path and run a series of checks on them.
+    """
+    build_path = Path(sys.argv[1])
+
+    for child in build_path.iterdir():
+        if not child.is_dir():
+            continue
+
+        for test in tests:
+            test(child)
+
+
+def test(test_func):
+    tests.append(test_func)
+
+
+@test
+def recipes_match_signed_and_unsigned(path):
+    api_root = path / 'api' / 'v1'
+    with open(api_root / 'recipe' / 'index.html') as f:
+        unsigned_data = json.load(f)
+    with open(api_root / 'recipe' / 'signed' / 'index.html') as f:
+        signed_data = json.load(f)
+
+    unsigned_recipes = sorted(r for r in unsigned_data)
+    signed_recipes = sorted(rs['recipe'] for rs in signed_data)
+
+    try:
+        assert signed_recipes == unsigned_recipes
+    except AssertionError:
+        print(dedent(f'''
+            Failure in test case {path}.
+            Expected signed recipes:
+
+            """
+            {signed_recipes}
+            """
+
+            to equal unsigned recipes:
+
+            """
+            {unsigned_recipes}
+            """
+        '''))
+        raise
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I'm not sure if this will work in CI, and I'll work on that later, but this demonstrates a problem in our mock test cases (at least on my laptop).

While testing #556, I noticed that the signed and unsigned data for recipes was mixed up: the signed data was correct, but the unsigned data came from another test case. I'm not sure what's going on, but hopefully having this test in CI will help diagnose it and fix the issue.