### PR TITLE
Bug 1348885: Do not call Cu.reportError on errors from the sandbox.

### DIFF
--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -174,8 +174,6 @@ this.RecipeRunner = {
         resolve(clonedResult);
       });
       sandboxManager.addGlobal("actionFailed", err => {
-        Cu.reportError(err);
-
         // Error objects can't be cloned, so we just copy the message
         // (which doesn't need to be cloned) to be somewhat useful.
         const message = err.message;


### PR DESCRIPTION
See [bug 1348885](https://bugzilla.mozilla.org/show_bug.cgi?id=1348885) for details. This is the simple way to avoid a hard-looking issue. :P

Only asking for one reviewer since this is a one-liner.