### PR TITLE
Stop blocking framing of selfrepair via CSP

### DIFF
--- a/recipe-server/contract-tests/test_api.py
+++ b/recipe-server/contract-tests/test_api.py
@@ -110,7 +110,7 @@ def test_recipe_signatures(conf, requests_session):
 
 
 def test_recipe_api_is_json(conf, requests_session):
-    r = requests_session.get(conf.getoption('server') + '/api/v1/recipe/')
+    r = requests_session.get(conf.getoption('server') + '/api/v1/recipe/?enabled=1')
     r.raise_for_status()
     data = r.json()
     assert isinstance(data, list)

--- a/recipe-server/contract-tests/test_performance.py
+++ b/recipe-server/contract-tests/test_performance.py
@@ -34,7 +34,7 @@ class TestHotPaths(object):
         r.raise_for_status()
         assert 'cookie' not in r.headers.get('vary', '').lower()
 
-    def test_cache_headers(self, conf, requests_session, path):
+    def test_cache_headers(self, conf, requests_session, path, only_readonly):
         r = requests_session.get(conf.getoption('server') + path)
         r.raise_for_status()
         cache_control = r.headers.get('cache-control')

--- a/recipe-server/contract-tests/test_performance.py
+++ b/recipe-server/contract-tests/test_performance.py
@@ -6,8 +6,8 @@ from pytest_testrail.plugin import testrail
 HOT_PATHS = [
     '/en-US/repair',
     '/en-US/repair/',
-    '/api/v1/recipe/',
-    '/api/v1/recipe/signed/',
+    '/api/v1/recipe/?enabled=1',
+    '/api/v1/recipe/signed/?enabled=1',
     '/api/v1/action/',
 ]
 

--- a/recipe-server/normandy/health/urls.py
+++ b/recipe-server/normandy/health/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     url(r'^__version__', views.version, name='version'),
     url(r'^__heartbeat__', views.heartbeat, name='heartbeat'),
     url(r'^__lbheartbeat__', views.lbheartbeat, name='lbheartbeat'),
+    url(r'^__cspreport__', views.cspreport, name='cspreport'),
 ]

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -290,7 +290,7 @@ class Base(Core):
     APP_SERVER_URL = values.URLValue(None)
 
     # URL for the CSP report-uri directive.
-    CSP_REPORT_URI = values.Value(None)
+    CSP_REPORT_URI = values.Value('/__cspreport__')
 
     # Normandy settings
     ADMIN_ENABLED = values.BooleanValue(True)

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -124,8 +124,13 @@ class Core(Configuration):
 
     # these don't fallback to default-src
     CSP_BASE_URI = "'none'"  # not using <base>
-    CSP_FRAME_ANCESTORS = "'none'"  # this page isn't iframed elsewhere
     CSP_FORM_ACTION = "'self'"  # we only submit forms to ourselves
+
+    # TODO(mythmon) Re-add this once either:
+    #   1) We know the domain we can use for Firefox's framing of the self-repair frame
+    #   2) We've deprecated the self-repair frame entirely
+    #   3) django-csp allows removing directives on an individual view (mozilla/django-csp#85)
+    # CSP_FRAME_ANCESTORS = "'none'"  # Block framing by default
 
     # Action names and the path they are located at.
     ACTIONS = {


### PR DESCRIPTION
This changes our CSP policy to allow framing the self-repair view, since it gets loaded in an iframe in Firefox. This should only affect the `/en-US/repair` endpoint (and other locales). It doesn't change our global policy.

I also included two small changes to the contract tests to make them nicer to run, since I ran them a lot while making this.