### PR TITLE
Clear client classification cache during mock-server test runs.

### DIFF
--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -38,6 +38,10 @@ this.ClientEnvironment = {
     return yield _classifyRequest;
   }),
 
+  clearClassifyCache() {
+    _classifyRequest = null;
+  },
+
   /**
    * Test wrapper that mocks the server request for classifying the client.
    * @param  {Object}   data          Fake server data to use

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -200,6 +200,7 @@ this.RecipeRunner = {
 
     try {
       Storage.clearAllStorage();
+      ClientEnvironment.clearClassifyCache();
       NormandyApi.clearIndexCache();
       yield this.start();
     } finally {


### PR DESCRIPTION
The geolocation mock tests weren't working when run from the browser console, because the classification (which geolocates the user using our service) was being cached, but the geolocation testcases provide their own mock classifications. They still work fine when manually restarting the browser, though.

The right solution is still to not globally cache this stuff for the entire session, but I'm deferring that refactor to a later time.

This is so minor I claim only one reviewer is necessary. :P