### PR TITLE
recipe-client-addon: Use getAppLocaleAsLangTag for getting browser locale

### DIFF
--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -165,9 +165,7 @@ this.ClientEnvironment = {
     });
 
     XPCOMUtils.defineLazyGetter(environment, "locale", () => {
-      return Cc["@mozilla.org/chrome/chrome-registry;1"]
-        .getService(Ci.nsIXULChromeRegistry)
-        .getSelectedLocale("browser");
+      return Services.locale.getAppLocaleAsLangTag();
     });
 
     XPCOMUtils.defineLazyGetter(environment, "doNotTrack", () => {

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -36,9 +36,7 @@ this.NormandyDriver = function(sandboxManager) {
     testing: false,
 
     get locale() {
-      return Cc["@mozilla.org/chrome/chrome-registry;1"]
-        .getService(Ci.nsIXULChromeRegistry)
-        .getSelectedLocale("browser");
+      return Services.locale.getAppLocaleAsLangTag();
     },
 
     get userId() {


### PR DESCRIPTION
This is from [bug 1347314](https://bugzilla.mozilla.org/show_bug.cgi?id=1347314). We accidentally squashed it in a recent mozilla-central sync.