### PR TITLE
recipe-server: Make whitenoise recognize our webpack'd files as immutable

### DIFF
--- a/recipe-server/normandy/base/middleware.py
+++ b/recipe-server/normandy/base/middleware.py
@@ -1,3 +1,6 @@
+import os
+import re
+
 from django.conf import settings
 from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
@@ -6,6 +9,7 @@ from django.contrib.auth.middleware import RemoteUserMiddleware
 from mozilla_cloud_services_logger.django.middleware import (
     RequestSummaryLogger as OriginalRequestSummaryLogger
 )
+from whitenoise.middleware import WhiteNoiseMiddleware
 
 
 def request_received_at_middleware(get_response):
@@ -43,3 +47,21 @@ class ConfigurableRemoteUserMiddleware(RemoteUserMiddleware):
         prefixed with "HTTP_".
         """
         return settings.OIDC_REMOTE_AUTH_HEADER
+
+
+class NormandyWhiteNoiseMiddleware(WhiteNoiseMiddleware):
+
+    def is_immutable_file(self, path, url):
+        """
+        Determine whether given URL represents an immutable file (i.e. a
+        file with a hash of its contents as part of its name) which can
+        therefore be cached forever
+        """
+        if not url.startswith(self.static_prefix):
+            return False
+        filename = os.path.basename(url)
+        # Check if the filename ends with either 20 or 32 hex digits, and then an extension
+        # 20 is for normal hashed content, like JS or CSS files, which use "[name].[hash].[ext]"
+        # 32 is for content addressed files, like images or fonts, which use "[hash].[ext]"
+        match = re.match(r'^.*([a-f0-9]{20}|[a-f0-9]{32})\.[\w\d]+$', filename)
+        return bool(match)

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -28,6 +28,7 @@ class Core(Configuration):
         'django.contrib.contenttypes',
         'django.contrib.sessions',
         'django.contrib.messages',
+        'whitenoise.runserver_nostatic',
         'django.contrib.staticfiles',
     ]
 
@@ -37,6 +38,7 @@ class Core(Configuration):
         'normandy.base.middleware.request_received_at_middleware',
         'normandy.base.middleware.RequestSummaryLogger',
         'django.middleware.security.SecurityMiddleware',
+        'normandy.base.middleware.NormandyWhiteNoiseMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
         'csp.middleware.CSPMiddleware',
@@ -71,7 +73,6 @@ class Core(Configuration):
     USE_TZ = True
 
     # Static files (CSS, JavaScript, Images)
-    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
     STATICFILES_FINDERS = [
         'django.contrib.staticfiles.finders.FileSystemFinder',
         'django.contrib.staticfiles.finders.AppDirectoriesFinder',
@@ -185,7 +186,7 @@ class Base(Core):
     def LOGGING(self):
         return {
             'version': 1,
-            'disable_existing_loggers': True,
+            'disable_existing_loggers': False,
             'formatters': {
                 'json': {
                     '()': 'mozilla_cloud_services_logger.formatters.JsonLogFormatter',

--- a/recipe-server/normandy/urls.py
+++ b/recipe-server/normandy/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.conf.urls import include, url
-from django.conf.urls.static import static
 from django.contrib import admin
 
 
@@ -16,6 +15,3 @@ urlpatterns += [
     url(r'', include('normandy.control.urls')),
     url(r'', include('normandy.health.urls')),
 ]
-
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/recipe-server/normandy/wsgi.py
+++ b/recipe-server/normandy/wsgi.py
@@ -1,11 +1,10 @@
 import os
 
 from configurations.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
 
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "normandy.settings")
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'normandy.settings')
 os.environ.setdefault('DJANGO_CONFIGURATION', 'Production')
 
 
-application = DjangoWhiteNoise(get_wsgi_application())
+application = get_wsgi_application()

--- a/recipe-server/requirements/constraints.txt
+++ b/recipe-server/requirements/constraints.txt
@@ -87,3 +87,5 @@ greenlet==0.4.12 \
 pycodestyle==2.3.1 \
     --hash=sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9 \
     --hash=sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766
+webencodings==0.5 \
+    --hash=sha256:a5c55ee93b24e740fe951c37b5c228dccc1f171450e188555a775261cce1b904

--- a/recipe-server/requirements/default.txt
+++ b/recipe-server/requirements/default.txt
@@ -109,11 +109,14 @@ sphinxcontrib-httpdomain==1.4.0 \
 statsd==3.2.1 \
     --hash=sha256:7aff40c6cdda703193fac6231410c6c0ad5939ce053a168016501e982c755c84 \
     --hash=sha256:3fa92bf0192af926f7a0d9be031fe3fd0fbaa1992d42cf2f07e68f76ac18288e
-whitenoise==2.0.6 \
-    --hash=sha256:826ffe5d608c9dc8daebef1b0b43d01f7958f17c2fce36e75c80e26160172c4f \
-    --hash=sha256:5aea935dfc09ef2beeb76960b4a808b0bbe65e85fb0b0312434b9c365ca02a41
+whitenoise==3.3.0 \
+    --hash=sha256:1d62a003a0ab747de96da45c831cbb512dcb7f69c1ef0bd20b1cd4ae45d8a0c4 \
+    --hash=sha256:d098327276de6fd189398a7bcb95789d1bb2d41b3e011eeae4562f6b1a107dd4
 newrelic==2.78.0.57 \
     --hash=sha256:2191b7699e14a07efa5d9221270eb29bdf6cce643aa56cff08546ecb3f729be6
 django-csp==3.2 \
     --hash=sha256:7cec78ba7c426deba6d4bea188dcfc1a8b2609ad98dd539c365605c9ec2996b2 \
     --hash=sha256:fb56c0126b4e69f854fd1581a4bef25fa7cac1f10235e95f697e297ceef88132
+html5lib==1.0b10 \
+    --hash=sha256:08a3efc117a4fc8c82c3c6d10d6f58ae266428d57ed50258a1466d2cd88de745 \
+    --hash=sha256:0d5fd54d5b2b79b876007a70c033a4023577768d18022c15681c00561432a0f9

--- a/recipe-server/webpack.config.js
+++ b/recipe-server/webpack.config.js
@@ -10,11 +10,14 @@ var childProcess = require('child_process');
 const BOLD = '\u001b[1m';
 const END_BOLD = '\u001b[39m\u001b[22m';
 const production = process.env.NODE_ENV === 'production';
+const cssNamePattern = production ? '[name].[hash].css' : '[name].css';
+const jsNamePattern = production ? '[name].[hash].js' : '[name].js';
 
 var plugins = [
   new BundleTracker({ filename: './webpack-stats.json' }),
   new webpack.optimize.OccurrenceOrderPlugin(true),
-  new ExtractTextPlugin(production ? '[name]-[hash].css' : '[name].css'),
+  // Note: This matches Django's idea of what a hashed url looks like. Be careful when changing it!
+  new ExtractTextPlugin(cssNamePattern),
   new webpack.DefinePlugin({
     PRODUCTION: production,
     DEVELOPMENT: !production,
@@ -61,7 +64,7 @@ module.exports = [
 
     output: {
       path: path.resolve('./assets/bundles/'),
-      filename: production ? '[name]-[hash].js' : '[name].js',
+      filename: jsNamePattern,
       chunkFilename: '[id].bundle.js',
     },
     externals: {
@@ -144,7 +147,7 @@ module.exports = [
 
     output: {
       path: path.resolve('./assets/bundles/'),
-      filename: production ? '[name]-[hash].js' : '[name].js',
+      filename: jsNamePattern,
     },
 
     module: {


### PR DESCRIPTION
This fixes a regression where our static files only had a cache length of 60 seconds. The upgrade of whitenoise also gets us support for [`Cache-Control: immutable`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Revalidation_and_reloading), which should save us some traffic in prod.

I added the SRI test here, because last time we fiddled with the static loaders, we broke SRI. I wanted to make sure it stayed fixed.