### PR TITLE
Inform telemetry of active preference experiments

### DIFF
--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -108,7 +108,9 @@ this.PreferenceExperiments = {
       }
 
       // Notify Telemetry of experiments we're running, since they don't persist between restarts
-      TelemetryEnvironment.setExperimentActive(name, branch);
+      if (!expired) {
+        TelemetryEnvironment.setExperimentActive(name, branch);
+      }
     });
   },
 

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -97,12 +97,12 @@ this.PreferenceExperiments = {
    */
   async init() {
     const store = await ensureStorage();
-    for (const experiment of Object.values(store.data)) {
+    Object.values(store.data).forEach(experiment => {
       const {expired, preferenceBranchType, preferenceName, preferenceValue} = experiment;
       if (!expired && preferenceBranchType === "default") {
         DefaultPreferences.set(preferenceName, preferenceValue);
       }
-    }
+    });
   },
 
   /**
@@ -136,21 +136,22 @@ this.PreferenceExperiments = {
 
   /**
    * Start a new preference experiment.
-   * @param {string} experimentName
-   * @param {string} branch
-   * @param {string} preferenceName
-   * @param {string|integer|boolean} preferenceValue
-   * @param {PreferenceBranchType} preferenceBranchType
+   * @param {Object} experiment
+   * @param {string} experiment.name
+   * @param {string} experiment.branch
+   * @param {string} experiment.preferenceName
+   * @param {string|integer|boolean} experiment.preferenceValue
+   * @param {PreferenceBranchType} experiment.preferenceBranchType
    * @rejects {Error}
    *   If an experiment with the given name already exists, or if an experiment
    *   for the given preference is active.
    */
-  async start(experimentName, branch, preferenceName, preferenceValue, preferenceBranchType) {
-    log.debug(`PreferenceExperiments.start(${experimentName}, ${branch})`);
+  async start({name, branch, preferenceName, preferenceValue, preferenceBranchType}) {
+    log.debug(`PreferenceExperiments.start(${name}, ${branch})`);
 
     const store = await ensureStorage();
-    if (experimentName in store.data) {
-      throw new Error(`A preference experiment named "${experimentName}" already exists.`);
+    if (name in store.data) {
+      throw new Error(`A preference experiment named "${name}" already exists.`);
     }
 
     const activeExperiments = Object.values(store.data).filter(e => !e.expired);
@@ -170,7 +171,7 @@ this.PreferenceExperiments = {
 
     /** @type {Experiment} */
     const experiment = {
-      name: experimentName,
+      name,
       branch,
       expired: false,
       lastSeen: new Date().toJSON(),
@@ -181,8 +182,8 @@ this.PreferenceExperiments = {
     };
 
     preferences.set(preferenceName, preferenceValue);
-    PreferenceExperiments.startObserver(experimentName, preferenceName, preferenceValue);
-    store.data[experimentName] = experiment;
+    PreferenceExperiments.startObserver(name, preferenceName, preferenceValue);
+    store.data[name] = experiment;
     store.saveSoon();
   },
 

--- a/recipe-client-addon/test/unit/test_PreferenceExperiments.js
+++ b/recipe-client-addon/test/unit/test_PreferenceExperiments.js
@@ -7,6 +7,7 @@ load("utils.js"); /* globals withMockPreferences */
 
 // Save ourselves some typing
 const {withMockExperiments} = PreferenceExperiments;
+const DefaultPreferences = new Preferences({defaultBranch: true});
 
 function experimentFactory(attrs) {
   return Object.assign({
@@ -17,6 +18,7 @@ function experimentFactory(attrs) {
     preferenceName: "fake.preference",
     preferenceValue: "falkevalue",
     previousPreferenceValue: "oldfakevalue",
+    preferenceBranchType: "default",
   }, attrs);
 }
 
@@ -49,13 +51,22 @@ add_task(withMockExperiments(function* (experiments) {
   );
 }));
 
+// start should throw if an invalid preferenceBranchType is given
+add_task(withMockExperiments(function* (experiments) {
+  experiments["test"] = experimentFactory({name: "test", preferenceName: "fake.preference"});
+  yield Assert.rejects(
+    PreferenceExperiments.start("different", "branch", "other.preference", "value", "invalid"),
+    "start threw an error due to an invalid preference branch type",
+  );
+}));
+
 // start should save experiment data, modify the preference, and register a
 // watcher.
 add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
   const startObserver = sinon.stub(PreferenceExperiments, "startObserver");
-  mockPreferences.set("fake.preference", "oldvalue");
+  mockPreferences.set("fake.preference", "oldvalue", "default");
 
-  yield PreferenceExperiments.start("test", "branch", "fake.preference", "newvalue");
+  yield PreferenceExperiments.start("test", "branch", "fake.preference", "newvalue", "default");
   ok("test" in experiments, "start saved the experiment");
   ok(
     startObserver.calledWith("test", "fake.preference", "newvalue"),
@@ -69,12 +80,56 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
     preferenceName: "fake.preference",
     preferenceValue: "newvalue",
     previousPreferenceValue: "oldvalue",
+    preferenceBranchType: "default",
   };
   const experiment = {};
   Object.keys(expectedExperiment).forEach(key => experiment[key] = experiments.test[key]);
   deepEqual(experiment, expectedExperiment, "start saved the experiment");
 
-  equal(Preferences.get("fake.preference"), "newvalue", "start modified the preference");
+  equal(
+    DefaultPreferences.get("fake.preference"),
+    "newvalue",
+    "start modified the default preference",
+  );
+  notEqual(
+    Preferences.get("fake.preference"),
+    "newvalue",
+    "start did not modify the user preference",
+  );
+
+  startObserver.restore();
+})));
+
+// start should modify the user preference for the user branch type
+add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
+  const startObserver = sinon.stub(PreferenceExperiments, "startObserver");
+  mockPreferences.set("fake.preference", "oldvalue", "user");
+
+  yield PreferenceExperiments.start("test", "branch", "fake.preference", "newvalue", "user");
+  ok(
+    startObserver.calledWith("test", "fake.preference", "newvalue"),
+    "start registered an observer",
+  );
+
+  const expectedExperiment = {
+    name: "test",
+    branch: "branch",
+    expired: false,
+    preferenceName: "fake.preference",
+    preferenceValue: "newvalue",
+    previousPreferenceValue: "oldvalue",
+    preferenceBranchType: "user",
+  };
+  const experiment = {};
+  Object.keys(expectedExperiment).forEach(key => experiment[key] = experiments.test[key]);
+  deepEqual(experiment, expectedExperiment, "start saved the experiment");
+
+  notEqual(
+    DefaultPreferences.get("fake.preference"),
+    "newvalue",
+    "start did not modify the default preference",
+  );
+  equal(Preferences.get("fake.preference"), "newvalue", "start modified the user preference");
 
   startObserver.restore();
 })));
@@ -104,6 +159,25 @@ add_task(withMockPreferences(function* (mockPreferences) {
 
   // Setting it to something different should trigger the call.
   Preferences.set("fake.preference", "newvalue");
+  ok(stop.called, "Changing to a different value triggered the observer");
+
+  PreferenceExperiments.stopAllObservers();
+  stop.restore();
+}));
+
+// startObserver should observe changes to the default preference value.
+add_task(withMockPreferences(function* (mockPreferences) {
+  const stop = sinon.stub(PreferenceExperiments, "stop");
+  mockPreferences.set("fake.preference", "startvalue", "default");
+
+  PreferenceExperiments.startObserver("test", "fake.preference", "experimentvalue");
+
+  // Setting it to the experimental value should not trigger the call.
+  DefaultPreferences.set("fake.preference", "experimentvalue");
+  ok(!stop.called, "Changing to the experimental pref value did not trigger the observer");
+
+  // Setting it to something different should trigger the call.
+  DefaultPreferences.set("fake.preference", "newvalue");
   ok(stop.called, "Changing to a different value triggered the observer");
 
   PreferenceExperiments.stopAllObservers();
@@ -213,13 +287,39 @@ add_task(withMockExperiments(function* (experiments) {
 // preference value.
 add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
-  mockPreferences.set("fake.preference", "experimentvalue");
+  mockPreferences.set("fake.preference", "experimentvalue", "default");
   experiments["test"] = experimentFactory({
     name: "test",
     expired: false,
     preferenceName: "fake.preference",
     preferenceValue: "experimentvalue",
     previousPreferenceValue: "oldvalue",
+    preferenceBranchType: "default",
+  });
+
+  yield PreferenceExperiments.stop("test");
+  ok(stopObserver.calledWith("test"), "stop removed an observer");
+  equal(experiments["test"].expired, true, "stop marked the experiment as expired");
+  equal(
+    DefaultPreferences.get("fake.preference"),
+    "oldvalue",
+    "stop reverted the preference to its previous value",
+  );
+
+  stopObserver.restore();
+})));
+
+// stop should also support user pref experiments
+add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
+  const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
+  mockPreferences.set("fake.preference", "experimentvalue", "user");
+  experiments["test"] = experimentFactory({
+    name: "test",
+    expired: false,
+    preferenceName: "fake.preference",
+    preferenceValue: "experimentvalue",
+    previousPreferenceValue: "oldvalue",
+    preferenceBranchType: "user",
   });
 
   yield PreferenceExperiments.stop("test");
@@ -234,16 +334,17 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
   stopObserver.restore();
 })));
 
-// stop should remove a preference that had no value prior to an experiment
+// stop should remove a preference that had no value prior to an experiment for user prefs
 add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
-  mockPreferences.set("fake.preference", "experimentvalue");
+  mockPreferences.set("fake.preference", "experimentvalue", "user");
   experiments["test"] = experimentFactory({
     name: "test",
     expired: false,
     preferenceName: "fake.preference",
     preferenceValue: "experimentvalue",
     previousPreferenceValue: undefined,
+    preferenceBranchType: "user",
   });
 
   yield PreferenceExperiments.stop("test");
@@ -258,18 +359,19 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
 // stop should not modify a preference if resetValue is false
 add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
-  mockPreferences.set("fake.preference", "customvalue");
+  mockPreferences.set("fake.preference", "customvalue", "default");
   experiments["test"] = experimentFactory({
     name: "test",
     expired: false,
     preferenceName: "fake.preference",
     preferenceValue: "experimentvalue",
     previousPreferenceValue: "oldvalue",
+    peferenceBranchType: "default",
   });
 
   yield PreferenceExperiments.stop("test", false);
   equal(
-    Preferences.get("fake.preference"),
+    DefaultPreferences.get("fake.preference"),
     "customvalue",
     "stop did not modify the preference",
   );
@@ -304,3 +406,43 @@ add_task(withMockExperiments(function* (experiments) {
   ok(yield PreferenceExperiments.has("test"), "has returned true for a stored experiment");
   ok(!(yield PreferenceExperiments.has("missing")), "has returned false for a missing experiment");
 }));
+
+// init should set the default preference value for active, default experiments
+add_task(withMockExperiments(withMockPreferences(function* testInit(experiments, mockPreferences) {
+  experiments["user"] = experimentFactory({
+    preferenceName: "user",
+    preferenceValue: true,
+    expired: false,
+    preferenceBranchType: "user",
+  });
+  experiments["default"] = experimentFactory({
+    preferenceName: "default",
+    preferenceValue: true,
+    expired: false,
+    preferenceBranchType: "default",
+  });
+  experiments["expireddefault"] = experimentFactory({
+    preferenceName: "expireddefault",
+    preferenceValue: true,
+    expired: true,
+    preferenceBranchType: "default",
+  });
+
+  for (const name of Object.keys(experiments)) {
+    mockPreferences.set(name, false, "default");
+  }
+
+  yield PreferenceExperiments.init();
+
+  equal(DefaultPreferences.get("user"), false, "init ignored a user pref experiment");
+  equal(
+    DefaultPreferences.get("expireddefault"),
+    false,
+    "init ignored an expired default pref experiment",
+  );
+  equal(
+    DefaultPreferences.get("default"),
+    true,
+    "init set the value for a default pref experiment",
+  );
+})));

--- a/recipe-client-addon/test/unit/test_PreferenceExperiments.js
+++ b/recipe-client-addon/test/unit/test_PreferenceExperiments.js
@@ -481,24 +481,17 @@ add_task(withMockExperiments(withMockPreferences(async function testInit(experim
 
 // init should register telemetry experiments
 add_task(withMockExperiments(async function testInit(experiments) {
-  experiments["experiment1"] = experimentFactory({name: "experiment1", branch: "branch1"});
-  experiments["experiment2"] = experimentFactory({name: "experiment2", branch: "branch2"});
-
-  let currentExperiments = TelemetryEnvironment.getActiveExperiments();
-  ok(!("experiment1" in currentExperiments), "experiment1 is not in telemetry");
-  ok(!("experiment2" in currentExperiments), "experiment2 is not in telemetry");
-
+  const setActiveStub = sinon.stub(TelemetryEnvironment, "setExperimentActive");
+  experiments["test"] = experimentFactory({name: "test", branch: "branch"});
   await PreferenceExperiments.init();
-
-  currentExperiments = TelemetryEnvironment.getActiveExperiments();
-  deepEqual(currentExperiments["experiment1"], {branch: "branch1"}, "experiment1 is in telemetry");
-  deepEqual(currentExperiments["experiment2"], {branch: "branch2"}, "experiment2 is in telemetry");
+  ok(setActiveStub.calledWith("test", "branch"), "Experiment is registered by init");
+  setActiveStub.restore();
 }));
 
 // starting and stopping experiments should register in telemetry
 add_task(withMockExperiments(async function testInit() {
-  let currentExperiments = TelemetryEnvironment.getActiveExperiments();
-  ok(!("test" in currentExperiments), "test experiment is not in telemetry before starting");
+  const setActiveStub = sinon.stub(TelemetryEnvironment, "setExperimentActive");
+  const setInactiveStub = sinon.stub(TelemetryEnvironment, "setExperimentInactive");
 
   await PreferenceExperiments.start({
     name: "test",
@@ -508,15 +501,19 @@ add_task(withMockExperiments(async function testInit() {
     preferenceBranchType: "default",
   });
 
-  currentExperiments = TelemetryEnvironment.getActiveExperiments();
-  deepEqual(
-    currentExperiments["test"],
-    {branch: "branch"},
-    "test experiment is in telemetry after starting"
-  );
-
+  ok(setActiveStub.calledWith("test", "branch"), "Experiment is registerd by start()");
   await PreferenceExperiments.stop("test");
+  ok(setInactiveStub.calledWith("test", "branch"), "Experiment is unregisterd by stop()");
 
-  currentExperiments = TelemetryEnvironment.getActiveExperiments();
-  ok(!("test" in currentExperiments), "test experiment is not in telemetry after stopping");
+  setActiveStub.restore();
+  setInactiveStub.restore();
+}));
+
+// Experiments shouldn't be recorded by init() in telemetry if they are expired
+add_task(withMockExperiments(async function testInit(experiments) {
+  const setActiveStub = sinon.stub(TelemetryEnvironment, "setExperimentActive");
+  experiments["experiment1"] = experimentFactory({name: "expired", branch: "branch", expired: true});
+  await PreferenceExperiments.init();
+  ok(!setActiveStub.called, "Expired experiment is not registered by init");
+  setActiveStub.restore();
 }));

--- a/recipe-client-addon/test/unit/test_PreferenceExperiments.js
+++ b/recipe-client-addon/test/unit/test_PreferenceExperiments.js
@@ -23,20 +23,20 @@ function experimentFactory(attrs) {
 }
 
 // clearAllExperimentStorage
-add_task(withMockExperiments(function* (experiments) {
+add_task(withMockExperiments(async function (experiments) {
   experiments["test"] = experimentFactory({name: "test"});
-  ok(yield PreferenceExperiments.has("test"), "Mock experiment is detected.");
-  yield PreferenceExperiments.clearAllExperimentStorage();
+  ok(await PreferenceExperiments.has("test"), "Mock experiment is detected.");
+  await PreferenceExperiments.clearAllExperimentStorage();
   ok(
-    !(yield PreferenceExperiments.has("test")),
+    !(await PreferenceExperiments.has("test")),
     "clearAllExperimentStorage removed all stored experiments",
   );
 }));
 
 // start should throw if an experiment with the given name already exists
-add_task(withMockExperiments(function* (experiments) {
+add_task(withMockExperiments(async function (experiments) {
   experiments["test"] = experimentFactory({name: "test"});
-  yield Assert.rejects(
+  await Assert.rejects(
     PreferenceExperiments.start({
       name: "test",
       branch: "branch",
@@ -49,9 +49,9 @@ add_task(withMockExperiments(function* (experiments) {
 }));
 
 // start should throw if an experiment for the given preference is active
-add_task(withMockExperiments(function* (experiments) {
+add_task(withMockExperiments(async function (experiments) {
   experiments["test"] = experimentFactory({name: "test", preferenceName: "fake.preference"});
-  yield Assert.rejects(
+  await Assert.rejects(
     PreferenceExperiments.start({
       name: "different",
       branch: "branch",
@@ -64,8 +64,8 @@ add_task(withMockExperiments(function* (experiments) {
 }));
 
 // start should throw if an invalid preferenceBranchType is given
-add_task(withMockExperiments(function* () {
-  yield Assert.rejects(
+add_task(withMockExperiments(async function () {
+  await Assert.rejects(
     PreferenceExperiments.start({
       name: "test",
       branch: "branch",
@@ -79,11 +79,11 @@ add_task(withMockExperiments(function* () {
 
 // start should save experiment data, modify the preference, and register a
 // watcher.
-add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
   const startObserver = sinon.stub(PreferenceExperiments, "startObserver");
   mockPreferences.set("fake.preference", "oldvalue", "default");
 
-  yield PreferenceExperiments.start({
+  await PreferenceExperiments.start({
     name: "test",
     branch: "branch",
     preferenceName: "fake.preference",
@@ -124,7 +124,7 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
 })));
 
 // start should modify the user preference for the user branch type
-add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
   const startObserver = sinon.stub(PreferenceExperiments, "startObserver");
   mockPreferences.set("fake.preference", "oldvalue", "user");
 
@@ -165,7 +165,7 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
 
 // startObserver should throw if an observer for the experiment is already
 // active.
-add_task(function* () {
+add_task(async function () {
   PreferenceExperiments.startObserver("test", "fake.preference", "newvalue");
   Assert.throws(
     () => PreferenceExperiments.startObserver("test", "another.fake", "othervalue"),
@@ -176,7 +176,7 @@ add_task(function* () {
 
 // startObserver should register an observer that calls stop when a preference
 // changes from its experimental value.
-add_task(withMockPreferences(function* (mockPreferences) {
+add_task(withMockPreferences(async function (mockPreferences) {
   const stop = sinon.stub(PreferenceExperiments, "stop");
   mockPreferences.set("fake.preference", "startvalue");
 
@@ -196,7 +196,7 @@ add_task(withMockPreferences(function* (mockPreferences) {
 }));
 
 // startObserver should observe changes to the default preference value.
-add_task(withMockPreferences(function* (mockPreferences) {
+add_task(withMockPreferences(async function (mockPreferences) {
   const stop = sinon.stub(PreferenceExperiments, "stop");
   mockPreferences.set("fake.preference", "startvalue", "default");
 
@@ -216,7 +216,7 @@ add_task(withMockPreferences(function* (mockPreferences) {
 }));
 
 // stopObserver should throw if there is no observer active for it to stop.
-add_task(function* () {
+add_task(async function () {
   Assert.throws(
     () => PreferenceExperiments.stopObserver("neveractive", "another.fake", "othervalue"),
     "stopObserver threw because there was not matching active observer",
@@ -224,7 +224,7 @@ add_task(function* () {
 });
 
 // stopObserver should cancel an active observer.
-add_task(withMockPreferences(function* (mockPreferences) {
+add_task(withMockPreferences(async function (mockPreferences) {
   const stop = sinon.stub(PreferenceExperiments, "stop");
   mockPreferences.set("fake.preference", "startvalue");
 
@@ -249,7 +249,7 @@ add_task(withMockPreferences(function* (mockPreferences) {
 }));
 
 // stopAllObservers
-add_task(withMockPreferences(function* (mockPreferences) {
+add_task(withMockPreferences(async function (mockPreferences) {
   const stop = sinon.stub(PreferenceExperiments, "stop");
   mockPreferences.set("fake.preference", "startvalue");
   mockPreferences.set("other.fake.preference", "startvalue");
@@ -278,18 +278,18 @@ add_task(withMockPreferences(function* (mockPreferences) {
 }));
 
 // markLastSeen should throw if it can't find a matching experiment
-add_task(function* () {
-  yield Assert.rejects(
+add_task(async function () {
+  await Assert.rejects(
     PreferenceExperiments.markLastSeen("neveractive"),
     "markLastSeen threw because there was not a matching experiment",
   );
 });
 
 // markLastSeen should update the lastSeen date
-add_task(withMockExperiments(function* (experiments) {
+add_task(withMockExperiments(async function (experiments) {
   const oldDate = new Date(1988, 10, 1).toJSON();
   experiments["test"] = experimentFactory({name: "test", lastSeen: oldDate});
-  yield PreferenceExperiments.markLastSeen("test");
+  await PreferenceExperiments.markLastSeen("test");
   notEqual(
     experiments["test"].lastSeen,
     oldDate,
@@ -298,17 +298,17 @@ add_task(withMockExperiments(function* (experiments) {
 }));
 
 // stop should throw if an experiment with the given name doesn't exist
-add_task(withMockExperiments(function* () {
-  yield Assert.rejects(
+add_task(withMockExperiments(async function () {
+  await Assert.rejects(
     PreferenceExperiments.stop("test"),
     "stop threw an error because there are no experiments with the given name",
   );
 }));
 
 // stop should throw if the experiment is already expired
-add_task(withMockExperiments(function* (experiments) {
+add_task(withMockExperiments(async function (experiments) {
   experiments["test"] = experimentFactory({name: "test", expired: true});
-  yield Assert.rejects(
+  await Assert.rejects(
     PreferenceExperiments.stop("test"),
     "stop threw an error because the experiment was already expired",
   );
@@ -316,7 +316,7 @@ add_task(withMockExperiments(function* (experiments) {
 
 // stop should mark the experiment as expired, stop its observer, and revert the
 // preference value.
-add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
   mockPreferences.set("fake.preference", "experimentvalue", "default");
   experiments["test"] = experimentFactory({
@@ -328,7 +328,7 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
     preferenceBranchType: "default",
   });
 
-  yield PreferenceExperiments.stop("test");
+  await PreferenceExperiments.stop("test");
   ok(stopObserver.calledWith("test"), "stop removed an observer");
   equal(experiments["test"].expired, true, "stop marked the experiment as expired");
   equal(
@@ -341,7 +341,7 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
 })));
 
 // stop should also support user pref experiments
-add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
   mockPreferences.set("fake.preference", "experimentvalue", "user");
   experiments["test"] = experimentFactory({
@@ -353,7 +353,7 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
     preferenceBranchType: "user",
   });
 
-  yield PreferenceExperiments.stop("test");
+  await PreferenceExperiments.stop("test");
   ok(stopObserver.calledWith("test"), "stop removed an observer");
   equal(experiments["test"].expired, true, "stop marked the experiment as expired");
   equal(
@@ -366,7 +366,7 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
 })));
 
 // stop should remove a preference that had no value prior to an experiment for user prefs
-add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
   mockPreferences.set("fake.preference", "experimentvalue", "user");
   experiments["test"] = experimentFactory({
@@ -378,7 +378,7 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
     preferenceBranchType: "user",
   });
 
-  yield PreferenceExperiments.stop("test");
+  await PreferenceExperiments.stop("test");
   ok(
     !Preferences.has("fake.preference"),
     "stop removed the preference that had no value prior to the experiment",
@@ -388,7 +388,7 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
 })));
 
 // stop should not modify a preference if resetValue is false
-add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
   mockPreferences.set("fake.preference", "customvalue", "default");
   experiments["test"] = experimentFactory({
@@ -400,7 +400,7 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
     peferenceBranchType: "default",
   });
 
-  yield PreferenceExperiments.stop("test", false);
+  await PreferenceExperiments.stop("test", false);
   equal(
     DefaultPreferences.get("fake.preference"),
     "customvalue",
@@ -411,19 +411,19 @@ add_task(withMockExperiments(withMockPreferences(function* (experiments, mockPre
 })));
 
 // get should throw if no experiment exists with the given name
-add_task(withMockExperiments(function* () {
-  yield Assert.rejects(
+add_task(withMockExperiments(async function () {
+  await Assert.rejects(
     PreferenceExperiments.get("neverexisted"),
     "get rejects if no experiment with the given name is found",
   );
 }));
 
 // get
-add_task(withMockExperiments(function* (experiments) {
+add_task(withMockExperiments(async function (experiments) {
   const experiment = experimentFactory({name: "test"});
   experiments["test"] = experiment;
 
-  const fetchedExperiment = yield PreferenceExperiments.get("test");
+  const fetchedExperiment = await PreferenceExperiments.get("test");
   deepEqual(fetchedExperiment, experiment, "get fetches the correct experiment");
 
   // Modifying the fetched experiment must not edit the data source.
@@ -432,14 +432,14 @@ add_task(withMockExperiments(function* (experiments) {
 }));
 
 // has
-add_task(withMockExperiments(function* (experiments) {
+add_task(withMockExperiments(async function (experiments) {
   experiments["test"] = experimentFactory({name: "test"});
-  ok(yield PreferenceExperiments.has("test"), "has returned true for a stored experiment");
-  ok(!(yield PreferenceExperiments.has("missing")), "has returned false for a missing experiment");
+  ok(await PreferenceExperiments.has("test"), "has returned true for a stored experiment");
+  ok(!(await PreferenceExperiments.has("missing")), "has returned false for a missing experiment");
 }));
 
 // init should set the default preference value for active, default experiments
-add_task(withMockExperiments(withMockPreferences(function* testInit(experiments, mockPreferences) {
+add_task(withMockExperiments(withMockPreferences(async function testInit(experiments, mockPreferences) {
   experiments["user"] = experimentFactory({
     preferenceName: "user",
     preferenceValue: true,
@@ -463,7 +463,7 @@ add_task(withMockExperiments(withMockPreferences(function* testInit(experiments,
     mockPreferences.set(name, false, "default");
   }
 
-  yield PreferenceExperiments.init();
+  await PreferenceExperiments.init();
 
   equal(DefaultPreferences.get("user"), false, "init ignored a user pref experiment");
   equal(

--- a/recipe-server/client/actions/preference-experiment/index.js
+++ b/recipe-server/client/actions/preference-experiment/index.js
@@ -13,7 +13,7 @@ export default class PreferenceExperimentAction extends Action {
     //
     // Once we remove self-repair support, we should be able to use native
     // async/await anyway, which solves the issue.
-    const { slug, preferenceName, branches } = this.recipe.arguments;
+    const { slug, preferenceName, preferenceBranchType, branches } = this.recipe.arguments;
     const experiments = this.normandy.preferenceExperiments;
 
     // Exit early if we're on an incompatible client.
@@ -25,8 +25,9 @@ export default class PreferenceExperimentAction extends Action {
     return experiments.has(slug).then(hasSlug => {
       // If the experiment doesn't exist yet, enroll!
       if (!hasSlug) {
-        return this.chooseBranch(branches)
-          .then(branch => experiments.start(slug, branch.slug, preferenceName, branch.value));
+        return this.chooseBranch(branches).then(branch =>
+          experiments.start(slug, branch.slug, preferenceName, branch.value, preferenceBranchType)
+        );
       }
 
       // If the experiment exists, and isn't expired, bump the lastSeen date.

--- a/recipe-server/client/actions/preference-experiment/index.js
+++ b/recipe-server/client/actions/preference-experiment/index.js
@@ -26,7 +26,13 @@ export default class PreferenceExperimentAction extends Action {
       // If the experiment doesn't exist yet, enroll!
       if (!hasSlug) {
         return this.chooseBranch(branches).then(branch =>
-          experiments.start(slug, branch.slug, preferenceName, branch.value, preferenceBranchType)
+          experiments.start({
+            name: slug,
+            branch: branch.slug,
+            preferenceName,
+            preferenceValue: branch.value,
+            preferenceBranchType,
+          })
         );
       }
 

--- a/recipe-server/client/actions/preference-experiment/package.json
+++ b/recipe-server/client/actions/preference-experiment/package.json
@@ -38,6 +38,12 @@
                     "enum": ["string", "integer", "boolean"],
                     "default": "boolean"
                 },
+                "preferenceBranchType": {
+                    "descript": "Controls whether the default or user value of the preference is modified",
+                    "type": "string",
+                    "enum": ["user", "default"],
+                    "default": "default"
+                },
                 "branches": {
                     "description": "List of experimental branches",
                     "type": "array",

--- a/recipe-server/client/actions/tests/test_preference-experiment.js
+++ b/recipe-server/client/actions/tests/test_preference-experiment.js
@@ -7,6 +7,7 @@ function preferenceExperimentFactory(args) {
       slug: 'test',
       preferenceName: 'fake.preference',
       preferenceType: 'string',
+      preferenceBranchType: 'default',
       branches: [
         { slug: 'test', value: 'foo', ratio: 1 },
       ],
@@ -80,6 +81,7 @@ describe('PreferenceExperimentAction', () => {
       const action = new PreferenceExperimentAction(normandy, preferenceExperimentFactory({
         slug: 'test',
         preferenceName: 'fake.preference',
+        preferenceBranchType: 'user',
         branches: [
           { slug: 'branch1', value: 'branch1', ratio: 1 },
           { slug: 'branch2', value: 'branch2', ratio: 1 },
@@ -89,7 +91,7 @@ describe('PreferenceExperimentAction', () => {
 
       await action.execute();
       expect(normandy.preferenceExperiments.start)
-        .toHaveBeenCalledWith('test', 'branch1', 'fake.preference', 'branch1');
+        .toHaveBeenCalledWith('test', 'branch1', 'fake.preference', 'branch1', 'user');
     });
 
     it('should mark the lastSeen date for the experiment if it is active', async () => {

--- a/recipe-server/client/actions/tests/test_preference-experiment.js
+++ b/recipe-server/client/actions/tests/test_preference-experiment.js
@@ -21,7 +21,7 @@ class MockPreferenceExperiments {
     this.experiments = {};
   }
 
-  async start(name, branch, preferenceName, preferenceValue) {
+  async start({ name, branch, preferenceName, preferenceValue }) {
     this.experiments[name] = {
       name,
       branch,
@@ -91,7 +91,13 @@ describe('PreferenceExperimentAction', () => {
 
       await action.execute();
       expect(normandy.preferenceExperiments.start)
-        .toHaveBeenCalledWith('test', 'branch1', 'fake.preference', 'branch1', 'user');
+        .toHaveBeenCalledWith({
+          name: 'test',
+          branch: 'branch1',
+          preferenceName: 'fake.preference',
+          preferenceValue: 'branch1',
+          preferenceBranchType: 'user',
+        });
     });
 
     it('should mark the lastSeen date for the experiment if it is active', async () => {

--- a/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
+++ b/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
@@ -37,6 +37,14 @@ export class PreferenceExperimentFields extends ActionFields {
     preferenceBranchType: pt.string.isRequired,
   }
 
+  static userBranchWarning = (
+    <p className="field-warning">
+      <i className="fa fa-exclamation-triangle" />
+      Setting user preferences instead of default ones is not recommended.
+      Do not choose this unless you know what you are doing.
+    </p>
+  );
+
   render() {
     const { preferenceBranchType } = this.props;
     return (
@@ -77,13 +85,7 @@ export class PreferenceExperimentFields extends ActionFields {
           <option value="default">Default</option>
           <option value="user">User</option>
         </ControlField>
-        {preferenceBranchType === 'user' &&
-          <p className="field-warning">
-            <i className="fa fa-exclamation-triangle" />
-            Setting user preferences instead of default ones is not recommended.
-            Do not choose this unless you know what you are doing.
-          </p>
-        }
+        {preferenceBranchType === 'user' && PreferenceExperimentFields.userBranchWarning}
         <FieldArray name="arguments.branches" component={PreferenceBranches} />
       </div>
     );

--- a/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
+++ b/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
@@ -24,15 +24,21 @@ const DEFAULT_BRANCH_VALUES = {
 /**
  * Form fields for the preference-experiment action.
  */
-export default class PreferenceExperimentFields extends ActionFields {
+export class PreferenceExperimentFields extends ActionFields {
   static initialValues = {
     slug: '',
     experimentDocumentUrl: '',
     preferenceName: '',
     preferenceType: 'boolean',
+    preferenceBranchType: 'default',
+  }
+
+  static propTypes = {
+    preferenceBranchType: pt.string.isRequired,
   }
 
   render() {
+    const { preferenceBranchType } = this.props;
     return (
       <div className="arguments-fields">
         <p className="info">Run a feature experiment activated by a preference.</p>
@@ -63,11 +69,32 @@ export default class PreferenceExperimentFields extends ActionFields {
           <option value="integer">Integer</option>
           <option value="string">String</option>
         </ControlField>
+        <ControlField
+          label="Preference Branch Type"
+          name="arguments.preferenceBranchType"
+          component="select"
+        >
+          <option value="default">Default</option>
+          <option value="user">User</option>
+        </ControlField>
+        {preferenceBranchType === 'user' &&
+          <p className="field-warning">
+            <i className="fa fa-exclamation-triangle" />
+            Setting user preferences instead of default ones is not recommended.
+            Do not choose this unless you know what you are doing.
+          </p>
+        }
         <FieldArray name="arguments.branches" component={PreferenceBranches} />
       </div>
     );
   }
 }
+
+export default connect(
+  state => ({
+    preferenceBranchType: selector(state, 'arguments.preferenceBranchType'),
+  })
+)(PreferenceExperimentFields);
 
 export class PreferenceBranches extends React.Component {
   static propTypes = {

--- a/recipe-server/client/control/sass/control.scss
+++ b/recipe-server/client/control/sass/control.scss
@@ -157,6 +157,16 @@
     text-transform: uppercase;
   }
 
+  .field-warning {
+    background: $yellow;
+    font-weight: bold;
+    padding: 15px;
+
+    .fa {
+      margin-right: 15px;
+    }
+  }
+
   /* A group of related fields, generally for things like radio buttons. */
   .fieldset {
     @extend .form-field;

--- a/recipe-server/client/control/tests/components/test_PreferenceExperimentFields.js
+++ b/recipe-server/client/control/tests/components/test_PreferenceExperimentFields.js
@@ -17,8 +17,6 @@ describe('<PreferenceExperimentFields>', () => {
 
   it('should render a warning if using the user preference branch type', () => {
     const wrapper = shallow(<PreferenceExperimentFields preferenceBranchType="user" />);
-    const warning = wrapper.find('.field-warning');
-    expect(warning.length).toBe(1);
-    expect(warning.text()).toContain('not recommended');
+    expect(wrapper.contains(PreferenceExperimentFields.userBranchWarning)).toBe(true);
   });
 });

--- a/recipe-server/client/control/tests/components/test_PreferenceExperimentFields.js
+++ b/recipe-server/client/control/tests/components/test_PreferenceExperimentFields.js
@@ -1,0 +1,24 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import {
+  PreferenceExperimentFields,
+} from 'control/components/action_fields/PreferenceExperimentFields';
+
+describe('<PreferenceExperimentFields>', () => {
+  it('should render without errors', () => {
+    const wrapper = () => {
+      shallow(<PreferenceExperimentFields preferenceBranchType="default" />);
+    };
+
+    expect(wrapper).not.toThrow();
+  });
+
+  it('should render a warning if using the user preference branch type', () => {
+    const wrapper = shallow(<PreferenceExperimentFields preferenceBranchType="user" />);
+    const warning = wrapper.find('.field-warning');
+    expect(warning.length).toBe(1);
+    expect(warning.text()).toContain('not recommended');
+  });
+});


### PR DESCRIPTION
This depends on #659 (which in turn depends on #641). The relevant commits are 2c4ee93 and after.

Fixes #646.