### PR TITLE
Remove comment from install.rdf.in.

### DIFF
--- a/recipe-client-addon/install.rdf.in
+++ b/recipe-client-addon/install.rdf.in
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-#filter substitution
-
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
   <Description about="urn:mozilla:install-manifest">
     <em:id>shield-recipe-client@mozilla.org</em:id>


### PR DESCRIPTION
The comment breaks the RDF parser in Firefox, which marks the generated
XPI as corrupt.