### PR TITLE
recipe-server: Handle validation errors in API gracefully

### DIFF
--- a/recipe-server/normandy/base/api/filters.py
+++ b/recipe-server/normandy/base/api/filters.py
@@ -11,7 +11,7 @@ class CaseInsensitiveBooleanFilter(django_filters.Filter):
             lc_value = value.lower()
             if lc_value in ['true', '1']:
                 value = True
-            if lc_value in ['false', '0']:
+            elif lc_value in ['false', '0']:
                 value = False
             return qs.filter(**{self.name: value})
         return qs

--- a/recipe-server/normandy/base/api/views.py
+++ b/recipe-server/normandy/base/api/views.py
@@ -1,11 +1,13 @@
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
 
-from rest_framework.compat import NoReverseMatch
+from rest_framework import status
+from rest_framework.compat import NoReverseMatch, set_rollback
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from rest_framework.views import APIView
+from rest_framework.views import APIView, exception_handler as original_exception_handler
 
 
 class APIRootView(APIView):
@@ -40,3 +42,25 @@ class APIRootView(APIView):
                 pass
 
         return Response(ret)
+
+
+def exception_handler(exc, context):
+    """
+    Returns the response that should be used for any given exception.
+
+    Adds support the DRF default to also handle django.core.exceptions.ValidationError
+
+    Any unhandled exceptions may return `None`, which will cause a 500 error
+    to be raised.
+    """
+    response = original_exception_handler(exc, context)
+
+    if response:
+        return response
+
+    elif isinstance(exc, DjangoValidationError):
+        data = {'messages': exc.messages}
+        set_rollback()
+        return Response(data, status=status.HTTP_400_BAD_REQUEST)
+
+    return None

--- a/recipe-server/normandy/recipes/tests/test_api.py
+++ b/recipe-server/normandy/recipes/tests/test_api.py
@@ -313,6 +313,21 @@ class TestRecipeAPI(object):
         assert res.status_code == 200
         assert [r['id'] for r in res.data] == [r1.id]
 
+    def test_filtering_by_enabled_fuzz(self, api_client):
+        """
+        Test that we don't return 500 responses when we get unexpected boolean filters.
+
+        This was a real case that showed up in our error logging.
+        """
+        url = "/api/v1/recipe/?enabled=javascript%3a%2f*<%2fscript><svg%2fonload%3d'%2b%2f'%2f%2b"
+        res = api_client.get(url)
+        assert res.status_code == 400
+        assert res.data == {
+            'messages': [
+                "'javascript:/*</script><svg/onload='+/'/+' value must be either True or False.",
+            ],
+        }
+
     def test_list_view_includes_cache_headers(self, api_client):
         res = api_client.get('/api/v1/recipe/')
         assert res.status_code == 200

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -96,7 +96,8 @@ class Core(Configuration):
         'DEFAULT_RENDERER_CLASSES': (
             'normandy.base.api.renderers.CanonicalJSONRenderer',
             'normandy.base.api.renderers.CustomBrowsableAPIRenderer',
-        )
+        ),
+        'EXCEPTION_HANDLER': 'normandy.base.api.views.exception_handler',
     }
 
     WEBPACK_LOADER = {


### PR DESCRIPTION
This should deal with [this recent Sentry issue](https://sentry.prod.mozaws.net/operations/normandy-prod/issues/387570/), which is what the test case was based on.