### PR TITLE
#635 - Add pref experiment type checks

### DIFF
--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -203,16 +203,16 @@ this.PreferenceExperiments = {
       preferenceBranchType,
     };
 
-    const existingPreferenceType = Services.prefs.getPrefType(preferenceName);
-    const givenType = PREFERENCE_TYPE_MAP[preferenceType];
+    const prevPrefType = Services.prefs.getPrefType(preferenceName);
+    const givenPrefType = PREFERENCE_TYPE_MAP[preferenceType];
 
-    if (!preferenceType || !givenType) {
+    if (!preferenceType || !givenPrefType) {
       throw new Error(`Invalid preferenceType provided (given "${preferenceType}")`);
     }
 
-    if (existingPreferenceType && existingPreferenceType !== givenType) {
+    if (prevPrefType !== Services.prefs.PREF_INVALID && prevPrefType !== givenPrefType) {
       throw new Error(
-        `Previous preference value is of type "${existingPreferenceType}", but was given "${givenType}" (${preferenceType})`
+        `Previous preference value is of type "${prevPrefType}", but was given "${givenPrefType}" (${preferenceType})`
       );
     }
 

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -187,10 +187,10 @@ this.PreferenceExperiments = {
       lastSeen: new Date().toJSON(),
       preferenceName,
       preferenceValue,
+      preferenceType,
       previousPreferenceValue: preferences.get(preferenceName, undefined),
       preferenceBranchType,
     };
-
 
     // If there's a previous preference value set, we need to ensure that the
     // incoming value is of the same type.
@@ -209,7 +209,7 @@ this.PreferenceExperiments = {
       // that matches the given argument type
       let givenType = Services.prefs.PREF_INVALID || 0;
       if(typeConversions.hasOwnProperty(argumentValueType)){
-        givenType = typeConversions[givenType];
+        givenType = typeConversions[argumentValueType];
       }
 
       // Compare both PREF_'d value types

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -190,9 +190,25 @@ this.PreferenceExperiments = {
       preferenceBranchType,
     };
 
+<<<<<<< 7645206452913171a140524661194c68d9691c4d
     preferences.set(preferenceName, preferenceValue);
     PreferenceExperiments.startObserver(name, preferenceName, preferenceValue);
     store.data[name] = experiment;
+=======
+    if (experiment.previousPreferenceValue) {
+      const previousType = typeof experiment.previousPreferenceValue;
+      const givenType = typeof preferenceValue;
+      if (previousType !== givenType) {
+        throw new Error(
+          `Previous preference value is of type "${previousType}", but was given "${givenType}"`
+        );
+      }
+    }
+
+    Preferences.set(preferenceName, preferenceValue);
+    PreferenceExperiments.startObserver(experimentName, preferenceName, preferenceValue);
+    store.data[experimentName] = experiment;
+>>>>>>> Add pref experiment type checks
     store.saveSoon();
 
     TelemetryEnvironment.setExperimentActive(name, branch);

--- a/recipe-client-addon/test/browser/browser_FilterExpressions.js
+++ b/recipe-client-addon/test/browser/browser_FilterExpressions.js
@@ -75,9 +75,9 @@ add_task(async function() {
   // preferenceValue can take a default value as an optional argument, which
   // defaults to `undefined`.
   val = await FilterExpressions.eval('"normandy.test.default"|preferenceValue(false) == false');
-  ok(val, `preferenceValue takes optional 'default value' param for prefs without set values`);
+  ok(val, "preferenceValue takes optional 'default value' param for prefs without set values");
   val = await FilterExpressions.eval('"normandy.test.value"|preferenceValue(5) == 5');
-  ok(!val, `preferenceValue default param is not returned for prefs with set values`);
+  ok(!val, "preferenceValue default param is not returned for prefs with set values");
 
   // Compare if the preference is user set
   val = await FilterExpressions.eval('"normandy.test.isSet"|preferenceIsUserSet == true');

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -165,11 +165,18 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 })));
 
 // start should detect if a new preference value type matches the previous value type
-add_task(withMockPreferences(function* (mockPreferences) {
+add_task(withMockPreferences(async function (mockPreferences) {
   mockPreferences.set("fake.type_preference", "oldvalue");
 
-  yield Assert.rejects(
-    PreferenceExperiments.start("test", "branch", "fake.type_preference", 12345),
+  await Assert.rejects(
+    PreferenceExperiments.start({
+      name: "test",
+      branch: "branch",
+      preferenceName: "fake.type_preference",
+      preferenceBranchType: "invalid",
+      preferenceValue: 12345,
+      preferenceType: "integer"
+    }),
     "start threw error for incompatible preference type"
   );
 }));

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -164,6 +164,17 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
   startObserver.restore();
 })));
 
+// start should detect if a new preference value type matches the previous value type
+add_task(withMockPreferences(function* (mockPreferences) {
+  mockPreferences.set("fake.type_preference", "oldvalue");
+
+  yield Assert.rejects(
+    PreferenceExperiments.start("test", "branch", "fake.type_preference", 12345),
+    "start threw error for incompatible preference type"
+  );
+}));
+
+
 // startObserver should throw if an observer for the experiment is already
 // active.
 add_task(async function () {

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -23,7 +23,7 @@ function experimentFactory(attrs) {
 }
 
 // clearAllExperimentStorage
-add_task(withMockExperiments(async function (experiments) {
+add_task(withMockExperiments(async function(experiments) {
   experiments["test"] = experimentFactory({name: "test"});
   ok(await PreferenceExperiments.has("test"), "Mock experiment is detected.");
   await PreferenceExperiments.clearAllExperimentStorage();
@@ -34,7 +34,7 @@ add_task(withMockExperiments(async function (experiments) {
 }));
 
 // start should throw if an experiment with the given name already exists
-add_task(withMockExperiments(async function (experiments) {
+add_task(withMockExperiments(async function(experiments) {
   experiments["test"] = experimentFactory({name: "test"});
   await Assert.rejects(
     PreferenceExperiments.start({
@@ -50,7 +50,7 @@ add_task(withMockExperiments(async function (experiments) {
 }));
 
 // start should throw if an experiment for the given preference is active
-add_task(withMockExperiments(async function (experiments) {
+add_task(withMockExperiments(async function(experiments) {
   experiments["test"] = experimentFactory({name: "test", preferenceName: "fake.preference"});
   await Assert.rejects(
     PreferenceExperiments.start({
@@ -66,7 +66,7 @@ add_task(withMockExperiments(async function (experiments) {
 }));
 
 // start should throw if an invalid preferenceBranchType is given
-add_task(withMockExperiments(async function () {
+add_task(withMockExperiments(async function() {
   await Assert.rejects(
     PreferenceExperiments.start({
       name: "test",
@@ -82,7 +82,7 @@ add_task(withMockExperiments(async function () {
 
 // start should save experiment data, modify the preference, and register a
 // watcher.
-add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const startObserver = sinon.stub(PreferenceExperiments, "startObserver");
   mockPreferences.set("fake.preference", "oldvalue", "default");
   mockPreferences.set("fake.preference", "uservalue", "user");
@@ -130,7 +130,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 })));
 
 // start should modify the user preference for the user branch type
-add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const startObserver = sinon.stub(PreferenceExperiments, "startObserver");
   mockPreferences.set("fake.preference", "oldvalue", "user");
   mockPreferences.set("fake.preference", "olddefaultvalue", "default");
@@ -174,7 +174,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 })));
 
 // start should detect if a new preference value type matches the previous value type
-add_task(withMockPreferences(async function (mockPreferences) {
+add_task(withMockPreferences(async function(mockPreferences) {
   mockPreferences.set("fake.type_preference", "oldvalue");
 
   await Assert.rejects(
@@ -182,7 +182,7 @@ add_task(withMockPreferences(async function (mockPreferences) {
       name: "test",
       branch: "branch",
       preferenceName: "fake.type_preference",
-      preferenceBranchType: "invalid",
+      preferenceBranchType: "user",
       preferenceValue: 12345,
       preferenceType: "integer"
     }),
@@ -193,7 +193,7 @@ add_task(withMockPreferences(async function (mockPreferences) {
 
 // startObserver should throw if an observer for the experiment is already
 // active.
-add_task(async function () {
+add_task(async function() {
   PreferenceExperiments.startObserver("test", "fake.preference", "newvalue");
   Assert.throws(
     () => PreferenceExperiments.startObserver("test", "another.fake", "othervalue"),
@@ -204,7 +204,7 @@ add_task(async function () {
 
 // startObserver should register an observer that calls stop when a preference
 // changes from its experimental value.
-add_task(withMockPreferences(async function (mockPreferences) {
+add_task(withMockPreferences(async function(mockPreferences) {
   const stop = sinon.stub(PreferenceExperiments, "stop");
   mockPreferences.set("fake.preference", "startvalue");
 
@@ -224,7 +224,7 @@ add_task(withMockPreferences(async function (mockPreferences) {
 }));
 
 // startObserver should observe changes to the default preference value.
-add_task(withMockPreferences(async function (mockPreferences) {
+add_task(withMockPreferences(async function(mockPreferences) {
   const stop = sinon.stub(PreferenceExperiments, "stop");
   mockPreferences.set("fake.preference", "startvalue", "default");
 
@@ -256,7 +256,7 @@ add_task(async function testHasObserver() {
 });
 
 // stopObserver should throw if there is no observer active for it to stop.
-add_task(async function () {
+add_task(async function() {
   Assert.throws(
     () => PreferenceExperiments.stopObserver("neveractive", "another.fake", "othervalue"),
     "stopObserver threw because there was not matching active observer",
@@ -264,7 +264,7 @@ add_task(async function () {
 });
 
 // stopObserver should cancel an active observer.
-add_task(withMockPreferences(async function (mockPreferences) {
+add_task(withMockPreferences(async function(mockPreferences) {
   const stop = sinon.stub(PreferenceExperiments, "stop");
   mockPreferences.set("fake.preference", "startvalue");
 
@@ -289,7 +289,7 @@ add_task(withMockPreferences(async function (mockPreferences) {
 }));
 
 // stopAllObservers
-add_task(withMockPreferences(async function (mockPreferences) {
+add_task(withMockPreferences(async function(mockPreferences) {
   const stop = sinon.stub(PreferenceExperiments, "stop");
   mockPreferences.set("fake.preference", "startvalue");
   mockPreferences.set("other.fake.preference", "startvalue");
@@ -318,7 +318,7 @@ add_task(withMockPreferences(async function (mockPreferences) {
 }));
 
 // markLastSeen should throw if it can't find a matching experiment
-add_task(async function () {
+add_task(async function() {
   await Assert.rejects(
     PreferenceExperiments.markLastSeen("neveractive"),
     "markLastSeen threw because there was not a matching experiment",
@@ -326,7 +326,7 @@ add_task(async function () {
 });
 
 // markLastSeen should update the lastSeen date
-add_task(withMockExperiments(async function (experiments) {
+add_task(withMockExperiments(async function(experiments) {
   const oldDate = new Date(1988, 10, 1).toJSON();
   experiments["test"] = experimentFactory({name: "test", lastSeen: oldDate});
   await PreferenceExperiments.markLastSeen("test");
@@ -338,7 +338,7 @@ add_task(withMockExperiments(async function (experiments) {
 }));
 
 // stop should throw if an experiment with the given name doesn't exist
-add_task(withMockExperiments(async function () {
+add_task(withMockExperiments(async function() {
   await Assert.rejects(
     PreferenceExperiments.stop("test"),
     "stop threw an error because there are no experiments with the given name",
@@ -346,7 +346,7 @@ add_task(withMockExperiments(async function () {
 }));
 
 // stop should throw if the experiment is already expired
-add_task(withMockExperiments(async function (experiments) {
+add_task(withMockExperiments(async function(experiments) {
   experiments["test"] = experimentFactory({name: "test", expired: true});
   await Assert.rejects(
     PreferenceExperiments.stop("test"),
@@ -356,7 +356,7 @@ add_task(withMockExperiments(async function (experiments) {
 
 // stop should mark the experiment as expired, stop its observer, and revert the
 // preference value.
-add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const stopObserver = sinon.spy(PreferenceExperiments, "stopObserver");
   mockPreferences.set("fake.preference", "experimentvalue", "default");
   experiments["test"] = experimentFactory({
@@ -384,7 +384,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 })));
 
 // stop should also support user pref experiments
-add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
   mockPreferences.set("fake.preference", "experimentvalue", "user");
   experiments["test"] = experimentFactory({
@@ -412,7 +412,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 })));
 
 // stop should not call stopObserver if there is no observer registered.
-add_task(withMockExperiments(withMockPreferences(async function (experiments) {
+add_task(withMockExperiments(withMockPreferences(async function(experiments) {
   const stopObserver = sinon.spy(PreferenceExperiments, "stopObserver");
   experiments["test"] = experimentFactory({name: "test", expired: false});
 
@@ -424,7 +424,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments) {
 })));
 
 // stop should remove a preference that had no value prior to an experiment for user prefs
-add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
   mockPreferences.set("fake.preference", "experimentvalue", "user");
   experiments["test"] = experimentFactory({
@@ -447,7 +447,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 })));
 
 // stop should not modify a preference if resetValue is false
-add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
   mockPreferences.set("fake.preference", "customvalue", "default");
   experiments["test"] = experimentFactory({
@@ -471,7 +471,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 })));
 
 // get should throw if no experiment exists with the given name
-add_task(withMockExperiments(async function () {
+add_task(withMockExperiments(async function() {
   await Assert.rejects(
     PreferenceExperiments.get("neverexisted"),
     "get rejects if no experiment with the given name is found",
@@ -479,7 +479,7 @@ add_task(withMockExperiments(async function () {
 }));
 
 // get
-add_task(withMockExperiments(async function (experiments) {
+add_task(withMockExperiments(async function(experiments) {
   const experiment = experimentFactory({name: "test"});
   experiments["test"] = experiment;
 
@@ -541,7 +541,7 @@ add_task(withMockExperiments(withMockPreferences(async function testGetAllActive
 })));
 
 // has
-add_task(withMockExperiments(async function (experiments) {
+add_task(withMockExperiments(async function(experiments) {
   experiments["test"] = experimentFactory({name: "test"});
   ok(await PreferenceExperiments.has("test"), "has returned true for a stored experiment");
   ok(!(await PreferenceExperiments.has("missing")), "has returned false for a missing experiment");

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -16,6 +16,7 @@ function experimentFactory(attrs) {
     lastSeen: new Date().toJSON(),
     preferenceName: "fake.preference",
     preferenceValue: "falkevalue",
+    preferenceType: "string",
     previousPreferenceValue: "oldfakevalue",
     preferenceBranchType: "default",
   }, attrs);
@@ -41,6 +42,7 @@ add_task(withMockExperiments(async function (experiments) {
       branch: "branch",
       preferenceName: "fake.preference",
       preferenceValue: "value",
+      preferenceType: "string",
       preferenceBranchType: "default",
     }),
     "start threw an error due to a conflicting experiment name",
@@ -56,6 +58,7 @@ add_task(withMockExperiments(async function (experiments) {
       branch: "branch",
       preferenceName: "fake.preference",
       preferenceValue: "value",
+      preferenceType: "string",
       preferenceBranchType: "default",
     }),
     "start threw an error due to an active experiment for the given preference",
@@ -70,6 +73,7 @@ add_task(withMockExperiments(async function () {
       branch: "branch",
       preferenceName: "fake.preference",
       preferenceValue: "value",
+      preferenceType: "string",
       preferenceBranchType: "invalid",
     }),
     "start threw an error due to an invalid preference branch type",
@@ -89,6 +93,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
     preferenceName: "fake.preference",
     preferenceValue: "newvalue",
     preferenceBranchType: "default",
+    preferenceType: "string",
   });
   ok("test" in experiments, "start saved the experiment");
   ok(
@@ -102,6 +107,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
     expired: false,
     preferenceName: "fake.preference",
     preferenceValue: "newvalue",
+    preferenceType: "string",
     previousPreferenceValue: "oldvalue",
     preferenceBranchType: "default",
   };
@@ -134,6 +140,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
     branch: "branch",
     preferenceName: "fake.preference",
     preferenceValue: "newvalue",
+    preferenceType: "string",
     preferenceBranchType: "user",
   });
   ok(
@@ -147,9 +154,11 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
     expired: false,
     preferenceName: "fake.preference",
     preferenceValue: "newvalue",
+    preferenceType: "string",
     previousPreferenceValue: "oldvalue",
     preferenceBranchType: "user",
   };
+
   const experiment = {};
   Object.keys(expectedExperiment).forEach(key => experiment[key] = experiments.test[key]);
   Assert.deepEqual(experiment, expectedExperiment, "start saved the experiment");
@@ -355,6 +364,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
     expired: false,
     preferenceName: "fake.preference",
     preferenceValue: "experimentvalue",
+    preferenceType: "string",
     previousPreferenceValue: "oldvalue",
     preferenceBranchType: "default",
   });
@@ -382,6 +392,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
     expired: false,
     preferenceName: "fake.preference",
     preferenceValue: "experimentvalue",
+    preferenceType: "string",
     previousPreferenceValue: "oldvalue",
     preferenceBranchType: "user",
   });
@@ -421,6 +432,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
     expired: false,
     preferenceName: "fake.preference",
     preferenceValue: "experimentvalue",
+    preferenceType: "string",
     previousPreferenceValue: undefined,
     preferenceBranchType: "user",
   });
@@ -443,6 +455,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
     expired: false,
     preferenceName: "fake.preference",
     preferenceValue: "experimentvalue",
+    preferenceType: "string",
     previousPreferenceValue: "oldvalue",
     peferenceBranchType: "default",
   });
@@ -539,18 +552,21 @@ add_task(withMockExperiments(withMockPreferences(async function testInit(experim
   experiments["user"] = experimentFactory({
     preferenceName: "user",
     preferenceValue: true,
+    preferenceType: "boolean",
     expired: false,
     preferenceBranchType: "user",
   });
   experiments["default"] = experimentFactory({
     preferenceName: "default",
     preferenceValue: true,
+    preferenceType: "boolean",
     expired: false,
     preferenceBranchType: "default",
   });
   experiments["expireddefault"] = experimentFactory({
     preferenceName: "expireddefault",
     preferenceValue: true,
+    preferenceType: "boolean",
     expired: true,
     preferenceBranchType: "default",
   });
@@ -593,6 +609,7 @@ add_task(withMockExperiments(async function testInit() {
     branch: "branch",
     preferenceName: "fake.preference",
     preferenceValue: "value",
+    preferenceType: "string",
     preferenceBranchType: "default",
   });
 

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -184,7 +184,7 @@ add_task(withMockPreferences(async function(mockPreferences) {
       preferenceName: "fake.type_preference",
       preferenceBranchType: "user",
       preferenceValue: 12345,
-      preferenceType: "integer"
+      preferenceType: "integer",
     }),
     "start threw error for incompatible preference type"
   );

--- a/recipe-server/client/actions/preference-experiment/index.js
+++ b/recipe-server/client/actions/preference-experiment/index.js
@@ -23,7 +23,7 @@ export default class PreferenceExperimentAction extends Action {
     //
     // Once we remove self-repair support, we should be able to use native
     // async/await anyway, which solves the issue.
-    const { slug, preferenceName, preferenceBranchType, branches } = this.recipe.arguments;
+    const { slug, preferenceName, preferenceBranchType, branches, preferenceType } = this.recipe.arguments;
     const experiments = this.normandy.preferenceExperiments;
 
     // Exit early if we're on an incompatible client.
@@ -43,6 +43,7 @@ export default class PreferenceExperimentAction extends Action {
             preferenceName,
             preferenceValue: branch.value,
             preferenceBranchType,
+            preferenceType,
           })
         );
       }

--- a/recipe-server/client/actions/preference-experiment/index.js
+++ b/recipe-server/client/actions/preference-experiment/index.js
@@ -23,7 +23,9 @@ export default class PreferenceExperimentAction extends Action {
     //
     // Once we remove self-repair support, we should be able to use native
     // async/await anyway, which solves the issue.
-    const { slug, preferenceName, preferenceBranchType, branches, preferenceType } = this.recipe.arguments;
+    const {
+      slug, preferenceName, preferenceBranchType, branches, preferenceType
+    } = this.recipe.arguments;
     const experiments = this.normandy.preferenceExperiments;
 
     // Exit early if we're on an incompatible client.

--- a/recipe-server/client/actions/tests/test_preference-experiment.js
+++ b/recipe-server/client/actions/tests/test_preference-experiment.js
@@ -25,12 +25,13 @@ class MockPreferenceExperiments {
     this.experiments = {};
   }
 
-  async start({ name, branch, preferenceName, preferenceValue }) {
+  async start({ name, branch, preferenceName, preferenceValue, preferenceType }) {
     this.experiments[name] = {
       name,
       branch,
       preferenceName,
       preferenceValue,
+      preferenceType,
       expired: false,
       lastSeen: 'start',
     };
@@ -115,6 +116,7 @@ describe('PreferenceExperimentAction', () => {
           preferenceName: 'fake.preference',
           preferenceValue: 'branch1',
           preferenceBranchType: 'user',
+          preferenceType: 'string',
         });
     });
 


### PR DESCRIPTION
Fixes #635 

- Adds type checks when setting preference experiment values

---

I'm having trouble getting the test(s) for this feature to work. It doesn't seem to catch errors as it should, and manually throwing hard errors in `start` doesn't bubble up to the test runner, either.  I'm wondering if I have the `yield` syntax incorrect or something.

@Osmose @mythmon If you could offer some feedback on this, that'd be super appreciated!