### PR TITLE
Fallback for LocaleService::GetAppLocale.

### DIFF
--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -171,7 +171,7 @@ this.ClientEnvironment = {
 
       return Cc["@mozilla.org/chrome/chrome-registry;1"]
         .getService(Ci.nsIXULChromeRegistry)
-        .getSelectedLocale("browser");
+        .getSelectedLocale("global");
     });
 
     XPCOMUtils.defineLazyGetter(environment, "doNotTrack", () => {

--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -165,7 +165,13 @@ this.ClientEnvironment = {
     });
 
     XPCOMUtils.defineLazyGetter(environment, "locale", () => {
-      return Services.locale.getAppLocaleAsLangTag();
+      if (Services.locale.getAppLocaleAsLangTag) {
+        return Services.locale.getAppLocaleAsLangTag();
+      }
+
+      return Cc["@mozilla.org/chrome/chrome-registry;1"]
+        .getService(Ci.nsIXULChromeRegistry)
+        .getSelectedLocale("browser");
     });
 
     XPCOMUtils.defineLazyGetter(environment, "doNotTrack", () => {

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -36,7 +36,13 @@ this.NormandyDriver = function(sandboxManager) {
     testing: false,
 
     get locale() {
-      return Services.locale.getAppLocaleAsLangTag();
+      if (Services.locale.getAppLocaleAsLangTag) {
+        return Services.locale.getAppLocaleAsLangTag();
+      }
+
+      return Cc["@mozilla.org/chrome/chrome-registry;1"]
+        .getService(Ci.nsIXULChromeRegistry)
+        .getSelectedLocale("browser");
     },
 
     get userId() {

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -42,7 +42,7 @@ this.NormandyDriver = function(sandboxManager) {
 
       return Cc["@mozilla.org/chrome/chrome-registry;1"]
         .getService(Ci.nsIXULChromeRegistry)
-        .getSelectedLocale("browser");
+        .getSelectedLocale("global");
     },
 
     get userId() {


### PR DESCRIPTION
If LocaleService::GetAppLocale is unavailable (outside of Nightly
currently), then we fallback to ChromeRegistry::GetSelectedLocale,
which we used previously.

This fixes the SHIELD standalone XPI so that it can be used on Aurora, Beta, and Release, which don't have the new API for getting locales yet. Without this fix I get errors running recipes from the missing API on DevEdition.

@Pike You reviewed [bug 1347314](https://bugzilla.mozilla.org/show_bug.cgi?id=1347314), would you be willing to review this? We sync the code in this Github repo to mozilla-central every so often, so we need a Firefox peer on our reviews.

Once the new API is available on every channel, we'll remove this fallback.

I wasn't sure whether we wanted a test for these fallbacks, nor whether mocking with services from the chrome registry was possible, so I omitted them. Feel free to scold me and I'll look into this more. :D