### PR TITLE
Fix #612: Add ability to filter recipes by active and expired experiments.

### DIFF
--- a/docs/user/filter_expressions.rst
+++ b/docs/user/filter_expressions.rst
@@ -222,6 +222,39 @@ filter expressions.
 
    Boolean specifying whether the user has enabled Do Not Track.
 
+.. js:attribute:: normandy.experiments
+
+   Object with several arrays containing the unique slugs for experiments that
+   the user has participated in. Currently, this is limited to preference
+   experiments.
+
+   .. js:attribute:: normandy.experiments.all
+
+      Array of experiment slugs for every experiment that the user has  enrolled
+      in, whether currently active or expired.
+
+   .. js:attribute:: normandy.experiments.active
+
+      Array of experiment slugs for active experiments that the user is enrolled
+      in.
+
+   .. js:attribute:: normandy.experiments.expired
+
+      Array of experiment slugs for expired experiments that the user has
+      enrolled in.
+
+   .. code-block:: javascript
+
+      // Target clients that have ever participated in the "australis"
+      // experiment, including clients that are currently running it
+      "australis" in normandy.experiments.all
+
+      // Target clients that are currently running the "quantum" experiment
+      "quantum" in normandy.experiments.active
+
+      // Target clients that ran the "photon" experiment, and have finished it
+      "photon" in normandy.experiments.expired
+
 Transforms
 ----------
 This section describes the transforms available to filter expressions, and what

--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -180,12 +180,18 @@ this.ClientEnvironment = {
     });
 
     XPCOMUtils.defineLazyGetter(environment, "experiments", async () => {
-      const experiments = await PreferenceExperiments.getAll();
-      return {
-        all: experiments.map(e => e.name),
-        active: experiments.filter(e => !e.expired).map(e => e.name),
-        expired: experiments.filter(e => e.expired).map(e => e.name),
-      };
+      const names = {all: [], active: [], expired: []};
+
+      for (const experiment of await PreferenceExperiments.getAll()) {
+        names.all.push(experiment.name);
+        if (experiment.expired) {
+          names.expired.push(experiment.name);
+        } else {
+          names.active.push(experiment.name);
+        }
+      }
+
+      return names;
     });
 
     return environment;

--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -13,6 +13,11 @@ XPCOMUtils.defineLazyModuleGetter(this, "ShellService", "resource:///modules/She
 XPCOMUtils.defineLazyModuleGetter(this, "AddonManager", "resource://gre/modules/AddonManager.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "TelemetryArchive", "resource://gre/modules/TelemetryArchive.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "NormandyApi", "resource://shield-recipe-client/lib/NormandyApi.jsm");
+XPCOMUtils.defineLazyModuleGetter(
+    this,
+    "PreferenceExperiments",
+    "resource://shield-recipe-client/lib/PreferenceExperiments.jsm",
+);
 
 const {generateUUID} = Cc["@mozilla.org/uuid-generator;1"].getService(Ci.nsIUUIDGenerator);
 
@@ -172,6 +177,15 @@ this.ClientEnvironment = {
 
     XPCOMUtils.defineLazyGetter(environment, "doNotTrack", () => {
       return Preferences.get("privacy.donottrackheader.enabled", false);
+    });
+
+    XPCOMUtils.defineLazyGetter(environment, "experiments", async () => {
+      const experiments = await PreferenceExperiments.getAll();
+      return {
+        all: experiments.map(e => e.name),
+        active: experiments.filter(e => !e.expired).map(e => e.name),
+        expired: experiments.filter(e => e.expired).map(e => e.name),
+      };
     });
 
     return environment;

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -285,6 +285,15 @@ this.PreferenceExperiments = {
   },
 
   /**
+   * Get a list of all stored experiment objects.
+   * @resolves {Experiment[]}
+   */
+  async getAll() {
+    const store = await ensureStorage();
+    return Object.values(store.data).map(experiment => Object.assign({}, experiment));
+  },
+
+  /**
    * Check if an experiment exists with the given name.
    * @param {string} experimentName
    * @resolves {boolean} True if the experiment exists, false if it doesn't.

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -290,6 +290,9 @@ this.PreferenceExperiments = {
    */
   async getAll() {
     const store = await ensureStorage();
+
+    // Return copies so that mutating returned experiments doesn't affect the
+    // stored values.
     return Object.values(store.data).map(experiment => Object.assign({}, experiment));
   },
 

--- a/recipe-client-addon/test/unit/test_PreferenceExperiments.js
+++ b/recipe-client-addon/test/unit/test_PreferenceExperiments.js
@@ -298,6 +298,30 @@ add_task(withMockExperiments(function* (experiments) {
   equal(experiments["test"].name, "test", "get returns a copy of the experiment");
 }));
 
+add_task(withMockExperiments(async function testGetAll(experiments) {
+  const experiment1 = experimentFactory({name: "experiment1"});
+  const experiment2 = experimentFactory({name: "experiment2", disabled: true});
+  experiments["experiment1"] = experiment1;
+  experiments["experiment2"] = experiment2;
+
+  const fetchedExperiments = await PreferenceExperiments.getAll();
+  equal(fetchedExperiments.length, 2, "getAll returns a list of all stored experiments");
+  deepEqual(
+    fetchedExperiments.find(e => e.name === "experiment1"),
+    experiment1,
+    "getAll returns a list with the correct experiments",
+  );
+  const fetchedExperiment2 = fetchedExperiments.find(e => e.name === "experiment2");
+  deepEqual(
+    fetchedExperiment2,
+    experiment2,
+    "getAll returns a list with the correct experiments, including disabled ones",
+  );
+
+  fetchedExperiment2.name = "othername";
+  equal(experiment2.name, "experiment2", "getAll returns copies of the experiments");
+}));
+
 // has
 add_task(withMockExperiments(function* (experiments) {
   experiments["test"] = experimentFactory({name: "test"});


### PR DESCRIPTION
What's this? Only 107 additions?

![](http://pa1.narvii.com/5861/0a1f779c938f8201ecc788427edb0ff72042767f_hq.gif)
