### PR TITLE
recipe-client-addon: Separate build and test in Taskcluster CI

### DIFF
--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -37,7 +37,6 @@ def main():
     decisionTaskId = os.environ['TASK_ID']
     owner = os.environ['GITHUB_HEAD_USER_EMAIL']
     source = os.environ['GITHUB_HEAD_REPO_URL']
-    artifact_url_pattern = 'http://taskcluster/queue/v1/task/{}/artifacts/{}'
 
     with requests.Session() as session:
         for task in tasks:

--- a/recipe-client-addon/bin/tc/build.sh
+++ b/recipe-client-addon/bin/tc/build.sh
@@ -8,11 +8,13 @@ export SHELL=$(which bash)
 echo 'Downloading gecko-dev...'
 curl -sfL https://github.com/mozilla/gecko-dev/archive/master.tar.gz | tar xz
 
+echo 'Fetching Normandy'
 pushd normandy/recipe-client-addon
 npm install
 ./bin/update-mozilla-central.sh ../gecko-dev/
 popd
 
+echo 'Building Firefox'
 pushd gecko-dev-master
 source /root/.cargo/env
 python2.7 ./python/mozboot/bin/bootstrap.py --no-interactive --application-choice=browser
@@ -20,4 +22,5 @@ source /root/.cargo/env
 ./mach build
 popd
 
-tar czf /artifacts/build.tar.gz gecko-dev-master
+echo 'Making build tarball artifact'
+tar czvf /artifacts/build.tar.gz gecko-dev-master

--- a/recipe-client-addon/bin/tc/build.sh
+++ b/recipe-client-addon/bin/tc/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -eu
+
+# mach wants this
+export SHELL=$(which bash)
+
+# Creates gecko-dev-master
+echo 'Downloading gecko-dev...'
+curl -sfL https://github.com/mozilla/gecko-dev/archive/master.tar.gz | tar xz
+
+pushd normandy/recipe-client-addon
+npm install
+./bin/update-mozilla-central.sh ../gecko-dev/
+popd
+
+pushd gecko-dev-master
+source /root/.cargo/env
+python2.7 ./python/mozboot/bin/bootstrap.py --no-interactive --application-choice=browser
+source /root/.cargo/env
+./mach build
+popd
+
+tar czf /artifacts/build.tar.gz gecko-dev-master

--- a/recipe-client-addon/bin/tc/build.sh
+++ b/recipe-client-addon/bin/tc/build.sh
@@ -14,11 +14,13 @@ npm install
 ./bin/update-mozilla-central.sh ../gecko-dev/
 popd
 
-echo 'Building Firefox'
+echo 'Setting up environment'
 pushd gecko-dev-master
 source /root/.cargo/env
 python2.7 ./python/mozboot/bin/bootstrap.py --no-interactive --application-choice=browser
 source /root/.cargo/env
+
+echo 'Building Firefox'
 ./mach build
 popd
 

--- a/recipe-client-addon/bin/tc/make-xpi.sh
+++ b/recipe-client-addon/bin/tc/make-xpi.sh
@@ -2,7 +2,10 @@
 set -eu
 
 pushd normandy/recipe-client-addon
+echo 'NPM install'
 npm install
+
+echo 'Making XPI'
 ./bin/make-xpi.sh
 cp shield-recipe-client.xpi /artifacts/
 popd

--- a/recipe-client-addon/bin/tc/test.sh
+++ b/recipe-client-addon/bin/tc/test.sh
@@ -4,14 +4,19 @@ set -eu
 # mach wants this
 export SHELL=$(which bash)
 
-# creates gecko-dev-master
+# Fetches build results, and creates ./gecko-dev-master/
 echo 'Downloading build result'
 curl -sfL "$BUILD_RESULT" | tar xz
 
+echo 'Setting up environment'
 pushd gecko-dev-master
 source /root/.cargo/env
 python2.7 ./python/mozboot/bin/bootstrap.py --no-interactive --application-choice=browser
 source /root/.cargo/env
+
+echo 'Running lints'
 ./mach lint browser/extensions/shield-recipe-client/
+
+echo 'Running tests'
 xvfb-run ./mach test browser/extensions/shield-recipe-client/
 popd

--- a/recipe-client-addon/bin/tc/test.sh
+++ b/recipe-client-addon/bin/tc/test.sh
@@ -4,20 +4,14 @@ set -eu
 # mach wants this
 export SHELL=$(which bash)
 
-# Creates gecko-dev-master
-echo 'Downloading gecko-dev...'
-curl -sL https://github.com/mozilla/gecko-dev/archive/master.tar.gz | tar xz
-
-pushd normandy/recipe-client-addon
-npm install
-./bin/update-mozilla-central.sh ../gecko-dev/
-popd
+# creates gecko-dev-master
+echo 'Downloading build result'
+curl -sfL "$BUILD_RESULT" | tar xz
 
 pushd gecko-dev-master
 source /root/.cargo/env
 python2.7 ./python/mozboot/bin/bootstrap.py --no-interactive --application-choice=browser
 source /root/.cargo/env
 ./mach lint browser/extensions/shield-recipe-client/
-./mach build
 xvfb-run ./mach test browser/extensions/shield-recipe-client/
 popd


### PR DESCRIPTION
This will make it easier to distinguish random build failures from actual problems with the tests. Hopefully this will also help us debug our builds in the future.