### PR TITLE
Fix #575: Add method for clearing index cache and mock-server tests.

### DIFF
--- a/mock-recipe-server/api_index.html
+++ b/mock-recipe-server/api_index.html
@@ -148,11 +148,9 @@
         let url = new URL(`/${testcase.dataset.name}/api/v1`, window.location);
         testcase.querySelector('.url').textContent = url.href;
         testcase.querySelector('.browser-code').value = (
-          `Cu.import('resource://shield-recipe-client/lib/Storage.jsm');\n` +
-          `Storage.clearAllStorage();\n` +
-          `Services.prefs.setCharPref("extensions.shield-recipe-client.api_url", "${url.href}");\n` +
+          `Cu.unload('resource://shield-recipe-client/lib/RecipeRunner.jsm');\n` +
           `Cu.import('resource://shield-recipe-client/lib/RecipeRunner.jsm');\n` +
-          `RecipeRunner.start();`
+          `RecipeRunner.testRun("${url.href}");\n`
         );
       }
 

--- a/mock-recipe-server/api_index.html
+++ b/mock-recipe-server/api_index.html
@@ -148,9 +148,8 @@
         let url = new URL(`/${testcase.dataset.name}/api/v1`, window.location);
         testcase.querySelector('.url').textContent = url.href;
         testcase.querySelector('.browser-code').value = (
-          `Cu.unload('resource://shield-recipe-client/lib/RecipeRunner.jsm');\n` +
-          `Cu.import('resource://shield-recipe-client/lib/RecipeRunner.jsm');\n` +
-          `RecipeRunner.testRun("${url.href}");\n`
+          `Cu.import('resource://shield-recipe-client/lib/RecipeRunner.jsm', {})` +
+          `.RecipeRunner.testRun("${url.href}");`
         );
       }
 

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -41,6 +41,7 @@ const PREF_SELF_SUPPORT_ENABLED = "browser.selfsupport.enabled";
 const PREF_LOGGING_LEVEL = PREF_BRANCH + "logging.level";
 
 let shouldRun = true;
+let log = null;
 
 this.install = function() {
   // Self Repair only checks its pref on start, so if we disable it, wait until
@@ -62,6 +63,7 @@ this.startup = function() {
 
   // Setup logging and listen for changes to logging prefs
   LogManager.configure(Services.prefs.getIntPref(PREF_LOGGING_LEVEL));
+  log = LogManager.getLogger("bootstrap");
   Preferences.observe(PREF_LOGGING_LEVEL, LogManager.configure);
   CleanupManager.addCleanupHandler(
     () => Preferences.ignore(PREF_LOGGING_LEVEL, LogManager.configure));
@@ -90,9 +92,13 @@ this.shutdown = function(data, reason) {
     "lib/SandboxManager.jsm",
     "lib/Storage.jsm",
   ];
-  for (const module in modules) {
+  for (const module of modules) {
+    log.debug(`Unloading ${module}`);
     Cu.unload(`resource://shield-recipe-client/${module}`);
   }
+
+  // Don't forget the logger!
+  log = null;
 };
 
 this.uninstall = function() {

--- a/recipe-client-addon/lib/NormandyApi.jsm
+++ b/recipe-client-addon/lib/NormandyApi.jsm
@@ -16,9 +16,13 @@ this.EXPORTED_SYMBOLS = ["NormandyApi"];
 const log = LogManager.getLogger("normandy-api");
 const prefs = Services.prefs.getBranch("extensions.shield-recipe-client.");
 
-let indexPromise;
+let indexPromise = null;
 
 this.NormandyApi = {
+  clearIndexCache() {
+    indexPromise = null;
+  },
+
   apiCall(method, endpoint, data = {}) {
     const url = new URL(endpoint);
     method = method.toLowerCase();

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -194,15 +194,17 @@ this.RecipeRunner = {
    * API url. This is used mainly by the mock-recipe-server JS that is
    * executed in the browser console.
    */
-  testRun(baseApiUrl) {
+  testRun: Task.async(function* (baseApiUrl) {
     const oldApiUrl = prefs.getCharPref("api_url");
     prefs.setCharPref("api_url", baseApiUrl);
 
-    Storage.clearAllStorage();
-    NormandyApi.clearIndexCache();
-    this.start();
-
-    prefs.setCharPref("api_url", oldApiUrl);
-    NormandyApi.clearIndexCache();
-  },
+    try {
+      Storage.clearAllStorage();
+      NormandyApi.clearIndexCache();
+      yield this.start();
+    } finally {
+      prefs.setCharPref("api_url", oldApiUrl);
+      NormandyApi.clearIndexCache();
+    }
+  }),
 };

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -18,6 +18,7 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["fetch"]); /* globals fetch */
 
 XPCOMUtils.defineLazyModuleGetter(this, "Preferences", "resource://gre/modules/Preferences.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "Storage", "resource://shield-recipe-client/lib/Storage.jsm");
 
 this.EXPORTED_SYMBOLS = ["RecipeRunner"];
 
@@ -186,5 +187,22 @@ this.RecipeRunner = {
       sandboxManager.evalInSandbox(prepScript);
       sandboxManager.evalInSandbox(actionScript);
     });
+  },
+
+  /**
+   * Clear out cached state and fetch/execute recipes from the given
+   * API url. This is used mainly by the mock-recipe-server JS that is
+   * executed in the browser console.
+   */
+  testRun(baseApiUrl) {
+    const oldApiUrl = prefs.getCharPref("api_url");
+    prefs.setCharPref("api_url", baseApiUrl);
+
+    Storage.clearAllStorage();
+    NormandyApi.clearIndexCache();
+    this.start();
+
+    prefs.setCharPref("api_url", oldApiUrl);
+    NormandyApi.clearIndexCache();
   },
 };


### PR DESCRIPTION
Long-term I'd like to do something like make `NormandyApi` a class, and use an instance of it during recipe runs (and the instance could then be discarded and GC'd to get rid of the index cache), but as a short-term fix, I added a method to clear the index cache that we can use in the mock-server testscases.

I also added the test method to `RecipeRunner` to avoid piling up even _more_ calls in the mock-server testcases. The unloading in particular helps get around an issue where running the mock-server testcases in the browser console, then updating the add-on without restarting, would leave the modules loaded in the browser console out-of-date.

I didn't add tests for these changes because the `testRun` method is only supposed to be run manually for testing, and `NormandyApi.clearIndexCache` is hard to unit-test, and will become irrelevant with the aforementioned refactoring that I'll work on soon; it's just a stopgap for now. But feel free to call me out as wrong on this. :D