### PR TITLE
Fix recipe preview by including credentials in self-repair fetch

### DIFF
--- a/recipe-server/client/control/api/index.js
+++ b/recipe-server/client/control/api/index.js
@@ -19,7 +19,7 @@ const BASE_API_URL = '/api/v1/';
 
 // Default API request settings
 export const API_REQUEST_SETTINGS = {
-  credentials: 'include',
+  credentials: 'same-origin',
   headers: {
     'X-CSRFToken': document.getElementsByTagName('html')[0].dataset.csrf,
     Accept: 'application/json',

--- a/recipe-server/client/selfrepair/self_repair_runner.js
+++ b/recipe-server/client/selfrepair/self_repair_runner.js
@@ -48,7 +48,8 @@ export function fetchAction(recipe) {
 
   if (!(recipe.action in cache)) {
     const headers = { Accept: 'application/json' };
-    cache[recipe.action] = fetch(`/api/v1/action/${recipe.action}/`, { headers })
+    const credentials = 'same-origin';
+    cache[recipe.action] = fetch(`/api/v1/action/${recipe.action}/`, { headers, credentials })
       .then(response => response.json());
   }
 
@@ -64,7 +65,7 @@ export function fetchRecipes() {
   const { recipeUrl } = document.documentElement.dataset;
   const headers = { Accept: 'application/json' };
 
-  return fetch(`${recipeUrl}?enabled=true`, { headers })
+  return fetch(`${recipeUrl}?enabled=true`, { headers, credentials: 'same-origin' })
   .then(response => response.json());
 }
 
@@ -79,7 +80,7 @@ export function classifyClient() {
 
   classifyUrl = new URL(classifyUrl, window.location.href);
 
-  return fetch(classifyUrl.href, { headers })
+  return fetch(classifyUrl.href, { headers, credentials: 'same-origin' })
   .then(response => response.json())
   .then(classification => {
     // Parse request time

--- a/recipe-server/client/selfrepair/tests/test_self_repair_runner.js
+++ b/recipe-server/client/selfrepair/tests/test_self_repair_runner.js
@@ -50,6 +50,7 @@ describe('Self-Repair Runner', () => {
       await fetchRecipes();
 
       expect(fetchMock.lastOptions()).toEqual({
+        credentials: 'same-origin',
         headers: {
           Accept: 'application/json',
         },
@@ -96,6 +97,7 @@ describe('Self-Repair Runner', () => {
       await fetchAction(recipe);
 
       expect(fetchMock.lastOptions()).toEqual({
+        credentials: 'same-origin',
         headers: {
           Accept: 'application/json',
         },


### PR DESCRIPTION
We are now using OIDC authentication on stage, and soon on prod. This introduced an error in recipe previews, because when we fetched actions (and other things), we did not include credentials (cookies), which meant that those requests got redirected to the auth0.

The fix for this is easy: include credentials in fetch for those requests.

The verification is harder: I rigged up the compose nginx to fake OIDC login, by requiring HTTP basic auth, and passing that as a `Remote-User` header. Now whatever is put in the HTTP basic auth prompt will be the user you get logged in, including creating a new user.

To test this: use compose. With only the first commit, the error from stage is reproduced (preview doesn't work). With both commits, it is fixed.

@relud can you r? the nginx changes here?