### PR TITLE
recipe-server: Use more eslint rules from eslint-plugin-react

### DIFF
--- a/recipe-server/.eslintrc
+++ b/recipe-server/.eslintrc
@@ -1,8 +1,11 @@
-extends: airbnb
+extends:
+  - airbnb
+  - plugin:react/recommended
 parser: babel-eslint
 plugins:
   - jasmine
   - babel
+  - react
 globals:
   PRODUCTION: false
   DEVELOPMENT: false
@@ -26,7 +29,12 @@ rules:
   import/no-named-as-default: [off]
   react/jsx-filename-extension: [error, { extensions: [.js] }]
   react/no-multi-comp: [off]
+  react/jsx-no-bind: [error]
+  react/jsx-boolean-value: [warn]
+  react/jsx-wrap-multilines: [error]
+  react/no-danger-with-children: [error]
   react/require-extension: [off]  # deprecated
+  react/self-closing-comp: [warn]
   jsx-a11y/label-has-for: [off]
 
   # generator-star-spacing is broken with parser: babel-eslint. Use a patched version

--- a/recipe-server/client/control/components/RecipeFilters.js
+++ b/recipe-server/client/control/components/RecipeFilters.js
@@ -128,7 +128,7 @@ export class RecipeFilters extends React.Component {
     return (
       <div className="fluid-8">
         <div id="secondary-header" className="fluid-8">
-          <div className="header-search" className="fluid-2">
+          <div className="header-search fluid-2">
             <RecipeCombobox
               onFilterSelect={this.handleAddFilter}
               availableFilters={availableFilters}

--- a/recipe-server/client/control/sass/control.scss
+++ b/recipe-server/client/control/sass/control.scss
@@ -90,7 +90,6 @@
   h3 {
     color: $darkBrown;
     display: inline-block;
-    float: left;
     font-size: 14px;
     font-weight: 600;
     margin: 15px;


### PR DESCRIPTION
The main rule that I wanted to add here was `react/jsx-no-bind`, which would have caught several review comments that have come up recently. While I was reading about the rules, I also noticed that there were several rules in `eslint-plugin-react` that seemed useful that we weren't using. Some of them even prevent straight up errors.

I'm happy to remove any of these extra rules if they aren't wanted.