### PR TITLE
Fix #566: Revert back to using the default Django staticfiles storage. 

### DIFF
--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -76,6 +76,7 @@ class Core(Configuration):
     USE_TZ = True
 
     # Static files (CSS, JavaScript, Images)
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
     STATICFILES_FINDERS = [
         'django.contrib.staticfiles.finders.FileSystemFinder',
         'django.contrib.staticfiles.finders.AppDirectoriesFinder',
@@ -276,7 +277,6 @@ class Base(Core):
         os.path.join(Core.BASE_DIR, 'assets'),
     )
 
-    STATICFILES_STORAGE = values.Value('whitenoise.django.GzipManifestStaticFilesStorage')
     # Overwrite old files when uploading media.
     DEFAULT_FILE_STORAGE = values.Value('storages.backends.overwrite.OverwriteStorage')
     # URL that the CDN exists at to front cached parts of the site, if any.
@@ -377,4 +377,3 @@ class Test(Base):
     SECRET_KEY = 'not a secret'
     DEFAULT_FILE_STORAGE = 'inmemorystorage.InMemoryStorage'
     SECURE_SSL_REDIRECT = False
-    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'

--- a/recipe-server/normandy/storage.py
+++ b/recipe-server/normandy/storage.py
@@ -1,6 +1,0 @@
-from pipeline.storage import PipelineMixin
-from whitenoise.django import GzipManifestStaticFilesStorage
-
-
-class GzipManifestPipelineStorage(PipelineMixin, GzipManifestStaticFilesStorage):
-    pass


### PR DESCRIPTION
Along with the fix, I deleted an old python file we weren't using anymore.