### PR TITLE
Update pytest-testrail to latest version

### DIFF
--- a/recipe-server/requirements/default.txt
+++ b/recipe-server/requirements/default.txt
@@ -86,8 +86,8 @@ pytest==3.0.2 \
 pytest-mock==0.11.0 \
     --hash=sha256:a897c6283aa116c161f5f08b8f73301685f6b8abfcd0b9b0d000668bc0faaaa3 \
     --hash=sha256:5d109071ac1c6a5a883aece92c507b4562efce86054ab39c83a9f3554688289d
-pytest-testrail==0.0.9 \
-    --hash=sha256:74a46e3f61eecccb43b55e44a7c99ae22bdf75f85ecf10caf88f03e2a95d0eb3
+pytest-testrail==0.0.11 \
+    --hash=sha256:0d671981dbc406189f42f52c890142e1728197821e3f25f888fe1791e59620aa
 raven==5.10.2 \
     --hash=sha256:f17269486e9f64ccd5a38a859e8191a8d8f5609e8f0efee6f1881e8a0fb20ed8 \
     --hash=sha256:58d52e16c834f70046f07d53795cafbf2709aef87afa9ca2a9d21be28a6ed92c


### PR DESCRIPTION
pytest-testrail 0.0.9 failed for me:

https://gist.github.com/stephendonner/6432be08802fe814356f0eba1e3b67b3

Bumping to pytest-testrail 0.011 fixed it:

```
(normandy) sdonner-17447:requirements sdonner$ hashin "pytest-testrail==0.0.11" --requirements-file=default.txt
(normandy) sdonner-17447:requirements sdonner$ git diff default.txt 
diff --git a/recipe-server/requirements/default.txt b/recipe-server/requirements/default.txt
index 6459005..fdc0b05 100644
--- a/recipe-server/requirements/default.txt
+++ b/recipe-server/requirements/default.txt
@@ -86,8 +86,8 @@ pytest==3.0.2 \
 pytest-mock==0.11.0 \
     --hash=sha256:a897c6283aa116c161f5f08b8f73301685f6b8abfcd0b9b0d000668bc0faaaa3 \
     --hash=sha256:5d109071ac1c6a5a883aece92c507b4562efce86054ab39c83a9f3554688289d
-pytest-testrail==0.0.9 \
-    --hash=sha256:74a46e3f61eecccb43b55e44a7c99ae22bdf75f85ecf10caf88f03e2a95d0eb3
+pytest-testrail==0.0.11 \
+    --hash=sha256:0d671981dbc406189f42f52c890142e1728197821e3f25f888fe1791e59620aa
 raven==5.10.2 \
     --hash=sha256:f17269486e9f64ccd5a38a859e8191a8d8f5609e8f0efee6f1881e8a0fb20ed8 \
     --hash=sha256:58d52e16c834f70046f07d53795cafbf2709aef87afa9ca2a9d21be28a6ed92c

(normandy) sdonner-17447:recipe-server sdonner$ pip install -r requirements/default.txt  -c requirements/constraints.txt 
Requirement already satisfied: bcrypt==3.1.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 1))
Requirement already satisfied: dj-database-url==0.3.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 8))
Requirement already satisfied: dj-inmemorystorage==1.4.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 11))
Requirement already satisfied: Django==1.10.5 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 13))
Requirement already satisfied: django-configurations==1.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 16))
Requirement already satisfied: django-countries==3.4.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 19))
Requirement already satisfied: django-dirtyfields==1.2.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 22))
Requirement already satisfied: django-filter==1.0.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 24))
Requirement already satisfied: django-mozilla-product-details==0.11.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 27))
Requirement already satisfied: django-npm==0.1.4 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 29))
Requirement already satisfied: django-reversion==2.0.4 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 31))
Requirement already satisfied: django-storages-redux==1.3.2 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 33))
Requirement already satisfied: django-sslserver==0.18 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 36))
Requirement already satisfied: django_webpack_loader==0.4.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 38))
Requirement already satisfied: djangorestframework==3.5.3 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 41))
Requirement already satisfied: ecdsa==0.13 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 44))
Requirement already satisfied: factory-boy==2.6.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 47))
Requirement already satisfied: flake8==3.3.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 50))
Requirement already satisfied: flake8-junit-report==2.0.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 53))
Requirement already satisfied: geoip2==2.2.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 55))
Requirement already satisfied: gevent==1.2.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 58))
Requirement already satisfied: gunicorn==19.4.5 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 66))
Requirement already satisfied: hashin==0.7.2 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 69))
Requirement already satisfied: jsonschema==2.5.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 72))
Requirement already satisfied: mozilla-cloud-services-logger==1.0.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 76))
Requirement already satisfied: psycopg2==2.6.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 78))
Requirement already satisfied: pytest-django==2.9.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 80))
Requirement already satisfied: pytest==3.0.2 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 83))
Requirement already satisfied: pytest-mock==0.11.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 86))
Collecting pytest-testrail==0.0.11 (from -r requirements/default.txt (line 89))
  Downloading pytest-testrail-0.0.11.tar.gz
Requirement already satisfied: raven==5.10.2 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 91))
Requirement already satisfied: requests==2.11.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 94))
Requirement already satisfied: requests-hawk==1.0.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 96))
Requirement already satisfied: Sphinx==1.3.5 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 99))
Requirement already satisfied: sphinx_rtd_theme==0.1.9 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 102))
Requirement already satisfied: sphinxcontrib-httpdomain==1.4.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 106))
Requirement already satisfied: statsd==3.2.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 109))
Requirement already satisfied: whitenoise==3.3.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 112))
Requirement already satisfied: newrelic==2.78.0.57 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 115))
Requirement already satisfied: django-csp==3.2 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 117))
Requirement already satisfied: html5lib==1.0b10 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -r requirements/default.txt (line 120))
Requirement already satisfied: cffi==1.5.2 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 7))
Requirement already satisfied: six==1.10.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 76))
Requirement already satisfied: pytz==2015.7 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 56))
Requirement already satisfied: setuptools==19.6 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 65))
Requirement already satisfied: fake-factory==0.5.3 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 23))
Requirement already satisfied: mccabe==0.6.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 36))
Requirement already satisfied: pyflakes==1.5.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 49))
Requirement already satisfied: pycodestyle==2.3.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 87))
Requirement already satisfied: maxminddb==1.2.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 34))
Requirement already satisfied: greenlet==0.4.12 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 82))
Requirement already satisfied: py==1.4.31 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 44))
Requirement already satisfied: configparser==3.5.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 16))
Requirement already satisfied: simplejson==3.8.2 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 69))
Requirement already satisfied: contextlib2==0.5.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 18))
Requirement already satisfied: mohawk==0.3.4 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 32))
Requirement already satisfied: docutils==0.12 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 20))
Requirement already satisfied: Babel==2.2.0 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 4))
Requirement already satisfied: snowballstemmer==1.2.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 79))
Requirement already satisfied: alabaster==0.7.7 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 1))
Requirement already satisfied: Jinja2==2.8 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 27))
Requirement already satisfied: Pygments==2.1 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 52))
Requirement already satisfied: webencodings==0.5 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 90))
Requirement already satisfied: pycparser==2.14 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 47))
Requirement already satisfied: MarkupSafe==0.23 in /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages (from -c requirements/constraints.txt (line 30))
Building wheels for collected packages: pytest-testrail
  Running setup.py bdist_wheel for pytest-testrail ... done
  Stored in directory: /Users/sdonner/Library/Caches/pip/wheels/ba/98/64/2b8e6887b1bf0c09022efa5877f8319c11b0cb5adbad2aa0f2
Successfully built pytest-testrail
Installing collected packages: pytest-testrail
  Found existing installation: pytest-testrail 0.0.9
    Uninstalling pytest-testrail-0.0.9:
      Successfully uninstalled pytest-testrail-0.0.9
Successfully installed pytest-testrail-0.0.11
(normandy) sdonner-17447:recipe-server sdonner$ py.test -v --server=https://normandy.stage.mozaws.net -v --no-ssl-cert-check --testrail=contract-tests/testrail.cfg contract-tests/
===================================== test session starts ======================================
platform darwin -- Python 3.6.0, pytest-3.0.2, py-1.4.31, pluggy-0.3.1 -- /Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/bin/python3.6
cachedir: .cache
django settings: normandy.settings (from ini file)
rootdir: /Users/sdonner/normandy/recipe-server, inifile: pytest.ini
plugins: django-2.9.1, mock-0.11.0, testrail-0.0.11
collected 25 items 
/Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)
Failed to create testrun: {'error': 'Authentication failed: invalid or missing user/password or session cookie.'}

contract-tests/test_api.py::testrail <- ../../.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages/pytest_testrail/plugin.py PASSED
contract-tests/test_api.py::test_expected_action_types PASSED
contract-tests/test_api.py::test_console_log PASSED
contract-tests/test_api.py::test_show_heartbeat PASSED
contract-tests/test_api.py::test_recipe_signatures PASSED
contract-tests/test_api.py::test_recipe_api_is_json PASSED
contract-tests/test_heartbeat.py::testrail <- ../../.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages/pytest_testrail/plugin.py PASSED
contract-tests/test_heartbeat.py::test_heartbeat_is_ok PASSED
contract-tests/test_performance.py::testrail <- ../../.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages/pytest_testrail/plugin.py PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_redirects[/en-US/repair] PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_redirects[/en-US/repair/] PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_redirects[/api/v1/recipe/?enabled=1] PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_redirects[/api/v1/recipe/signed/?enabled=1] PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_redirects[/api/v1/action/] PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_vary_cookie[/en-US/repair] PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_vary_cookie[/en-US/repair/] PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_vary_cookie[/api/v1/recipe/?enabled=1] PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_vary_cookie[/api/v1/recipe/signed/?enabled=1] PASSED
contract-tests/test_performance.py::TestHotPaths::test_no_vary_cookie[/api/v1/action/] PASSED
contract-tests/test_performance.py::TestHotPaths::test_cache_headers[/en-US/repair] PASSED
contract-tests/test_performance.py::TestHotPaths::test_cache_headers[/en-US/repair/] PASSED
contract-tests/test_performance.py::TestHotPaths::test_cache_headers[/api/v1/recipe/?enabled=1] PASSED
contract-tests/test_performance.py::TestHotPaths::test_cache_headers[/api/v1/recipe/signed/?enabled=1] PASSED
contract-tests/test_performance.py::TestHotPaths::test_cache_headers[/api/v1/action/] PASSED
contract-tests/test_performance.py::test_static_cache_headers PASSED/Users/sdonner/.pyenv/versions/3.6.0/envs/normandy/lib/python3.6/site-packages/requests/packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)


================================== 25 passed in 11.36 seconds =====
```

@chartjes @mythmon @Osmose r?