### PR TITLE
Revision history lookup fix

### DIFF
--- a/recipe-server/client/control/actions/ControlActions.js
+++ b/recipe-server/client/control/actions/ControlActions.js
@@ -6,6 +6,10 @@ export const SINGLE_RECIPE_RECEIVED = 'SINGLE_RECIPE_RECEIVED';
 export const SINGLE_REVISION_RECEIVED = 'SINGLE_REVISION_RECEIVED';
 
 export const SET_SELECTED_RECIPE = 'SET_SELECTED_RECIPE';
+export const SET_SELECTED_REVISION = 'SET_SELECTED_REVISION';
+
+export const REVISIONS_RECEIVED = 'REVISIONS_RECEIVED';
+
 export const SHOW_NOTIFICATION = 'SHOW_NOTIFICATION';
 export const DISMISS_NOTIFICATION = 'DISMISS_NOTIFICATION';
 
@@ -246,6 +250,21 @@ function setSelectedRecipe(recipeId) {
   };
 }
 
+function setSelectedRevision(revisionId) {
+  return {
+    type: SET_SELECTED_REVISION,
+    revisionId,
+  };
+}
+
+function revisionsReceived({ recipeId, revisions }) {
+  return {
+    type: REVISIONS_RECEIVED,
+    recipeId,
+    revisions,
+  };
+}
+
 function showNotification(notification) {
   return dispatch => {
     // Use time-based id and dismiss automatically after 10 seconds.
@@ -302,6 +321,8 @@ export {
   singleRecipeReceived,
   singleRevisionReceived,
   setSelectedRecipe,
+  setSelectedRevision,
+  revisionsReceived,
   showNotification,
   dismissNotification,
   recipeAdded,

--- a/recipe-server/client/control/components/RecipeContainer.js
+++ b/recipe-server/client/control/components/RecipeContainer.js
@@ -1,10 +1,13 @@
 import React, { PropTypes as pt } from 'react';
 import { connect } from 'react-redux';
+import moment from 'moment';
+
 import {
   makeApiRequest,
   singleRecipeReceived,
-  singleRevisionReceived,
   setSelectedRecipe,
+  setSelectedRevision,
+  revisionsReceived,
 } from 'control/actions/ControlActions';
 
 export default function composeRecipeContainer(Component) {
@@ -17,7 +20,7 @@ export default function composeRecipeContainer(Component) {
 
     componentWillMount() {
       if (this.props.recipeId) {
-        this.getRecipeData(this.props.recipeId);
+        this.getRecipeData(this.props.recipeId, this.props.routeParams.revisionId);
       }
     }
 
@@ -26,37 +29,43 @@ export default function composeRecipeContainer(Component) {
       const isRouteRevisionChanging =
         routeParams.revisionId !== this.props.routeParams.revisionId;
 
-      if (recipeId && isRecipeChanging) {
+      if (isRecipeChanging) {
         this.getRecipeData(recipeId, routeParams && routeParams.revisionId);
       }
-      if (routeParams.revisionId && isRouteRevisionChanging) {
-        this.getRecipeRevision(routeParams.revisionId);
+
+      if (isRouteRevisionChanging) {
+        this.props.dispatch(setSelectedRevision(routeParams.revisionId));
       }
     }
 
     getRecipeData(recipeId, revisionId) {
-      const { dispatch, recipe, routeParams } = this.props;
-      if (!recipe) {
-        dispatch(setSelectedRecipe(recipeId));
+      const { dispatch } = this.props;
+      if (!recipeId) {
+        return;
+      }
 
-        // always get the latest
-        dispatch(makeApiRequest('fetchSingleRecipe', { recipeId }))
+      dispatch(setSelectedRecipe(recipeId));
+      dispatch(setSelectedRevision(revisionId));
+
+      dispatch(makeApiRequest('fetchSingleRecipe', { recipeId }))
         .then(newRecipe => {
           dispatch(singleRecipeReceived(newRecipe));
-          // get a specific revision, if specified
-          if (revisionId || routeParams.revisionId) {
-            this.getRecipeRevision(revisionId || routeParams.revisionId);
-          }
+
+          this.getRecipeHistory(recipeId, revisionId);
         });
-      }
     }
 
-    getRecipeRevision(revisionId) {
+    getRecipeHistory(recipeId, revisionId) {
       const { dispatch } = this.props;
 
-      return dispatch(makeApiRequest('fetchSingleRevision', { revisionId }))
-        .then(revision => {
-          dispatch(singleRevisionReceived({ revision }));
+      dispatch(makeApiRequest('fetchRecipeHistory', { recipeId }))
+        .then(revisions => {
+          dispatch(setSelectedRevision(revisionId || revisions[0].id));
+
+          dispatch(revisionsReceived({
+            recipeId,
+            revisions,
+          }));
         });
     }
 
@@ -69,33 +78,40 @@ export default function composeRecipeContainer(Component) {
     let recipe = null;
     let revision = null;
     const selectedRecipeId = state.recipes && state.recipes.selectedRecipe;
-    let selectedRevisionId = props.routeParams && props.routeParams.revisionId;
+    let selectedRevisionId = state.recipes && state.recipes.selectedRevision;
 
     const recipeRevisions = state.recipes.revisions[selectedRecipeId] || {};
+
 
     if (selectedRecipeId) {
       recipe = state.recipes.list
         .find(rec => rec.id === selectedRecipeId);
 
+      let latestId = -1;
+      let latestTime;
       // If there is a selected revision, attempt to pull that info.
       if (!selectedRevisionId) {
         // If there is _not_ a selected revision, default to the latest
-        let latestId = -1;
 
         for (const revisionId in recipeRevisions) {
-          if (recipeRevisions[revisionId].id > latestId) {
-            latestId = recipeRevisions[revisionId].revision_id;
+          if (recipeRevisions.hasOwnProperty(revisionId)) {
+            const sinceRevision = moment().diff(recipeRevisions[revisionId].date_created);
+            if (!selectedRevisionId || sinceRevision < latestTime) {
+              latestId = revisionId;
+              latestTime = sinceRevision;
+            }
           }
         }
-        selectedRevisionId = recipeRevisions[latestId] && recipeRevisions[latestId].revision_id;
+        selectedRevisionId = latestId;
       }
 
-      revision = recipeRevisions[selectedRevisionId];
+      revision = (recipeRevisions[selectedRevisionId] || {}).recipe;
 
       if (!revision) {
         recipe = null;
       }
     }
+
     return {
       recipeId: state.recipes.selectedRecipe || parseInt(props.params.id, 10) || null,
       recipe,

--- a/recipe-server/client/control/components/RecipeContainer.js
+++ b/recipe-server/client/control/components/RecipeContainer.js
@@ -1,6 +1,5 @@
 import React, { PropTypes as pt } from 'react';
 import { connect } from 'react-redux';
-import moment from 'moment';
 
 import {
   makeApiRequest,
@@ -10,123 +9,95 @@ import {
   revisionsReceived,
 } from 'control/actions/ControlActions';
 
+import {
+  getSelectedRevision,
+} from 'control/selectors/RecipesSelector';
+
+export class RecipeContainer extends React.Component {
+  static propTypes = {
+    dispatch: pt.func.isRequired,
+    recipe: pt.object.isRequired,
+    routeParams: pt.object.isRequired,
+  }
+
+  componentWillMount() {
+    if (this.props.recipeId) {
+      this.getRecipeData(this.props.recipeId, this.props.routeParams.revisionId);
+    }
+  }
+
+  componentWillReceiveProps({ recipeId, routeParams = {} }) {
+    const isRecipeChanging = recipeId !== this.props.recipeId;
+    const isRouteRevisionChanging =
+      routeParams.revisionId !== this.props.routeParams.revisionId;
+
+    if (isRecipeChanging) {
+      this.getRecipeData(recipeId, routeParams && routeParams.revisionId);
+    }
+
+    if (isRouteRevisionChanging) {
+      this.props.dispatch(setSelectedRevision(routeParams.revisionId));
+    }
+  }
+
+  getRecipeData(recipeId, revisionId) {
+    const { dispatch } = this.props;
+    if (!recipeId) {
+      return;
+    }
+
+    dispatch(setSelectedRecipe(recipeId));
+    dispatch(setSelectedRevision(revisionId));
+
+    dispatch(makeApiRequest('fetchSingleRecipe', { recipeId }))
+      .then(newRecipe => {
+        dispatch(singleRecipeReceived(newRecipe));
+
+        this.getRecipeHistory(recipeId, revisionId);
+      });
+  }
+
+  getRecipeHistory(recipeId, revisionId) {
+    const { dispatch } = this.props;
+
+    dispatch(makeApiRequest('fetchRecipeHistory', { recipeId }))
+      .then(revisions => {
+        dispatch(setSelectedRevision(revisionId || revisions[0].id));
+
+        dispatch(revisionsReceived({
+          recipeId,
+          revisions,
+        }));
+      });
+  }
+
+  render() {
+    return null;
+  }
+}
+RecipeContainer.propTypes = {
+  recipeId: React.PropTypes.number,
+  recipe: React.PropTypes.object,
+  dispatch: React.PropTypes.func,
+};
+
 export default function composeRecipeContainer(Component) {
-  class RecipeContainer extends React.Component {
-    static propTypes = {
-      dispatch: pt.func.isRequired,
-      recipe: pt.object.isRequired,
-      routeParams: pt.object.isRequired,
-    }
-
-    componentWillMount() {
-      if (this.props.recipeId) {
-        this.getRecipeData(this.props.recipeId, this.props.routeParams.revisionId);
-      }
-    }
-
-    componentWillReceiveProps({ recipeId, routeParams = {} }) {
-      const isRecipeChanging = recipeId !== this.props.recipeId;
-      const isRouteRevisionChanging =
-        routeParams.revisionId !== this.props.routeParams.revisionId;
-
-      if (isRecipeChanging) {
-        this.getRecipeData(recipeId, routeParams && routeParams.revisionId);
-      }
-
-      if (isRouteRevisionChanging) {
-        this.props.dispatch(setSelectedRevision(routeParams.revisionId));
-      }
-    }
-
-    getRecipeData(recipeId, revisionId) {
-      const { dispatch } = this.props;
-      if (!recipeId) {
-        return;
-      }
-
-      dispatch(setSelectedRecipe(recipeId));
-      dispatch(setSelectedRevision(revisionId));
-
-      dispatch(makeApiRequest('fetchSingleRecipe', { recipeId }))
-        .then(newRecipe => {
-          dispatch(singleRecipeReceived(newRecipe));
-
-          this.getRecipeHistory(recipeId, revisionId);
-        });
-    }
-
-    getRecipeHistory(recipeId, revisionId) {
-      const { dispatch } = this.props;
-
-      dispatch(makeApiRequest('fetchRecipeHistory', { recipeId }))
-        .then(revisions => {
-          dispatch(setSelectedRevision(revisionId || revisions[0].id));
-
-          dispatch(revisionsReceived({
-            recipeId,
-            revisions,
-          }));
-        });
-    }
-
+  class ComposedRecipeContainer extends RecipeContainer {
     render() {
       return <Component {...this.props} {...this.state} />;
     }
   }
 
-  const mapStateToProps = (state, props) => {
-    let recipe = null;
-    let revision = null;
-    const selectedRecipeId = state.recipes && state.recipes.selectedRecipe;
-    let selectedRevisionId = state.recipes && state.recipes.selectedRevision;
+  const mapStateToProps = (state, props) => ({
+    dispatch: props.dispatch,
+    recipeId: state.recipes.selectedRecipe || parseInt(props.params.id, 10) || null,
+      // Get selected recipe + revision data
+    ...getSelectedRevision(state),
+  });
 
-    const recipeRevisions = state.recipes.revisions[selectedRecipeId] || {};
-
-
-    if (selectedRecipeId) {
-      recipe = state.recipes.list
-        .find(rec => rec.id === selectedRecipeId);
-
-      let latestId = -1;
-      let latestTime;
-      // If there is a selected revision, attempt to pull that info.
-      if (!selectedRevisionId) {
-        // If there is _not_ a selected revision, default to the latest
-
-        for (const revisionId in recipeRevisions) {
-          if (recipeRevisions.hasOwnProperty(revisionId)) {
-            const sinceRevision = moment().diff(recipeRevisions[revisionId].date_created);
-            if (!selectedRevisionId || sinceRevision < latestTime) {
-              latestId = revisionId;
-              latestTime = sinceRevision;
-            }
-          }
-        }
-        selectedRevisionId = latestId;
-      }
-
-      revision = (recipeRevisions[selectedRevisionId] || {}).recipe;
-
-      if (!revision) {
-        recipe = null;
-      }
-    }
-
-    return {
-      recipeId: state.recipes.selectedRecipe || parseInt(props.params.id, 10) || null,
-      recipe,
-      revision,
-      dispatch: props.dispatch,
-    };
-  };
-
-  RecipeContainer.propTypes = {
-    recipeId: React.PropTypes.number,
-    recipe: React.PropTypes.object,
-    dispatch: React.PropTypes.func,
-  };
+  ComposedRecipeContainer.propTypes = { ...RecipeContainer.propTypes };
 
   return connect(
     mapStateToProps
-  )(RecipeContainer);
+  )(ComposedRecipeContainer);
 }

--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -131,9 +131,9 @@ export class RecipeForm extends React.Component {
       },
     } = this.props;
 
-    const requestDetails = revision.approval_request;
+    const requestDetails = revision && revision.approval_request;
     const currentUserID = userId;
-    const isViewingLatestApproved = recipe.approved_revision_id
+    const isViewingLatestApproved = recipe && recipe.approved_revision_id
       && revision.revision_id === recipe.approved_revision_id;
     const hasApprovalRequest = !!requestDetails;
     const requestAuthorID = hasApprovalRequest && requestDetails.creator.id;

--- a/recipe-server/client/control/components/RecipeHistory.js
+++ b/recipe-server/client/control/components/RecipeHistory.js
@@ -105,7 +105,7 @@ export class HistoryItem extends React.Component {
 
     // Do not include form state changes if the current revision was
     // clicked.
-    if (revision.recipe.revision_id === recipe.revision_id) {
+    if (revision.recipe.revision_id === recipe.latest_revision_id) {
       dispatch(push(`/control/recipe/${recipe.id}/`));
     } else {
       dispatch(push(`/control/recipe/${recipe.id}/revision/${revision.id}/`));

--- a/recipe-server/client/control/reducers/RecipesReducer.js
+++ b/recipe-server/client/control/reducers/RecipesReducer.js
@@ -3,7 +3,9 @@ import {
   RECIPE_DELETED,
   RECIPE_UPDATED,
   RECIPES_RECEIVED,
+  REVISIONS_RECEIVED,
   SET_SELECTED_RECIPE,
+  SET_SELECTED_REVISION,
   SINGLE_RECIPE_RECEIVED,
   SINGLE_REVISION_RECEIVED,
 } from 'control/actions/ControlActions';
@@ -80,10 +82,34 @@ function recipesReducer(state = initialState, action) {
       };
     }
 
+    case REVISIONS_RECEIVED: {
+      const newRevisions = {};
+      [].concat(action.revisions).forEach(rev => {
+        newRevisions[rev.id] = rev;
+      });
+
+      return {
+        ...state,
+        revisions: {
+          ...state.revisions,
+          [action.recipeId]: {
+            ...state.revisions[action.recipeId],
+            ...newRevisions,
+          },
+        },
+      };
+    }
+
     case SET_SELECTED_RECIPE:
       return {
         ...state,
         selectedRecipe: action.recipeId,
+      };
+
+    case SET_SELECTED_REVISION:
+      return {
+        ...state,
+        selectedRevision: action.revisionId,
       };
 
     case RECIPE_ADDED:

--- a/recipe-server/client/control/selectors/RecipesSelector.js
+++ b/recipe-server/client/control/selectors/RecipesSelector.js
@@ -25,18 +25,46 @@ export function getLastApprovedRevision(revisions) {
     }, {});
 }
 
-export function getLatestRevision(revisions) {
-  return [].concat(Object.keys(revisions || {}))
-    // Array of revision objects
-    .map(id => revisions[id])
-    .reduce((prev, current) => {
-      if (!prev.approval_request) {
-        return current;
+
+export function getSelectedRevision({ recipes = {} }) {
+  let recipe = null;
+  let revision = null;
+  const selectedRecipeId = recipes.selectedRecipe;
+  let selectedRevisionId = recipes.selectedRevision;
+
+  const recipeRevisions = recipes.revisions[selectedRecipeId] || {};
+
+  if (selectedRecipeId) {
+    recipe = recipes.list
+      .find(rec => rec.id === selectedRecipeId);
+
+    let latestId = -1;
+    let latestTime;
+    // If there is a selected revision, attempt to pull that info.
+    if (!selectedRevisionId) {
+      // If there is _not_ a selected revision, default to the latest
+
+      for (const revisionId in recipeRevisions) {
+        if (recipeRevisions.hasOwnProperty(revisionId)) {
+          const sinceRevision = moment().diff(recipeRevisions[revisionId].date_created);
+          if (!selectedRevisionId || sinceRevision < latestTime) {
+            latestId = revisionId;
+            latestTime = sinceRevision;
+          }
+        }
       }
+      selectedRevisionId = latestId;
+    }
 
-      const prevTime = moment().diff(prev.approval_request.created);
-      const currentTime = moment().diff(current.approval_request.created);
+    revision = (recipeRevisions[selectedRevisionId] || {}).recipe;
 
-      return prevTime < currentTime ? prev : current;
-    }, {});
+    if (!revision) {
+      recipe = null;
+    }
+  }
+
+  return {
+    recipe,
+    revision,
+  };
 }

--- a/recipe-server/client/control/selectors/RecipesSelector.js
+++ b/recipe-server/client/control/selectors/RecipesSelector.js
@@ -24,3 +24,19 @@ export function getLastApprovedRevision(revisions) {
       return prevTime < currentTime ? prev : current;
     }, {});
 }
+
+export function getLatestRevision(revisions) {
+  return [].concat(Object.keys(revisions || {}))
+    // Array of revision objects
+    .map(id => revisions[id])
+    .reduce((prev, current) => {
+      if (!prev.approval_request) {
+        return current;
+      }
+
+      const prevTime = moment().diff(prev.approval_request.created);
+      const currentTime = moment().diff(current.approval_request.created);
+
+      return prevTime < currentTime ? prev : current;
+    }, {});
+}

--- a/recipe-server/client/control/tests/components/test_RecipeContainer.js
+++ b/recipe-server/client/control/tests/components/test_RecipeContainer.js
@@ -1,0 +1,24 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { RecipeContainer } from 'control/components/RecipeContainer';
+
+/**
+ * Creates mock required props for RecipeContainer.
+ */
+function propFactory(props = {}) {
+  return {
+    dispatch: () => Promise.resolve(),
+    recipe: {},
+    routeParams: {},
+    ...props,
+  };
+}
+
+describe('<RecipeContainer>', () => {
+  it('should not throw when instantiating', () => {
+    const wrapper = () => { shallow(<RecipeContainer {...propFactory()} />); };
+    expect(wrapper).not.toThrow();
+  });
+});

--- a/recipe-server/client/control/tests/fixtures.js
+++ b/recipe-server/client/control/tests/fixtures.js
@@ -15,6 +15,13 @@ export const fixtureStoredSingleRevision = {
   },
 };
 
+export const fixtureSingleRevision = {
+  id: 1,
+  name: 'Lorem Ipsum',
+  enabled: true,
+  revision_id: 'abc',
+};
+
 export const fixtureStoredRevisions = {
   1: {
     abc: {
@@ -43,7 +50,6 @@ export const fixtureStoredRevisions = {
 };
 
 export const initialState = {
-  user: {},
   controlApp: {
     isFetching: false,
   },
@@ -93,6 +99,7 @@ export const initialState = {
     enabled: true,
   }],
   notifications: [],
+  user: {},
   form: {},
   routing: {
     locationBeforeTransitions: null,

--- a/recipe-server/client/control/tests/reducers/test_controlAppReducer.js
+++ b/recipe-server/client/control/tests/reducers/test_controlAppReducer.js
@@ -3,6 +3,7 @@ import * as actions from 'control/actions/ControlActions';
 import {
   fixtureRecipes,
   fixtureStoredRevisions,
+  fixtureSingleRevision,
   fixtureStoredSingleRevision,
   initialState,
 } from 'control/tests/fixtures';
@@ -75,6 +76,37 @@ describe('controlApp reducer', () => {
         revisions: {},
         selectedRecipe: 2,
         recipeListNeedsFetch: true,
+      },
+    });
+  });
+
+  it('should handle SET_SELECTED_REVISION', () => {
+    expect(appReducer(undefined, {
+      type: actions.SET_SELECTED_REVISION,
+      revisionId: 2,
+    })).toEqual({
+      ...initialState,
+      recipes: {
+        ...initialState.recipes,
+        selectedRevision: 2,
+      },
+    });
+  });
+
+  it('should handle REVISIONS_RECEIVED', () => {
+    expect(appReducer(undefined, {
+      type: actions.REVISIONS_RECEIVED,
+      revisions: [fixtureSingleRevision],
+      recipeId: 'test-id',
+    })).toEqual({
+      ...initialState,
+      recipes: {
+        ...initialState.recipes,
+        revisions: {
+          'test-id': {
+            [fixtureSingleRevision.id]: fixtureSingleRevision,
+          },
+        },
       },
     });
   });

--- a/recipe-server/client/control/tests/selectors/test_recipesSelectors.js
+++ b/recipe-server/client/control/tests/selectors/test_recipesSelectors.js
@@ -1,0 +1,85 @@
+import * as recipesSelectors from 'control/selectors/RecipesSelector';
+
+import {
+  fixtureRecipes,
+  fixtureStoredRevisions,
+} from '../fixtures.js';
+
+
+const fixtureApprovedRevisions = {
+  abc: {
+    id: 'abc',
+    approval_request: {
+      approved: true,
+      created: Date.now() - 1000,
+    },
+  },
+  def: {
+    id: 'def',
+    approval_request: {
+      approved: true,
+      created: Date.now() - 500,
+    },
+  },
+  ghi: {
+    id: 'ghi',
+    approval_request: {
+      created: Date.now() - 250,
+    },
+  },
+};
+
+
+describe('Recipe Selectors', () => {
+  it('getLastApprovedRevision', () => {
+    const revisions = { ...fixtureApprovedRevisions };
+
+    // expect the last approved to be the most recent, accepted revision
+    let lastApproved = recipesSelectors.getLastApprovedRevision(revisions);
+    expect(lastApproved.id).toBe('def');
+
+    // update the latest approved
+    revisions.ghi.approval_request.approved = true;
+
+    // selector should reflect the change
+    lastApproved = recipesSelectors.getLastApprovedRevision(revisions);
+    expect(lastApproved.id).toBe('ghi');
+  });
+
+  it('getSelectedRevision', () => {
+    const revisions = {
+      1: {
+        abc: {
+          id: 1,
+          name: 'Lorem Ipsum',
+          enabled: true,
+          revision_id: 'abc',
+          recipe: fixtureRecipes[0],
+        },
+      },
+      2: {
+        def: {
+          id: 2,
+          name: 'Dolor set amet',
+          enabled: true,
+          revision_id: 'def',
+          recipe: fixtureRecipes[1],
+        },
+      },
+    };
+
+    const state = {
+      recipes: {
+        list: fixtureRecipes,
+        revisions,
+        selectedRecipe: 1,
+        selectedRevision: 'abc',
+      },
+    };
+
+    expect(recipesSelectors.getSelectedRevision(state)).toEqual({
+      recipe: fixtureRecipes[0],
+      revision: fixtureStoredRevisions[1].abc,
+    });
+  });
+});


### PR DESCRIPTION
~Depends on PR #567 .~

Changes the way in which recipe revisions are loaded. Currently, they are loaded as the user visits each revision (or, the whole history, if they go to the history page).

This patch switches it so that the initial recipe is loaded, followed by the revision history, regardless of which revision the user is viewing. This allows us to display data on the front end that requires knowledge about all revisions (e.g. latest approved, latest draft, revision approval/comments for each, etc).

r?