### PR TITLE
recipe-client-addon: Use nsIUpdateTimerManager to run every 24 hours

### DIFF
--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -35,6 +35,7 @@ const DEFAULT_PREFS = {
   startup_delay_seconds: 300,
   "logging.level": Log.Level.Warn,
   user_id: "",
+  run_interval_seconds: 86400, // 24 hours
 };
 const PREF_DEV_MODE = "extensions.shield-recipe-client.dev_mode";
 const PREF_SELF_SUPPORT_ENABLED = "browser.selfsupport.enabled";

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -4,14 +4,13 @@
 
 "use strict";
 
-const {utils: Cu, classes: Cc, interfaces: Ci} = Components;
+const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 Cu.import("resource://shield-recipe-client/lib/NormandyDriver.jsm");
 Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm");
 Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm");
 Cu.import("resource://shield-recipe-client/lib/SandboxManager.jsm");
-Cu.import("resource://shield-recipe-client/lib/Storage.jsm");
 Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm");
 Cu.import("resource://shield-recipe-client/lib/CleanupManager.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
@@ -73,6 +72,9 @@ this.RecipeRunner = {
     return true;
   },
 
+  /**
+   * Watch for preference changes from Services.pref.addObserver.
+   */
   observe(changedPrefBranch, action, changedPref) {
     if (action === "nsPref:changed" && changedPref === "run_interval_seconds") {
       this.updateRunInterval();

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -4,7 +4,7 @@
 
 "use strict";
 
-const {utils: Cu} = Components;
+const {utils: Cu, classes: Cc, interfaces: Ci} = Components;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Timer.jsm"); /* globals setTimeout */
 Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
@@ -14,6 +14,7 @@ Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm");
 Cu.import("resource://shield-recipe-client/lib/SandboxManager.jsm");
 Cu.import("resource://shield-recipe-client/lib/Storage.jsm");
 Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm");
+Cu.import("resource://shield-recipe-client/lib/CleanupManager.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.importGlobalProperties(["fetch"]); /* globals fetch */
 
@@ -24,6 +25,7 @@ this.EXPORTED_SYMBOLS = ["RecipeRunner"];
 
 const log = LogManager.getLogger("recipe-runner");
 const prefs = Services.prefs.getBranch("extensions.shield-recipe-client.");
+const TIMER_NAME = "recipe-client-addon-run";
 
 this.RecipeRunner = {
   init() {
@@ -34,15 +36,25 @@ this.RecipeRunner = {
     const durabilityManager = new SandboxManager();
     Storage.seedDurability(durabilityManager.sandbox);
 
-    let delay;
     if (prefs.getBoolPref("dev_mode")) {
-      delay = 0;
-    } else {
-      // startup delay is in seconds
-      delay = prefs.getIntPref("startup_delay_seconds") * 1000;
+      // Run right now in dev mode
+      this.run();
     }
 
-    setTimeout(this.start.bind(this), delay);
+    // Run once every `runInterval` wall-clock seconds.
+    // This is managed by setting a "last ran" timestamp, and running if it is
+    // more than `runInterval` seconds ago.
+    const runInterval = prefs.getIntPref("run_interval_seconds");
+    const timerManager = Cc["@mozilla.org/updates/timer-manager;1"]
+                         .getService(Ci.nsIUpdateTimerManager);
+    timerManager.registerTimer(TIMER_NAME, () => this.run(), runInterval);
+    if (timerManager.unregisterTimer) {
+      CleanupManager.addCleanupHandler(() => timerManager.unregisterTimer(TIMER_NAME));
+    } else {
+      // Since we can't unregister the timer yet (Bug 1350471), re-register
+      // with a period so long as to never actually run
+      timerManager.registerTimer(TIMER_NAME, () => {}, 1e10); // about 300 years
+    }
   },
 
   checkPrefs() {
@@ -66,7 +78,8 @@ this.RecipeRunner = {
     return true;
   },
 
-  async start() {
+  async run() {
+    this.clearCaches();
     // Unless lazy classification is enabled, prep the classify cache.
     if (!Preferences.get("extensions.shield-recipe-client.experiments.lazy_classify", false)) {
       await ClientEnvironment.getClientClassification();
@@ -196,6 +209,15 @@ this.RecipeRunner = {
   },
 
   /**
+   * Clear all caches of systems used by RecipeRunner, in preparation
+   * for a clean run.
+   */
+  clearCaches() {
+    ClientEnvironment.clearClassifyCache();
+    NormandyApi.clearIndexCache();
+  },
+
+  /**
    * Clear out cached state and fetch/execute recipes from the given
    * API url. This is used mainly by the mock-recipe-server JS that is
    * executed in the browser console.
@@ -206,12 +228,11 @@ this.RecipeRunner = {
 
     try {
       Storage.clearAllStorage();
-      ClientEnvironment.clearClassifyCache();
-      NormandyApi.clearIndexCache();
-      await this.start();
+      this.clearCaches();
+      await this.run();
     } finally {
       prefs.setCharPref("api_url", oldApiUrl);
-      NormandyApi.clearIndexCache();
+      this.clearCaches();
     }
   },
 };

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -47,15 +47,7 @@ this.RecipeRunner = {
     }
 
     this.updateRunInterval();
-    if (timerManager.unregisterTimer) {
-      CleanupManager.addCleanupHandler(() => timerManager.unregisterTimer(TIMER_NAME));
-    } else {
-      // Since we can't unregister the timer yet (Bug 1350471), re-register
-      // with a period so long as to never actually run
-      CleanupManager.addCleanupHandler(() => {
-        timerManager.registerTimer(TIMER_NAME, () => {}, 1e10); // about 300 years
-      });
-    }
+    CleanupManager.addCleanupHandler(() => timerManager.unregisterTimer(TIMER_NAME));
 
     // Watch for the run interval to change, and re-register
     Preferences.observe(PREF_RUN_INTERVAL, this.updateRunInterval);

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -28,6 +28,7 @@ this.EXPORTED_SYMBOLS = ["RecipeRunner"];
 const log = LogManager.getLogger("recipe-runner");
 const prefs = Services.prefs.getBranch("extensions.shield-recipe-client.");
 const TIMER_NAME = "recipe-client-addon-run";
+const RUN_INTERVAL_PREF = "run_interval_seconds";
 
 this.RecipeRunner = {
   init() {
@@ -47,8 +48,8 @@ this.RecipeRunner = {
     CleanupManager.addCleanupHandler(() => timerManager.unregisterTimer(TIMER_NAME));
 
     // Watch for the run interval to change, and re-register the timer with the new value
-    prefs.addObserver("run_interval_seconds", this, false);
-    CleanupManager.addCleanupHandler(() => prefs.removeObserver("run_interval_seconds", this));
+    prefs.addObserver(RUN_INTERVAL_PREF, this, false);
+    CleanupManager.addCleanupHandler(() => prefs.removeObserver(RUN_INTERVAL_PREF, this));
   },
 
   checkPrefs() {
@@ -76,7 +77,7 @@ this.RecipeRunner = {
    * Watch for preference changes from Services.pref.addObserver.
    */
   observe(changedPrefBranch, action, changedPref) {
-    if (action === "nsPref:changed" && changedPref === "run_interval_seconds") {
+    if (action === "nsPref:changed" && changedPref === RUN_INTERVAL_PREF) {
       this.updateRunInterval();
     } else {
       log.debug(`Observer fired with unexpected pref change: ${action} ${changedPref}`);
@@ -87,7 +88,7 @@ this.RecipeRunner = {
     // Run once every `runInterval` wall-clock seconds. This is managed by setting a "last ran"
     // timestamp, and running if it is more than `runInterval` seconds ago. Even with very short
     // intervals, the timer will only fire at most once every few minutes.
-    const runInterval = prefs.getIntPref("run_interval_seconds");
+    const runInterval = prefs.getIntPref(RUN_INTERVAL_PREF);
     timerManager.registerTimer(TIMER_NAME, () => this.run(), runInterval);
   },
 

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -1,5 +1,6 @@
 "use strict";
 
+Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.import("resource://shield-recipe-client/lib/RecipeRunner.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm", this);
 
@@ -143,7 +144,7 @@ add_task(async function checkFilter() {
   ok(!(await RecipeRunner.checkFilter(recipe)), "The recipe is available in the filter context");
 });
 
-add_task(async function testStart() {
+add_task(async function testClientClassificationCache() {
   const getStub = sinon.stub(ClientEnvironment, "getClientClassification")
     .returns(Promise.resolve(false));
 
@@ -152,8 +153,8 @@ add_task(async function testStart() {
     ["extensions.shield-recipe-client.experiments.lazy_classify", false],
   ]});
   ok(!getStub.called, "getClientClassification hasn't been called");
-  await RecipeRunner.start();
-  ok(getStub.called, "getClientClassfication was called eagerly");
+  await RecipeRunner.run();
+  ok(getStub.called, "getClientClassification was called eagerly");
 
   // When the experiment pref is true, do not eagerly call getClientClassification.
   await SpecialPowers.pushPrefEnv({set: [
@@ -161,8 +162,8 @@ add_task(async function testStart() {
   ]});
   getStub.reset();
   ok(!getStub.called, "getClientClassification hasn't been called");
-  await RecipeRunner.start();
-  ok(!getStub.called, "getClientClassfication was not called eagerly");
+  await RecipeRunner.run();
+  ok(!getStub.called, "getClientClassification was not called eagerly");
 
   getStub.restore();
 });


### PR DESCRIPTION
This makes the add-on *not* run automatically on start up and instead run once every 24 hours. It re-uses the same timer that the update manager uses (though they aren't synced up, and in fact the timer prevents them from both running at once).

Fixes #588.