### PR TITLE
Fix TaskCluster builds.

### DIFF
--- a/recipe-client-addon/bin/tc/test.sh
+++ b/recipe-client-addon/bin/tc/test.sh
@@ -10,7 +10,8 @@ echo 'deb https://deb.nodesource.com/node_6.x yakkety main' > /etc/apt/sources.l
 echo 'deb-src https://deb.nodesource.com/node_6.x yakkety main' >> /etc/apt/sources.list.d/nodesource.list
 apt-get update
 
-apt-get install -y curl python2.7 xvfb nodejs
+# libgl1-mesa-dev works around a webrender build issue
+apt-get install -y curl python2.7 xvfb nodejs libgl1-mesa-dev
 
 # Creates gecko-dev-master
 echo 'Downloading gecko-dev...'


### PR DESCRIPTION
@Mossop says installing libgl1-mesa-dev will fix the build errors due to webrender. Let's see!