### PR TITLE
Update canonical site url to normandy.services.mozilla.com

### DIFF
--- a/docs/dev/concepts.rst
+++ b/docs/dev/concepts.rst
@@ -79,7 +79,7 @@ JSON format as returned by Normandy:
       "revision_id": 12,
       "action": {
          "name": "console-log",
-         "implementation_url": "https://self-repair.mozilla.org/api/v1/action/console-log/implementation/8ee8e7621fc08574f854972ee77be2a5280fb546/",
+         "implementation_url": "https://normandy.cdn.mozilla.net/api/v1/action/console-log/implementation/8ee8e7621fc08574f854972ee77be2a5280fb546/",
          "arguments_schema": {
             "$schema": "http://json-schema.org/draft-04/schema#",
             "description": "Log a message to the console",

--- a/docs/qa/environments.rst
+++ b/docs/qa/environments.rst
@@ -9,7 +9,8 @@ Production
 Production is the live, user-facing instance of Normandy that is hit by every
 active user of Firefox.
 
-- **Server URL:** https://self-repair.mozilla.org/
+- **Server URL:** https://normandy.cdn.mozilla.net/
+- **Alternate URL (deprecated):** https://self-repair.mozilla.org/
 - **Control Interface:** https://normandy-admin.prod.mozaws.net/control/
 
 Preferences
@@ -19,7 +20,7 @@ production server:
 
 .. describe:: extensions.shield-recipe-client.api_url
 
-   ``https://self-repair.mozilla.org/api/v1``
+   ``https://normandy.cdn.mozilla.net/api/v1``
 
 .. describe:: security.content.signature.root_hash
 

--- a/docs/qa/example.rst
+++ b/docs/qa/example.rst
@@ -125,7 +125,7 @@ our new recipe:
 
       {
          "name": "show-heartbeat",
-         "implementation_url": "https://self-repair.mozilla.org/api/v1/action/notification/implementation/4574dbc126af07cd031a0da29d625a11365403ea/",
+         "implementation_url": "https://normandy.cdn.mozilla.net/v1/action/notification/implementation/4574dbc126af07cd031a0da29d625a11365403ea/",
          "arguments_schema": {
                "$schema": "http://json-schema.org/draft-04/schema#",
                "title": "Display a pop-up notification",

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -29,7 +29,7 @@ const REASONS = {
 
 const PREF_BRANCH = "extensions.shield-recipe-client.";
 const DEFAULT_PREFS = {
-  api_url: "https://self-repair.mozilla.org/api/v1",
+  api_url: "https://normandy.cdn.mozilla.net/api/v1",
   dev_mode: false,
   enabled: true,
   startup_delay_seconds: 300,


### PR DESCRIPTION
This changes the system add-on and our docs to point to https://normandy.services.mozilla.com, which will be our new home in the future.

The main reason for this is that we can easily make this new URL be backed by the CDN in the ways we want, and the SSL certs are a lot cheaper than what we'd have to do to pull off the same trick for self-repair.mozilla.org.

@relud Did I get all that right? Did I tell any lies? Can you confirm that normandy.services.mozilla.com should be able to handle the load of our full userbase?