### PR TITLE
addon: Add Storage durability checks (#433)

### DIFF
--- a/recipe-client-addon/bin/make-xpi.sh
+++ b/recipe-client-addon/bin/make-xpi.sh
@@ -23,7 +23,7 @@ rm "${DEST}/install.rdf.in"
 cp "${BASE_DIR}/install.rdf" "${DEST}"
 rm "${DEST}/jar.mn"
 cp "${BASE_DIR}/chrome.manifest" "${DEST}"
-rm "${DEST}/test" -r
+rm -r "${DEST}/test"
 
 pushd $DEST
 zip -r shield-recipe-client.xpi *

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -26,16 +26,14 @@ const log = LogManager.getLogger("normandy-driver");
 const actionLog = LogManager.getLogger("normandy-driver.actions");
 
 this.NormandyDriver = function(sandboxManager) {
+
   if (!sandboxManager) {
     throw new Error("sandboxManager is required");
   }
   const {sandbox} = sandboxManager;
 
-  Storage.seedDurability(sandbox);
-
   return {
     testing: false,
-    skipDurabilityCheck: false,
 
     get locale() {
       return Cc["@mozilla.org/chrome/chrome-registry;1"]
@@ -120,10 +118,10 @@ this.NormandyDriver = function(sandboxManager) {
       return ret;
     },
 
-    async createStorage(keyPrefix) {
+    async createStorage(keyPrefix, skipDurabilityCheck) {
       let storage;
       try {
-        if (!this.skipDurabilityCheck) {
+        if (!skipDurabilityCheck) {
           await Storage.checkDurability(sandbox);
         }
 

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -31,8 +31,11 @@ this.NormandyDriver = function(sandboxManager) {
   }
   const {sandbox} = sandboxManager;
 
+  Storage.seedDurability(sandbox);
+
   return {
     testing: false,
+    skipDurabilityCheck: false,
 
     get locale() {
       return Cc["@mozilla.org/chrome/chrome-registry;1"]
@@ -117,9 +120,13 @@ this.NormandyDriver = function(sandboxManager) {
       return ret;
     },
 
-    createStorage(keyPrefix) {
+    async createStorage(keyPrefix) {
       let storage;
       try {
+        if (!this.skipDurabilityCheck) {
+          await Storage.checkDurability(sandbox);
+        }
+
         storage = Storage.makeStorage(keyPrefix, sandbox);
       } catch (e) {
         log.error(e.stack);

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -12,6 +12,7 @@ Cu.import("resource://shield-recipe-client/lib/NormandyDriver.jsm");
 Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm");
 Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm");
 Cu.import("resource://shield-recipe-client/lib/SandboxManager.jsm");
+Cu.import("resource://shield-recipe-client/lib/Storage.jsm");
 Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["fetch"]); /* globals fetch */
@@ -29,6 +30,9 @@ this.RecipeRunner = {
     if (!this.checkPrefs()) {
       return;
     }
+
+    const durabilityManager = new SandboxManager();
+    Storage.seedDurability(durabilityManager.sandbox);
 
     let delay;
     if (prefs.getBoolPref("dev_mode")) {

--- a/recipe-client-addon/lib/Storage.jsm
+++ b/recipe-client-addon/lib/Storage.jsm
@@ -14,6 +14,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "OS", "resource://gre/modules/osfile.jsm
 this.EXPORTED_SYMBOLS = ["Storage"];
 
 const log = LogManager.getLogger("storage");
+
+const STORAGE_DURABILITY_KEY = '_storageDurability';
 let storePromise;
 
 function loadStorage() {
@@ -36,6 +38,56 @@ this.Storage = {
 
     const storageInterface = {
       /**
+       * Sets the initial 'durability values' for this store to increase durability
+       * confidence in later checks. Should only be called on instantiation.
+       *
+       * @returns  {Promise}
+       * @resolves When the store durability is set successfully.
+       * @rejects  Javascript exception.
+       */
+      seedStoreDurability() {
+        return new sandbox.Promise((resolve, reject) =>
+          loadStorage()
+            .then(store => {
+              store.data[prefix] = store.data[prefix] || {};
+              store.data[prefix][STORAGE_DURABILITY_KEY] = 0;
+              store.saveSoon();
+            })
+            .catch(err => reject(new sandbox.Error()))
+        );
+      },
+
+      /**
+       * Checks the durability of the current store
+       *
+       * @returns  {Promise}
+       * @resolves When the store durability is set successfully.
+       * @rejects  Javascript exception.
+       */
+      checkStoreDurability(store) {
+        store.data[prefix] = store.data[prefix] || {};
+        const localStore = store.data[prefix];
+
+        // Determine if the store has an existing durability key, and if so,
+        // detect if it is an actual number or not.
+        let durability = parseInt(localStore[STORAGE_DURABILITY_KEY], 10);
+        const isDurabilityInvalid = isNaN(durability);
+
+        // If `durability` is invalid (doesn't exist, is NaN), there is a problem
+        // with the storage's integrity.
+        if(isDurabilityInvalid) {
+          log.warn('Storage durability unconfirmed');
+        } else {
+          // If we're still here, set the new durability value into storage.
+          store.data[prefix][STORAGE_DURABILITY_KEY] = durability + 1;
+          store.saveSoon();
+        }
+
+        // Return the store so this method can be chained into promises.
+        return store;
+      }
+
+      /**
        * Sets an item in the prefixed storage.
        * @returns {Promise}
        * @resolves With the stored value, or null.
@@ -44,6 +96,7 @@ this.Storage = {
       getItem(keySuffix) {
         return new sandbox.Promise((resolve, reject) => {
           loadStorage()
+            .then(this.checkStoreDurability)
             .then(store => {
               const namespace = store.data[prefix] || {};
               const value = namespace[keySuffix] || null;
@@ -65,6 +118,7 @@ this.Storage = {
       setItem(keySuffix, value) {
         return new sandbox.Promise((resolve, reject) => {
           loadStorage()
+            .then(this.checkStoreDurability)
             .then(store => {
               if (!(prefix in store.data)) {
                 store.data[prefix] = {};
@@ -89,6 +143,7 @@ this.Storage = {
       removeItem(keySuffix) {
         return new sandbox.Promise((resolve, reject) => {
           loadStorage()
+            .then(this.checkStoreDurability)
             .then(store => {
               if (!(prefix in store.data)) {
                 return;
@@ -113,6 +168,7 @@ this.Storage = {
       clear() {
         return new sandbox.Promise((resolve, reject) => {
           return loadStorage()
+            .then(this.checkStoreDurability)
             .then(store => {
               store.data[prefix] = {};
               store.saveSoon();
@@ -125,6 +181,9 @@ this.Storage = {
         });
       },
     };
+
+    // Prepare this store for future durability checks.
+    storageInterface.seedStoreDurability();
 
     return Cu.cloneInto(storageInterface, sandbox, {
       cloneFunctions: true,

--- a/recipe-client-addon/lib/Storage.jsm
+++ b/recipe-client-addon/lib/Storage.jsm
@@ -30,27 +30,28 @@ function loadStorage() {
 }
 
 this.Storage = {
-  DURABILITY_NAMESPACE: '_storageDurability',
+  DURABILITY_NAMESPACE: 'normandy_storageDurability',
   DURABILITY_KEY: 'durable',
+  isDurabilityInvalid(value) {
+    return typeof value === 'undefined' || isNaN(value);
+  },
   async seedDurability(sandbox) {
     const globalDurabilityStore = Storage.makeStorage(this.DURABILITY_NAMESPACE, sandbox);
     let durability = await globalDurabilityStore.getItem(this.DURABILITY_KEY);
 
-    durability = parseInt(durability, 10);
-
-    if (isNaN(durability)) {
+    if (this.isDurabilityInvalid(durability)) {
       durability = 0;
     }
+
     globalDurabilityStore.setItem(this.DURABILITY_KEY, durability + 1);
   },
 
   async checkDurability(sandbox) {
       const globalDurabilityStore = Storage.makeStorage(this.DURABILITY_NAMESPACE, sandbox);
 
-      let durability = await globalDurabilityStore.getItem(this.DURABILITY_KEY)
-      durability = parseInt(durability, 10);
+      const durability = await globalDurabilityStore.getItem(this.DURABILITY_KEY)
 
-      const isDurabilityInvalid = isNaN(durability) || durability < 1;
+      const isDurabilityInvalid = this.isDurabilityInvalid(durability) || durability < 2;
 
       if(isDurabilityInvalid) {
         throw new Error('Storage durability unconfirmed');

--- a/recipe-client-addon/lib/Storage.jsm
+++ b/recipe-client-addon/lib/Storage.jsm
@@ -30,13 +30,15 @@ function loadStorage() {
 }
 
 this.Storage = {
-  DURABILITY_NAMESPACE: 'normandy_storageDurability',
-  DURABILITY_KEY: 'durable',
+  DURABILITY_NAMESPACE: "normandy_storageDurability",
+  DURABILITY_KEY: "durable",
   isDurabilityInvalid(value) {
-    return typeof value === 'undefined' || isNaN(value);
+    return typeof value === "undefined" || isNaN(value);
   },
   async seedDurability(sandbox) {
-    const globalDurabilityStore = Storage.makeStorage(this.DURABILITY_NAMESPACE, sandbox);
+    let globalDurabilityStore = this.makeStorage(this.DURABILITY_NAMESPACE, sandbox);
+    globalDurabilityStore = Cu.waiveXrays(globalDurabilityStore);
+
     let durability = await globalDurabilityStore.getItem(this.DURABILITY_KEY);
 
     if (this.isDurabilityInvalid(durability)) {
@@ -47,10 +49,10 @@ this.Storage = {
   },
 
   async checkDurability(sandbox) {
-      const globalDurabilityStore = Storage.makeStorage(this.DURABILITY_NAMESPACE, sandbox);
+      let globalDurabilityStore = this.makeStorage(this.DURABILITY_NAMESPACE, sandbox);
+      globalDurabilityStore = Cu.waiveXrays(globalDurabilityStore);
 
       const durability = await globalDurabilityStore.getItem(this.DURABILITY_KEY)
-
       const isDurabilityInvalid = this.isDurabilityInvalid(durability) || durability < 2;
 
       if(isDurabilityInvalid) {

--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -8,7 +8,7 @@ Cu.import("resource://shield-recipe-client/lib/Storage.jsm", this);
 // This test determines if `skipDurabilityCheck` correctly ignores the
 // store durability.
 add_task(async function(){
-  const fakeSandbox = { Promise };
+  const fakeSandbox = { Promise, Error };
   const driver = new NormandyDriver({ sandbox: fakeSandbox });
 
   const store = Storage.makeStorage(Storage.DURABILITY_NAMESPACE, fakeSandbox);
@@ -29,7 +29,8 @@ add_task(async function(){
     // Create storage with 'skipDurabilityCheck' disabled
     await driver.createStorage('test', false);
   } catch(e) {
-    Assert.equal(e.message, 'Storage durability unconfirmed');
+    Assert.equal(e.message, 'Storage durability unconfirmed',
+      'skipDurabilityCheck should throw an error for invalid storage durability');
   }
 });
 

--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -1,5 +1,38 @@
 "use strict";
 
+Cu.import("resource://shield-recipe-client/lib/NormandyDriver.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/Storage.jsm", this);
+
+
+// Storage durability checks occur when drivers create new Storage instances.
+// This test determines if `skipDurabilityCheck` correctly ignores the
+// store durability.
+add_task(async function(){
+  const fakeSandbox = { Promise };
+  const driver = new NormandyDriver({ sandbox: fakeSandbox });
+
+  const store = Storage.makeStorage(Storage.DURABILITY_NAMESPACE, fakeSandbox);
+  await store.setItem(Storage.DURABILITY_KEY, -1);
+  let hadError = false;
+
+  try {
+    // Create storage with the 'skipDurabilityCheck' flag set to true
+    await driver.createStorage('test', true);
+  } catch(e) {
+    hadError = true;
+  }
+  Assert.equal(hadError, false, 'skipDurabilityCheck should ignore bad storage durability');
+
+
+  await store.setItem(Storage.DURABILITY_KEY, -1);
+  try {
+    // Create storage with 'skipDurabilityCheck' disabled
+    await driver.createStorage('test', false);
+  } catch(e) {
+    Assert.equal(e.message, 'Storage durability unconfirmed');
+  }
+});
+
 add_task(withDriver(Assert, async function uuids(driver) {
   // Test that it is a UUID
   const uuid1 = driver.uuid();

--- a/recipe-client-addon/test/browser/browser_Storage.js
+++ b/recipe-client-addon/test/browser/browser_Storage.js
@@ -44,3 +44,36 @@ add_task(async function() {
   Assert.equal(await store1.getItem("removeTest"), null);
   Assert.equal(await store2.getItem("removeTest"), null);
 });
+
+// Tests fail if durability is not seeded properly
+add_task(async function() {
+  const store = Storage.makeStorage(Storage.DURABILITY_NAMESPACE, fakeSandbox);
+  await Storage.seedDurability(fakeSandbox);
+
+  // Properly seeded store should have a starting value of 1
+  Assert.equal(await store.getItem(Storage.DURABILITY_KEY), 1, "Storage durability is set to 1 on start");
+});
+
+// Tests fails if storage is does not appear to be durable.
+add_task(async function() {
+  // Manually edit the storage durability values to be invalid
+  const store = Storage.makeStorage(Storage.DURABILITY_NAMESPACE, fakeSandbox);
+  await store.setItem(Storage.DURABILITY_KEY, -1);
+
+  // Ensure invalid values fail durability checks
+  try {
+    await Storage.checkDurability(fakeSandbox);
+    throw new Error('Did not throw error');
+  } catch (err) {
+    Assert.equal(err.message, 'Storage durability unconfirmed', "Storage durability fails for invalid values");
+  }
+
+  // Ensure NaN's fail durability checks
+  await store.setItem(Storage.DURABILITY_KEY, 'not a number');
+  try {
+    await Storage.checkDurability(fakeSandbox);
+    throw new Error('Did not throw error');
+  } catch (err) {
+    Assert.equal(err.message, 'Storage durability unconfirmed', "Storage durability fails for NaN values");
+  }
+});

--- a/recipe-client-addon/test/browser/browser_Storage.js
+++ b/recipe-client-addon/test/browser/browser_Storage.js
@@ -2,7 +2,7 @@
 
 Cu.import("resource://shield-recipe-client/lib/Storage.jsm", this);
 
-const fakeSandbox = {Promise};
+const fakeSandbox = { Promise, Error };
 const store1 = Storage.makeStorage("prefix1", fakeSandbox);
 const store2 = Storage.makeStorage("prefix2", fakeSandbox);
 


### PR DESCRIPTION
Fixes #433 

I think this is ready for feedback, though I had a few questions:

- Should non-durable storage throw errors?
- Right now I have it set up so that when Storage is created, it seeds the durability check, and then every read/write after that it checks the durability.
  - Does it matter if the durability is set to 0 for each new Storage? Should it retain the existing value for any reason?
  - Is it overkill to run a durability check on each read/write? On selfrepair we check on every read, fwiw.
- Is `store.saveSoon()` necessary to save the durability key update? I'm assuming so.
- How should tests for this be written? There already exists a bunch of `browser_Storage` tests that cover storing different types of data (objects, strings, numbers, etc). 
  - Could it be as simple as creating two stores with the same namespace, and testing if they can interact with the same values?
  - On the self repair side, we simply set a value and then check if the store can read it - which doesn't necessarily seem to be a complete 'durability' check, but maybe I'm wrong.
- When a Storage object is created, I see a call to `Cu.cloneInto(...)` - does the durability seed need to happen after that step?