### PR TITLE
Bug 1349576: Remove use of services.sync.numClients preference.

### DIFF
--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -149,7 +149,7 @@ this.ClientEnvironment = {
     });
 
     XPCOMUtils.defineLazyGetter(environment, "syncTotalDevices", () => {
-      return Preferences.get("services.sync.numClients", 0);
+      return environment.syncDesktopDevices + environment.syncMobileDevices;
     });
 
     XPCOMUtils.defineLazyGetter(environment, "plugins", async function() {

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -78,11 +78,11 @@ this.NormandyDriver = function(sandboxManager) {
         syncSetup: Preferences.isSet("services.sync.username"),
         syncDesktopDevices: Preferences.get("services.sync.clients.devices.desktop", 0),
         syncMobileDevices: Preferences.get("services.sync.clients.devices.mobile", 0),
-        syncTotalDevices: Preferences.get("services.sync.numClients", 0),
         plugins: {},
         doNotTrack: Preferences.get("privacy.donottrackheader.enabled", false),
         distribution: Preferences.get("distribution.id", "default"),
       };
+      appinfo.syncTotalDevices = appinfo.syncDesktopDevices + appinfo.syncMobileDevices;
 
       const searchEnginePromise = new Promise(resolve => {
         Services.search.init(rv => {

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -78,6 +78,7 @@ this.NormandyDriver = function(sandboxManager) {
         syncSetup: Preferences.isSet("services.sync.username"),
         syncDesktopDevices: Preferences.get("services.sync.clients.devices.desktop", 0),
         syncMobileDevices: Preferences.get("services.sync.clients.devices.mobile", 0),
+        syncTotalDevices: null,
         plugins: {},
         doNotTrack: Preferences.get("privacy.donottrackheader.enabled", false),
         distribution: Preferences.get("distribution.id", "default"),

--- a/recipe-client-addon/test/browser/browser_ClientEnvironment.js
+++ b/recipe-client-addon/test/browser/browser_ClientEnvironment.js
@@ -64,7 +64,6 @@ add_task(async function testSync() {
   is(environment.syncTotalDevices, 0, "syncTotalDevices defaults to zero");
   await SpecialPowers.pushPrefEnv({
     set: [
-      ["services.sync.numClients", 9],
       ["services.sync.clients.devices.mobile", 5],
       ["services.sync.clients.devices.desktop", 4],
     ],

--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -23,7 +23,6 @@ add_task(withDriver(Assert, async function syncDeviceCounts(driver) {
 
   await SpecialPowers.pushPrefEnv({
     set: [
-      ["services.sync.numClients", 9],
       ["services.sync.clients.devices.mobile", 5],
       ["services.sync.clients.devices.desktop", 4],
     ],


### PR DESCRIPTION
It seems that sync is no longer maintaining this preference, so instead we
simply add the mobile and desktop client counts to get the same value.