### PR TITLE
Fix #652: Add option for setting user or default prefs for experiments.

### DIFF
--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -45,6 +45,8 @@ const PREF_LOGGING_LEVEL = PREF_BRANCH + "logging.level";
 let shouldRun = true;
 let log = null;
 
+this.EXPORTED_SYMBOLS = ["install", "startup", "shutdown", "uninstall"];
+
 this.install = function() {
   // Self Repair only checks its pref on start, so if we disable it, wait until
   // next startup to run, unless the dev_mode preference is set.
@@ -56,7 +58,7 @@ this.install = function() {
   }
 };
 
-this.startup = function() {
+this.startup = async function() {
   setDefaultPrefs();
 
   // Setup logging and listen for changes to logging prefs
@@ -72,11 +74,13 @@ this.startup = function() {
 
   // Initialize experiments first to avoid a race between initializing prefs
   // and recipes rolling back pref changes when experiments end.
-  PreferenceExperiments.init().catch(err => {
+  try {
+    await PreferenceExperiments.init();
+  } catch (err) {
     log.error("Failed to initialize preference experiments:", err);
-  }).then(() => {
-    RecipeRunner.init();
-  });
+  }
+
+  await RecipeRunner.init();
 };
 
 this.shutdown = function(data, reason) {

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -15,6 +15,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "RecipeRunner",
   "resource://shield-recipe-client/lib/RecipeRunner.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "CleanupManager",
   "resource://shield-recipe-client/lib/CleanupManager.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PreferenceExperiments",
+  "resource://shield-recipe-client/lib/PreferenceExperiments.jsm");
 
 const REASONS = {
   APP_STARTUP: 1,      // The application is starting up.
@@ -68,7 +70,13 @@ this.startup = function() {
     return;
   }
 
-  RecipeRunner.init();
+  // Initialize experiments first to avoid a race between initializing prefs
+  // and recipes rolling back pref changes when experiments end.
+  PreferenceExperiments.init().catch(err => {
+    log.error("Failed to initialize preference experiments:", err);
+  }).then(() => {
+    RecipeRunner.init();
+  });
 };
 
 this.shutdown = function(data, reason) {

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -45,6 +45,7 @@ const PREF_LOGGING_LEVEL = PREF_BRANCH + "logging.level";
 let shouldRun = true;
 let log = null;
 
+// These are exported for testing purposes only.
 this.EXPORTED_SYMBOLS = ["install", "startup", "shutdown", "uninstall"];
 
 this.install = function() {

--- a/recipe-client-addon/jar.mn
+++ b/recipe-client-addon/jar.mn
@@ -6,4 +6,5 @@
 % resource shield-recipe-client %content/
   content/lib/ (./lib/*)
   content/data/ (./data/*)
+  content/bootstrap.js (./bootstrap.js)
   content/node_modules/jexl/ (./node_modules/jexl/*)

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -97,12 +97,12 @@ this.PreferenceExperiments = {
    */
   async init() {
     const store = await ensureStorage();
-    for (const experiment of Object.values(store.data)) {
+    Object.values(store.data).forEach(experiment => {
       const {expired, preferenceBranchType, preferenceName, preferenceValue} = experiment;
       if (!expired && preferenceBranchType === "default") {
         DefaultPreferences.set(preferenceName, preferenceValue);
       }
-    }
+    });
   },
 
   /**
@@ -136,21 +136,22 @@ this.PreferenceExperiments = {
 
   /**
    * Start a new preference experiment.
-   * @param {string} experimentName
-   * @param {string} branch
-   * @param {string} preferenceName
-   * @param {string|integer|boolean} preferenceValue
-   * @param {PreferenceBranchType} preferenceBranchType
+   * @param {Object} experiment
+   * @param {string} experiment.name
+   * @param {string} experiment.branch
+   * @param {string} experiment.preferenceName
+   * @param {string|integer|boolean} experiment.preferenceValue
+   * @param {PreferenceBranchType} experiment.preferenceBranchType
    * @rejects {Error}
    *   If an experiment with the given name already exists, or if an experiment
    *   for the given preference is active.
    */
-  async start(experimentName, branch, preferenceName, preferenceValue, preferenceBranchType) {
-    log.debug(`PreferenceExperiments.start(${experimentName}, ${branch})`);
+  async start({name, branch, preferenceName, preferenceValue, preferenceBranchType}) {
+    log.debug(`PreferenceExperiments.start(${name}, ${branch})`);
 
     const store = await ensureStorage();
-    if (experimentName in store.data) {
-      throw new Error(`A preference experiment named "${experimentName}" already exists.`);
+    if (name in store.data) {
+      throw new Error(`A preference experiment named "${name}" already exists.`);
     }
 
     const activeExperiments = Object.values(store.data).filter(e => !e.expired);
@@ -170,7 +171,7 @@ this.PreferenceExperiments = {
 
     /** @type {Experiment} */
     const experiment = {
-      name: experimentName,
+      name,
       branch,
       expired: false,
       lastSeen: new Date().toJSON(),
@@ -181,8 +182,8 @@ this.PreferenceExperiments = {
     };
 
     preferences.set(preferenceName, preferenceValue);
-    PreferenceExperiments.startObserver(experimentName, preferenceName, preferenceValue);
-    store.data[experimentName] = experiment;
+    PreferenceExperiments.startObserver(name, preferenceName, preferenceValue);
+    store.data[name] = experiment;
     store.saveSoon();
   },
 

--- a/recipe-client-addon/test/browser/browser.ini
+++ b/recipe-client-addon/test/browser/browser.ini
@@ -8,3 +8,4 @@ head = head.js
 [browser_RecipeRunner.js]
 [browser_LogManager.js]
 [browser_ClientEnvironment.js]
+[browser_bootstrap.js]

--- a/recipe-client-addon/test/browser/browser_bootstrap.js
+++ b/recipe-client-addon/test/browser/browser_bootstrap.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const bootstrap = Cu.import("resource://shield-recipe-client/bootstrap.js", {});
+Cu.import("resource://shield-recipe-client/lib/RecipeRunner.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm", this);
+
+add_task(async function testStartup() {
+  sinon.stub(RecipeRunner, "init");
+  sinon.stub(PreferenceExperiments, "init");
+
+  await bootstrap.startup();
+  ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
+  ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+
+  PreferenceExperiments.init.restore();
+  RecipeRunner.init.restore();
+});
+
+add_task(async function testStartupPrefInitFail() {
+  sinon.stub(RecipeRunner, "init");
+  sinon.stub(PreferenceExperiments, "init").returns(Promise.reject(new Error("oh no")));
+
+  await bootstrap.startup();
+  ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
+  // Even if PreferenceExperiments.init fails, RecipeRunner.init should be called.
+  ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+
+  PreferenceExperiments.init.restore();
+  RecipeRunner.init.restore();
+});

--- a/recipe-server/client/actions/preference-experiment/index.js
+++ b/recipe-server/client/actions/preference-experiment/index.js
@@ -13,7 +13,7 @@ export default class PreferenceExperimentAction extends Action {
     //
     // Once we remove self-repair support, we should be able to use native
     // async/await anyway, which solves the issue.
-    const { slug, preferenceName, branches } = this.recipe.arguments;
+    const { slug, preferenceName, preferenceBranchType, branches } = this.recipe.arguments;
     const experiments = this.normandy.preferenceExperiments;
 
     // Exit early if we're on an incompatible client.
@@ -25,8 +25,9 @@ export default class PreferenceExperimentAction extends Action {
     return experiments.has(slug).then(hasSlug => {
       // If the experiment doesn't exist yet, enroll!
       if (!hasSlug) {
-        return this.chooseBranch(branches)
-          .then(branch => experiments.start(slug, branch.slug, preferenceName, branch.value));
+        return this.chooseBranch(branches).then(branch =>
+          experiments.start(slug, branch.slug, preferenceName, branch.value, preferenceBranchType)
+        );
       }
 
       // If the experiment exists, and isn't expired, bump the lastSeen date.

--- a/recipe-server/client/actions/preference-experiment/index.js
+++ b/recipe-server/client/actions/preference-experiment/index.js
@@ -26,7 +26,13 @@ export default class PreferenceExperimentAction extends Action {
       // If the experiment doesn't exist yet, enroll!
       if (!hasSlug) {
         return this.chooseBranch(branches).then(branch =>
-          experiments.start(slug, branch.slug, preferenceName, branch.value, preferenceBranchType)
+          experiments.start({
+            name: slug,
+            branch: branch.slug,
+            preferenceName,
+            preferenceValue: branch.value,
+            preferenceBranchType,
+          })
         );
       }
 

--- a/recipe-server/client/actions/preference-experiment/package.json
+++ b/recipe-server/client/actions/preference-experiment/package.json
@@ -38,6 +38,12 @@
                     "enum": ["string", "integer", "boolean"],
                     "default": "boolean"
                 },
+                "preferenceBranchType": {
+                    "descript": "Controls whether the default or user value of the preference is modified",
+                    "type": "string",
+                    "enum": ["user", "default"],
+                    "default": "default"
+                },
                 "branches": {
                     "description": "List of experimental branches",
                     "type": "array",

--- a/recipe-server/client/actions/tests/test_preference-experiment.js
+++ b/recipe-server/client/actions/tests/test_preference-experiment.js
@@ -7,6 +7,7 @@ function preferenceExperimentFactory(args) {
       slug: 'test',
       preferenceName: 'fake.preference',
       preferenceType: 'string',
+      preferenceBranchType: 'default',
       branches: [
         { slug: 'test', value: 'foo', ratio: 1 },
       ],
@@ -80,6 +81,7 @@ describe('PreferenceExperimentAction', () => {
       const action = new PreferenceExperimentAction(normandy, preferenceExperimentFactory({
         slug: 'test',
         preferenceName: 'fake.preference',
+        preferenceBranchType: 'user',
         branches: [
           { slug: 'branch1', value: 'branch1', ratio: 1 },
           { slug: 'branch2', value: 'branch2', ratio: 1 },
@@ -89,7 +91,7 @@ describe('PreferenceExperimentAction', () => {
 
       await action.execute();
       expect(normandy.preferenceExperiments.start)
-        .toHaveBeenCalledWith('test', 'branch1', 'fake.preference', 'branch1');
+        .toHaveBeenCalledWith('test', 'branch1', 'fake.preference', 'branch1', 'user');
     });
 
     it('should mark the lastSeen date for the experiment if it is active', async () => {

--- a/recipe-server/client/actions/tests/test_preference-experiment.js
+++ b/recipe-server/client/actions/tests/test_preference-experiment.js
@@ -21,7 +21,7 @@ class MockPreferenceExperiments {
     this.experiments = {};
   }
 
-  async start(name, branch, preferenceName, preferenceValue) {
+  async start({ name, branch, preferenceName, preferenceValue }) {
     this.experiments[name] = {
       name,
       branch,
@@ -91,7 +91,13 @@ describe('PreferenceExperimentAction', () => {
 
       await action.execute();
       expect(normandy.preferenceExperiments.start)
-        .toHaveBeenCalledWith('test', 'branch1', 'fake.preference', 'branch1', 'user');
+        .toHaveBeenCalledWith({
+          name: 'test',
+          branch: 'branch1',
+          preferenceName: 'fake.preference',
+          preferenceValue: 'branch1',
+          preferenceBranchType: 'user',
+        });
     });
 
     it('should mark the lastSeen date for the experiment if it is active', async () => {

--- a/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
+++ b/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
@@ -37,6 +37,14 @@ export class PreferenceExperimentFields extends ActionFields {
     preferenceBranchType: pt.string.isRequired,
   }
 
+  static userBranchWarning = (
+    <p className="field-warning">
+      <i className="fa fa-exclamation-triangle" />
+      Setting user preferences instead of default ones is not recommended.
+      Do not choose this unless you know what you are doing.
+    </p>
+  );
+
   render() {
     const { preferenceBranchType } = this.props;
     return (
@@ -77,13 +85,7 @@ export class PreferenceExperimentFields extends ActionFields {
           <option value="default">Default</option>
           <option value="user">User</option>
         </ControlField>
-        {preferenceBranchType === 'user' &&
-          <p className="field-warning">
-            <i className="fa fa-exclamation-triangle" />
-            Setting user preferences instead of default ones is not recommended.
-            Do not choose this unless you know what you are doing.
-          </p>
-        }
+        {preferenceBranchType === 'user' && PreferenceExperimentFields.userBranchWarning}
         <FieldArray name="arguments.branches" component={PreferenceBranches} />
       </div>
     );

--- a/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
+++ b/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
@@ -24,15 +24,21 @@ const DEFAULT_BRANCH_VALUES = {
 /**
  * Form fields for the preference-experiment action.
  */
-export default class PreferenceExperimentFields extends ActionFields {
+export class PreferenceExperimentFields extends ActionFields {
   static initialValues = {
     slug: '',
     experimentDocumentUrl: '',
     preferenceName: '',
     preferenceType: 'boolean',
+    preferenceBranchType: 'default',
+  }
+
+  static propTypes = {
+    preferenceBranchType: pt.string.isRequired,
   }
 
   render() {
+    const { preferenceBranchType } = this.props;
     return (
       <div className="arguments-fields">
         <p className="info">Run a feature experiment activated by a preference.</p>
@@ -63,11 +69,32 @@ export default class PreferenceExperimentFields extends ActionFields {
           <option value="integer">Integer</option>
           <option value="string">String</option>
         </ControlField>
+        <ControlField
+          label="Preference Branch Type"
+          name="arguments.preferenceBranchType"
+          component="select"
+        >
+          <option value="default">Default</option>
+          <option value="user">User</option>
+        </ControlField>
+        {preferenceBranchType === 'user' &&
+          <p className="field-warning">
+            <i className="fa fa-exclamation-triangle" />
+            Setting user preferences instead of default ones is not recommended.
+            Do not choose this unless you know what you are doing.
+          </p>
+        }
         <FieldArray name="arguments.branches" component={PreferenceBranches} />
       </div>
     );
   }
 }
+
+export default connect(
+  state => ({
+    preferenceBranchType: selector(state, 'arguments.preferenceBranchType'),
+  })
+)(PreferenceExperimentFields);
 
 export class PreferenceBranches extends React.Component {
   static propTypes = {

--- a/recipe-server/client/control/sass/control.scss
+++ b/recipe-server/client/control/sass/control.scss
@@ -172,6 +172,16 @@
     text-transform: uppercase;
   }
 
+  .field-warning {
+    background: $yellow;
+    font-weight: bold;
+    padding: 15px;
+
+    .fa {
+      margin-right: 15px;
+    }
+  }
+
   /* A group of related fields, generally for things like radio buttons. */
   .fieldset {
     @extend .form-field;

--- a/recipe-server/client/control/tests/components/test_PreferenceExperimentFields.js
+++ b/recipe-server/client/control/tests/components/test_PreferenceExperimentFields.js
@@ -17,8 +17,6 @@ describe('<PreferenceExperimentFields>', () => {
 
   it('should render a warning if using the user preference branch type', () => {
     const wrapper = shallow(<PreferenceExperimentFields preferenceBranchType="user" />);
-    const warning = wrapper.find('.field-warning');
-    expect(warning.length).toBe(1);
-    expect(warning.text()).toContain('not recommended');
+    expect(wrapper.contains(PreferenceExperimentFields.userBranchWarning)).toBe(true);
   });
 });

--- a/recipe-server/client/control/tests/components/test_PreferenceExperimentFields.js
+++ b/recipe-server/client/control/tests/components/test_PreferenceExperimentFields.js
@@ -1,0 +1,24 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import {
+  PreferenceExperimentFields,
+} from 'control/components/action_fields/PreferenceExperimentFields';
+
+describe('<PreferenceExperimentFields>', () => {
+  it('should render without errors', () => {
+    const wrapper = () => {
+      shallow(<PreferenceExperimentFields preferenceBranchType="default" />);
+    };
+
+    expect(wrapper).not.toThrow();
+  });
+
+  it('should render a warning if using the user preference branch type', () => {
+    const wrapper = shallow(<PreferenceExperimentFields preferenceBranchType="user" />);
+    const warning = wrapper.find('.field-warning');
+    expect(warning.length).toBe(1);
+    expect(warning.text()).toContain('not recommended');
+  });
+});


### PR DESCRIPTION
In which I continue to sidestep rewriting the entire PreferenceExperiments test suite to use async/await.

It turns out preference observers react to changes in the effective preference value, which covers default value changes, which helped cut down on a bunch of the code and tests I originally had here.