### PR TITLE
#351 Add Preference filter expressions

### DIFF
--- a/recipe-client-addon/lib/FilterExpressions.jsm
+++ b/recipe-client-addon/lib/FilterExpressions.jsm
@@ -7,6 +7,7 @@
 const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://shield-recipe-client/lib/Sampling.jsm");
+Cu.import("resource://shield-recipe-client/lib/PreferenceFilters.jsm");
 
 this.EXPORTED_SYMBOLS = ["FilterExpressions"];
 
@@ -27,6 +28,9 @@ XPCOMUtils.defineLazyGetter(this, "jexl", () => {
     date: dateString => new Date(dateString),
     stableSample: Sampling.stableSample,
     bucketSample: Sampling.bucketSample,
+    preferenceValue: PreferenceFilters.preferenceValue,
+    preferenceIsUserSet: PreferenceFilters.preferenceIsUserSet,
+    preferenceExists: PreferenceFilters.preferenceExists,
   });
   return jexl;
 });

--- a/recipe-client-addon/lib/PreferenceFilters.jsm
+++ b/recipe-client-addon/lib/PreferenceFilters.jsm
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const {utils: Cu} = Components;
+
+Cu.import("resource://gre/modules/Preferences.jsm");
+
+this.EXPORTED_SYMBOLS = ["PreferenceFilters"];
+
+this.PreferenceFilters = {
+  // Compare the value of a given preference. Takes a `default` value as an
+  // optional argument to pass into `Preferences.get`.
+  preferenceValue(prefKey, defaultValue) {
+    return Preferences.get(prefKey, defaultValue);
+  },
+
+  // Compare if the preference is user set.
+  preferenceIsUserSet(prefKey) {
+    return Preferences.isSet(prefKey);
+  },
+
+  // Compare if the preference has _any_ value, whether it's user-set or default.
+  preferenceExists(prefKey) {
+    return Preferences.has(prefKey);
+  },
+};

--- a/recipe-client-addon/test/browser/browser_FilterExpressions.js
+++ b/recipe-client-addon/test/browser/browser_FilterExpressions.js
@@ -1,6 +1,5 @@
 "use strict";
 
-Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm", this);
 
 // Basic JEXL tests
@@ -44,23 +43,23 @@ add_task(async function() {
   let val;
   // Test stable sample returns true for matching samples
   val = await FilterExpressions.eval('["test"]|stableSample(1)');
-  is(val, true, "Stable sample returns true for 100% sample");
+  ok(val, "Stable sample returns true for 100% sample");
 
   // Test stable sample returns true for matching samples
   val = await FilterExpressions.eval('["test"]|stableSample(0)');
-  is(val, false, "Stable sample returns false for 0% sample");
+  ok(!val, "Stable sample returns false for 0% sample");
 
   // Test stable sample for known samples
   val = await FilterExpressions.eval('["test-1"]|stableSample(0.5)');
-  is(val, true, "Stable sample returns true for a known sample");
+  ok(val, "Stable sample returns true for a known sample");
   val = await FilterExpressions.eval('["test-4"]|stableSample(0.5)');
-  is(val, false, "Stable sample returns false for a known sample");
+  ok(!val, "Stable sample returns false for a known sample");
 
   // Test bucket sample for known samples
   val = await FilterExpressions.eval('["test-1"]|bucketSample(0, 5, 10)');
-  is(val, true, "Bucket sample returns true for a known sample");
+  ok(val, "Bucket sample returns true for a known sample");
   val = await FilterExpressions.eval('["test-4"]|bucketSample(0, 5, 10)');
-  is(val, false, "Bucket sample returns false for a known sample");
+  ok(!val, "Bucket sample returns false for a known sample");
 });
 
 // Preference tests
@@ -69,24 +68,26 @@ add_task(async function() {
   // Compare the value of the preference
   await SpecialPowers.pushPrefEnv({set: [["normandy.test.value", 3]]});
   val = await FilterExpressions.eval('"normandy.test.value"|preferenceValue == 3');
-  is(val, true, "preferenceValue expression compares against preference values");
+  ok(val, "preferenceValue expression compares against preference values");
+  val = await FilterExpressions.eval('"normandy.test.value"|preferenceValue == "test"');
+  ok(!val, "preferenceValue expression fails value checks appropriately");
 
   // preferenceValue can take a default value as an optional argument, which
   // defaults to `undefined`.
   val = await FilterExpressions.eval('"normandy.test.default"|preferenceValue(false) == false');
-  is(val, true, `preferenceValue takes optional 'default value' param for prefs without set values`);
-
-  val = await FilterExpressions.eval('"normandy.test.value"|preferenceValue(5) == 3');
-  is(val, true, `preferenceValue default param is not returned for prefs with set values`);
+  ok(val, `preferenceValue takes optional 'default value' param for prefs without set values`);
+  val = await FilterExpressions.eval('"normandy.test.value"|preferenceValue(5) == 5');
+  ok(!val, `preferenceValue default param is not returned for prefs with set values`);
 
   // Compare if the preference is user set
-  val = await FilterExpressions.eval('"normandy.test.isSet"|preferenceIsUserSet != true');
-  is(val, true, "preferenceIsUserSet expression determines if preference is even set");
-
+  val = await FilterExpressions.eval('"normandy.test.isSet"|preferenceIsUserSet == true');
+  ok(!val, "preferenceIsUserSet expression determines if preference is set at all");
   val = await FilterExpressions.eval('"normandy.test.value"|preferenceIsUserSet == true');
-  is(val, true, "preferenceIsUserSet expression determines if user set preference themselves");
+  ok(val, "preferenceIsUserSet expression determines if user's preference has been set");
 
   // Compare if the preference has _any_ value, whether it's user-set or default,
-  val = await FilterExpressions.eval('"normandy.test.nonexistant"|preferenceExists == false');
-  is(val, true, "preferenceExists expression determines if preference exists at all");
+  val = await FilterExpressions.eval('"normandy.test.nonexistant"|preferenceExists == true');
+  ok(!val, "preferenceExists expression determines if preference exists at all");
+  val = await FilterExpressions.eval('"normandy.test.value"|preferenceExists == true');
+  ok(val, "preferenceExists expression fails existence check appropriately");
 });

--- a/recipe-client-addon/test/browser/browser_FilterExpressions.js
+++ b/recipe-client-addon/test/browser/browser_FilterExpressions.js
@@ -1,7 +1,9 @@
 "use strict";
 
+Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm", this);
 
+// Basic JEXL tests
 add_task(async function() {
   let val;
   // Test that basic expressions work
@@ -16,6 +18,14 @@ add_task(async function() {
   `);
   is(val, 4, "multiline expression works");
 
+  // Test that it reads from the context correctly.
+  val = await FilterExpressions.eval("first + second + 3", {first: 1, second: 2});
+  is(val, 6, "context is available to filter expressions");
+});
+
+// Date tests
+add_task(async function() {
+  let val;
   // Test has a date transform
   val = await FilterExpressions.eval('"2016-04-22"|date');
   const d = new Date(Date.UTC(2016, 3, 22)); // months are 0 based
@@ -27,7 +37,11 @@ add_task(async function() {
   ok(val, "dates are comparable with less-than");
   val = await FilterExpressions.eval('"2017-01-01"|date > someTime', context);
   ok(val, "dates are comparable with greater-than");
+});
 
+// Sampling tests
+add_task(async function() {
+  let val;
   // Test stable sample returns true for matching samples
   val = await FilterExpressions.eval('["test"]|stableSample(1)');
   is(val, true, "Stable sample returns true for 100% sample");
@@ -47,8 +61,32 @@ add_task(async function() {
   is(val, true, "Bucket sample returns true for a known sample");
   val = await FilterExpressions.eval('["test-4"]|bucketSample(0, 5, 10)');
   is(val, false, "Bucket sample returns false for a known sample");
+});
 
-  // Test that it reads from the context correctly.
-  val = await FilterExpressions.eval("first + second + 3", {first: 1, second: 2});
-  is(val, 6, "context is available to filter expressions");
+// Preference tests
+add_task(async function() {
+  let val;
+  // Compare the value of the preference
+  Preferences.set("normandy.test.value", 3);
+  val = await FilterExpressions.eval('"normandy.test.value"|preferenceValue == 3');
+  is(val, true, "preferenceValue expression compares against preference values");
+
+  // preferenceValue can take a default value as an optional argument, which
+  // defaults to `undefined`.
+  val = await FilterExpressions.eval('"normandy.test.default"|preferenceValue(false) == false');
+  is(val, true, `preferenceValue takes optional 'default value' param for prefs without set values`);
+
+  val = await FilterExpressions.eval('"normandy.test.value"|preferenceValue(5) == 3');
+  is(val, true, `preferenceValue default param is not returned for prefs with set values`);
+
+  // Compare if the preference is user set
+  val = await FilterExpressions.eval('"normandy.test.isSet"|preferenceIsUserSet != true');
+  is(val, true, "preferenceIsUserSet expression determines if preference is even set");
+
+  val = await FilterExpressions.eval('"normandy.test.value"|preferenceIsUserSet == true');
+  is(val, true, "preferenceIsUserSet expression determines if user set preference themselves");
+
+  // Compare if the preference has _any_ value, whether it's user-set or default,
+  val = await FilterExpressions.eval('"normandy.test.nonexistant"|preferenceExists == false');
+  is(val, true, "preferenceExists expression determines if preference exists at all");
 });

--- a/recipe-client-addon/test/browser/browser_FilterExpressions.js
+++ b/recipe-client-addon/test/browser/browser_FilterExpressions.js
@@ -67,7 +67,7 @@ add_task(async function() {
 add_task(async function() {
   let val;
   // Compare the value of the preference
-  Preferences.set("normandy.test.value", 3);
+  await SpecialPowers.pushPrefEnv({set: [["normandy.test.value", 3]]});
   val = await FilterExpressions.eval('"normandy.test.value"|preferenceValue == 3');
   is(val, true, "preferenceValue expression compares against preference values");
 

--- a/recipe-server/normandy/recipes/api/serializers.py
+++ b/recipe-server/normandy/recipes/api/serializers.py
@@ -135,6 +135,9 @@ class RecipeSerializer(serializers.ModelSerializer):
         jexl.add_transform('date', lambda x: x)
         jexl.add_transform('stableSample', lambda x: x)
         jexl.add_transform('bucketSample', lambda x: x)
+        jexl.add_transform('preferenceValue', lambda x: x)
+        jexl.add_transform('preferenceIsUserSet', lambda x: x)
+        jexl.add_transform('preferenceExists', lambda x: x)
 
         errors = list(jexl.validate(value))
         if errors:


### PR DESCRIPTION
Fixes #351 

- Adds `preferenceValue`, `preferenceIsUserSet`, `preferenceExists` filter expressions to JEXL
- Adds relevant tests for new filters

This was suspiciously easy, so I have a feeling I'm missing something, but this is ready for feedback!