### PR TITLE
recipe-server: Add cache headers to signed recipe endpoint

### DIFF
--- a/recipe-server/contract-tests/test_performance.py
+++ b/recipe-server/contract-tests/test_performance.py
@@ -7,6 +7,7 @@ HOT_PATHS = [
     '/en-US/repair',
     '/en-US/repair/',
     '/api/v1/recipe/',
+    '/api/v1/recipe/signed/',
     '/api/v1/action/',
 ]
 
@@ -32,3 +33,16 @@ class TestHotPaths(object):
         r = requests_session.get(conf.getoption('server') + path)
         r.raise_for_status()
         assert 'cookie' not in r.headers.get('vary', '').lower()
+
+    def test_cache_headers(self, conf, requests_session, path):
+        r = requests_session.get(conf.getoption('server') + path)
+        r.raise_for_status()
+        cache_control = r.headers.get('cache-control')
+        assert cache_control is not None
+
+        # parse cache-control header.
+        parts = [part.strip() for part in cache_control.split(',')]
+        max_age = [part for part in parts if part.startswith('max-age=')][0]
+        max_age_seconds = int(max_age.split('=')[1])
+        assert 'public' in parts
+        assert max_age_seconds > 0

--- a/recipe-server/normandy/recipes/api/views.py
+++ b/recipe-server/normandy/recipes/api/views.py
@@ -107,12 +107,14 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
         return queryset
 
     @list_route(methods=['GET'])
+    @cache_control(public=True, max_age=settings.API_CACHE_TIME)
     def signed(self, request, pk=None):
         recipes = self.filter_queryset(self.get_queryset()).exclude(signature=None)
         serializer = SignedRecipeSerializer(recipes, many=True)
         return Response(serializer.data)
 
     @detail_route(methods=['GET'])
+    @cache_control(public=True, max_age=settings.API_CACHE_TIME)
     def history(self, request, pk=None):
         recipe = self.get_object()
         serializer = RecipeRevisionSerializer(recipe.revisions.all(), many=True,

--- a/recipe-server/normandy/recipes/tests/test_api.py
+++ b/recipe-server/normandy/recipes/tests/test_api.py
@@ -320,9 +320,16 @@ class TestRecipeAPI(object):
         assert 'max-age=' in res['Cache-Control']
         assert 'public' in res['Cache-Control']
 
+    def test_signed_view_includes_cache_headers(self, api_client):
+        res = api_client.get('/api/v1/recipe/signed/')
+        assert res.status_code == 200
+        # It isn't important to assert a particular value for max-age
+        assert 'max-age=' in res['Cache-Control']
+        assert 'public' in res['Cache-Control']
+
     def test_detail_view_includes_cache_headers(self, api_client):
         recipe = RecipeFactory()
-        res = api_client.get('/api/v1/recipe/{id}/'.format(id=recipe.id))
+        res = api_client.get(f'/api/v1/recipe/{recipe.id}/')
         assert res.status_code == 200
         # It isn't important to assert a particular value for max-age
         assert 'max-age=' in res['Cache-Control']

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -284,8 +284,6 @@ class Base(Core):
         os.path.join(Core.BASE_DIR, 'assets'),
     )
 
-    # Overwrite old files when uploading media.
-    DEFAULT_FILE_STORAGE = values.Value('storages.backends.overwrite.OverwriteStorage')
     # URL that the CDN exists at to front cached parts of the site, if any.
     CDN_URL = values.URLValue(None)
     # URL that bypasses any CDNs
@@ -369,7 +367,7 @@ class ProductionInsecure(Production):
     ])
 
 
-class ProductionReadOnlyInsecure(ProductionReadOnly, ProductionInsecure):
+class ProductionReadOnlyInsecure(ProductionInsecure, ProductionReadOnly):
     pass
 
 


### PR DESCRIPTION
Fixes #580