### PR TITLE
self-repair: Remove stale reference to driver.location

### DIFF
--- a/recipe-server/client/selfrepair/self_repair.js
+++ b/recipe-server/client/selfrepair/self_repair.js
@@ -12,9 +12,6 @@ driver.registerCallbacks();
 // Actually fetch and run the recipes.
 fetchRecipes().then(recipes => {
   filterContext(driver).then(context => {
-    // Update Normandy driver with user's country.
-    driver._location.countryCode = context.normandy.country;
-
     for (const recipe of recipes) {
       doesRecipeMatch(recipe, context).then(([, match]) => {
         if (match) {


### PR DESCRIPTION
We removed `driver.location` recently, but didn't remove this reference to it. This prevents any self-repair clients (i.e. almost everyone) from running recipes.

I thought about a test for this, but I can't think of any clean way of testing this without being able to make assertions about a real browser beyond what the functional tests can do. Since the self-repair driver is on its way out, I'm ok with this.

Also, I rewrote this as a async function because it is much nicer this way, and I hate easy to read diffs.