### PR TITLE
recipe-server: Add test for signing consistency during approval.

### DIFF
--- a/recipe-server/normandy/conftest.py
+++ b/recipe-server/normandy/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from rest_framework.test import APIClient
 
 from normandy.base.tests import UserFactory, skip_except_in_ci
+from normandy.base.utils import canonical_json_dumps
 from normandy.recipes import geolocation as geolocation_module
 
 
@@ -39,4 +40,14 @@ def mocked_autograph(mocker):
         return sigs
 
     mocked.return_value.sign_data.side_effect = fake_sign
+
+    def verify_api_pair(recipe_and_signature):
+        recipe = recipe_and_signature['recipe']
+        expected_signature = recipe_and_signature['signature']['signature']
+        data = canonical_json_dumps(recipe).encode()
+        actual_signature = fake_sign([data])[0]['signature']
+        assert actual_signature == expected_signature
+
+    mocked.verify_api_pair = verify_api_pair
+
     return mocked

--- a/recipe-server/normandy/recipes/api/views.py
+++ b/recipe-server/normandy/recipes/api/views.py
@@ -160,8 +160,7 @@ class RecipeRevisionViewSet(viewsets.ReadOnlyModelViewSet):
             return Response({'error': 'This revision already has an approval request.'},
                             status=status.HTTP_400_BAD_REQUEST)
 
-        approval_request = ApprovalRequest(revision=revision, creator=request.user)
-        approval_request.save()
+        approval_request = revision.request_approval(creator=request.user)
 
         return Response(ApprovalRequestSerializer(approval_request).data,
                         status=status.HTTP_201_CREATED)

--- a/recipe-server/normandy/recipes/models.py
+++ b/recipe-server/normandy/recipes/models.py
@@ -72,9 +72,16 @@ class RecipeQuerySet(models.QuerySet):
         """
         Update the signatures on all Recipes in the queryset.
         """
-        autographer = Autographer()
         # Convert to a list because order must be preserved
         recipes = list(self)
+
+        try:
+            autographer = Autographer()
+        except ImproperlyConfigured:
+            for recipe in recipes:
+                recipe.signature = None
+                recipe.save()
+            return
 
         recipe_ids = [r.id for r in recipes]
         logger.info(
@@ -182,7 +189,11 @@ class Recipe(DirtyFieldsMixin, models.Model):
         return CanonicalJSONRenderer().render(data)
 
     def update_signature(self):
-        autographer = Autographer()
+        try:
+            autographer = Autographer()
+        except ImproperlyConfigured:
+            self.signature = None
+            return
 
         logger.info(
             f'Requesting signatures for recipes with ids [{self.id}] from Autograph',
@@ -273,10 +284,7 @@ class Recipe(DirtyFieldsMixin, models.Model):
                 super().save(*args, **kwargs)
                 kwargs['force_insert'] = False
 
-                try:
-                    self.update_signature()
-                except ImproperlyConfigured:
-                    self.signature = None
+                self.update_signature()
 
         super().save(*args, **kwargs)
 
@@ -382,6 +390,13 @@ class RecipeRevision(models.Model):
         self.updated = timezone.now()
         super().save(*args, **kwargs)
 
+    def request_approval(self, creator):
+        approval_request = ApprovalRequest(revision=self, creator=creator)
+        approval_request.save()
+        self.recipe.update_signature()
+        self.recipe.save()
+        return approval_request
+
 
 class ApprovalRequest(models.Model):
     revision = models.OneToOneField(RecipeRevision, related_name='approval_request')
@@ -426,6 +441,10 @@ class ApprovalRequest(models.Model):
         self.approver = approver
         self.comment = comment
         self.save()
+
+        recipe = self.revision.recipe
+        recipe.update_signature()
+        recipe.save()
 
 
 @reversion.register()

--- a/recipe-server/normandy/recipes/tests/test_api.py
+++ b/recipe-server/normandy/recipes/tests/test_api.py
@@ -708,7 +708,6 @@ def test_full_approval_flow(api_client, mocked_autograph):
     assert res.status_code == 200
     signed_data_1 = res.json()
     assert len(signed_data_1) == 1
-    assert signed_data_1[0]['recipe'] == recipe_data_1
     mocked_autograph.verify_api_pair(signed_data_1[0])
 
     # Make another change
@@ -724,10 +723,12 @@ def test_full_approval_flow(api_client, mocked_autograph):
     recipe_data_2 = res.json()
     assert recipe_data_2['extra_filter_expression'] == 'counter == 0'
 
-    # The signatures should remain the same
+    # It is signed correctly
     res = api_client.get('/api/v1/recipe/signed/')
     assert res.status_code == 200
-    assert res.json() == signed_data_1
+    signed_data_2 = res.json()
+    assert len(signed_data_2) == 1
+    mocked_autograph.verify_api_pair(signed_data_2[0])
 
     # Request approval for the change
     res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
@@ -741,10 +742,12 @@ def test_full_approval_flow(api_client, mocked_autograph):
     assert res.status_code == 200
     assert res.json() == recipe_data_2
 
-    # The signatures should remain the same
+    # It is signed correctly
     res = api_client.get('/api/v1/recipe/signed/')
     assert res.status_code == 200
-    assert res.json() == signed_data_1
+    signed_data_3 = res.json()
+    assert len(signed_data_3) == 1
+    mocked_autograph.verify_api_pair(signed_data_3[0])
 
     # Reject the change
     api_client.force_authenticate(user2)
@@ -758,10 +761,12 @@ def test_full_approval_flow(api_client, mocked_autograph):
     assert res.status_code == 200
     assert res.json() == recipe_data_2
 
-    # The signatures should remain the same
+    # It is signed correctly
     res = api_client.get('/api/v1/recipe/signed/')
     assert res.status_code == 200
-    assert res.json() == signed_data_1
+    signed_data_4 = res.json()
+    assert len(signed_data_4) == 1
+    mocked_autograph.verify_api_pair(signed_data_4[0])
 
     # Make a third version of the recipe
     api_client.force_authenticate(user1)
@@ -793,7 +798,6 @@ def test_full_approval_flow(api_client, mocked_autograph):
     # It is signed correctly
     res = api_client.get('/api/v1/recipe/signed/')
     assert res.status_code == 200
-    signed_data_2 = res.json()
-    assert len(signed_data_2) == 1
-    assert signed_data_2[0]['recipe'] == recipe_data_4
-    mocked_autograph.verify_api_pair(signed_data_2[0])
+    signed_data_5 = res.json()
+    assert len(signed_data_5) == 1
+    mocked_autograph.verify_api_pair(signed_data_5[0])

--- a/recipe-server/normandy/recipes/tests/test_api.py
+++ b/recipe-server/normandy/recipes/tests/test_api.py
@@ -664,7 +664,7 @@ class TestClassifyClient(object):
 
 
 @pytest.mark.django_db
-def test_full_approval_flow(api_client):
+def test_full_approval_flow(api_client, mocked_autograph):
     action = ActionFactory()
     user1 = UserFactory(is_superuser=True)
     user2 = UserFactory(is_superuser=True)
@@ -679,11 +679,11 @@ def test_full_approval_flow(api_client):
         'enabled': 'false',
     })
     assert res.status_code == 201
-    recipe_data_1 = res.json()
+    recipe_data_0 = res.json()
 
     # Request approval for it
     res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
-                          .format(recipe_data_1['revision_id']))
+                          .format(recipe_data_0['revision_id']))
     approval_data = res.json()
     assert res.status_code == 201
 
@@ -698,6 +698,19 @@ def test_full_approval_flow(api_client):
                           {'comment': 'r+'})
     assert res.status_code == 200
 
+    # It is now visible in the API
+    res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_0['id']))
+    assert res.status_code == 200
+    recipe_data_1 = res.json()
+
+    # It is signed correctly
+    res = api_client.get('/api/v1/recipe/signed/')
+    assert res.status_code == 200
+    signed_data_1 = res.json()
+    assert len(signed_data_1) == 1
+    assert signed_data_1[0]['recipe'] == recipe_data_1
+    mocked_autograph.verify_api_pair(signed_data_1[0])
+
     # Make another change
     api_client.force_authenticate(user1)
     res = api_client.patch('/api/v1/recipe/{}/'.format(recipe_data_1['id']), {
@@ -711,6 +724,11 @@ def test_full_approval_flow(api_client):
     recipe_data_2 = res.json()
     assert recipe_data_2['extra_filter_expression'] == 'counter == 0'
 
+    # The signatures should remain the same
+    res = api_client.get('/api/v1/recipe/signed/')
+    assert res.status_code == 200
+    assert res.json() == signed_data_1
+
     # Request approval for the change
     res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
                           .format(recipe_data_2['latest_revision_id']))
@@ -723,6 +741,11 @@ def test_full_approval_flow(api_client):
     assert res.status_code == 200
     assert res.json() == recipe_data_2
 
+    # The signatures should remain the same
+    res = api_client.get('/api/v1/recipe/signed/')
+    assert res.status_code == 200
+    assert res.json() == signed_data_1
+
     # Reject the change
     api_client.force_authenticate(user2)
     res = api_client.post('/api/v1/approval_request/{}/reject/'.format(approval_data['id']),
@@ -734,6 +757,11 @@ def test_full_approval_flow(api_client):
     res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_1['id']))
     assert res.status_code == 200
     assert res.json() == recipe_data_2
+
+    # The signatures should remain the same
+    res = api_client.get('/api/v1/recipe/signed/')
+    assert res.status_code == 200
+    assert res.json() == signed_data_1
 
     # Make a third version of the recipe
     api_client.force_authenticate(user1)
@@ -761,3 +789,11 @@ def test_full_approval_flow(api_client):
     recipe_data_4 = res.json()
     assert recipe_data_4['extra_filter_expression'] == 'counter == 2'
     assert recipe_data_4['latest_revision_id'] == recipe_data_4['revision_id']
+
+    # It is signed correctly
+    res = api_client.get('/api/v1/recipe/signed/')
+    assert res.status_code == 200
+    signed_data_2 = res.json()
+    assert len(signed_data_2) == 1
+    assert signed_data_2[0]['recipe'] == recipe_data_4
+    mocked_autograph.verify_api_pair(signed_data_2[0])

--- a/recipe-server/normandy/recipes/tests/test_models.py
+++ b/recipe-server/normandy/recipes/tests/test_models.py
@@ -168,7 +168,7 @@ class TestRecipe(object):
     def test_signature_is_cleared_if_autograph_unavailable(self, mocker):
         # Mock the Autographer to return an error
         mock_autograph = mocker.patch('normandy.recipes.models.Autographer')
-        mock_autograph.return_value.sign_data.side_effect = ImproperlyConfigured
+        mock_autograph.side_effect = ImproperlyConfigured
 
         recipe = RecipeFactory(name='unchanged', signed=True)
         original_signature = recipe.signature


### PR DESCRIPTION
This test is currently failing with the below traceback. @Osmose, @rehandalal does this looks like a correct test? If so, we can start in on fixing it.

```
_________ normandy/recipes/tests/test_api.py::test_full_approval_flow __________
normandy/recipes/tests/test_api.py:730: in test_full_approval_flow
    assert res.json() == signed_data_1
E   assert [{'recipe': {...'x5u': None}}] == [{'recipe': {'...'x5u': None}}]
E     At index 0 diff: {'recipe': {'action': 'đPjUlwrrgnTAY', 'approval_request': None, 'approved_revision_id': '4f415737bb0f7b350e546b1bd569917481ceb33f520f91749e42ea303aa2ddf4', 'arguments': {}, 'channels': [], 'countries': [], 'enabled': False, 'extra_filter_expression': 'counter == 0', 'filter_expression': 'counter == 0', 'id': 94, 'is_approved': True, 'last_updated': '2017-04-11T23:11:21.300314Z', 'latest_revision_id': 'c6c6e466e8c551c7ed8f4b3e021433164ea195d159d414e0dead92620b7a099a', 'locales': [], 'name': 'test recipe', 'revision_id': '4f415737bb0f7b350e546b1bd569917481ceb33f520f91749e42ea303aa2ddf4'}, 'signature': {'public_key': '', 'signature': '343230392a94cbf7f237eaf631240a6c506f4f23e40273c9be0529870c7b1bb3', 'timestamp': '2017-04-11T23:11:21.403831Z', 'x5u': None}} != {'recipe': {'action': 'đPjUlwrrgnTAY', 'approval_request': {'approved': True, 'approver': {'email': 'test73@example.com', 'first_name': '', 'id': 152, 'last_name': ''}, 'comment': 'r+', 'created': '2017-04-11T23:11:21.317127Z', 'creator': {'email': 'test72@example.com', 'first_name': '', 'id': 151, 'last_name': ''}, 'id': 30}, 'approved_revision_id': '4f415737bb0f7b350e546b1bd569917481ceb33f520f91749e42ea303aa2ddf4', 'arguments': {}, 'channels': [], 'countries': [], 'enabled': False, 'extra_filter_expression': 'counter == 0', 'filter_expression': 'counter == 0', 'id': 94, 'is_approved': True, 'last_updated': '2017-04-11T23:11:21.300314Z', 'latest_revision_id': '4f415737bb0f7b350e546b1bd569917481ceb33f520f91749e42ea303aa2ddf4', 'locales': [], 'name': 'test recipe', 'revision_id': '4f415737bb0f7b350e546b1bd569917481ceb33f520f91749e42ea303aa2ddf4'}, 'signature': {'public_key': '', 'signature': '0d60a6d4776cfa6a6c4135d1c14d4dc552b9b1745228379bdfa0f94941773696', 'timestamp': '2017-04-11T23:11:21.336857Z', 'x5u': None}}
E     Full diff:
E     [{'recipe': {'action': 'đPjUlwrrgnTAY',
E     -              'approval_request': None,
E     ?                                  ^ ^
E     +              'approval_request': {'approved': True,
E     ?                                  ^^^^^^ ^^^^^^^^^
E     +                                   'approver': {'email': 'test73@example.com',
E     +                                                'first_name': '',
E     +                                                'id': 152,
E     +                                                'last_name': ''},
E     +                                   'comment': 'r+',
E     +                                   'created': '2017-04-11T23:11:21.317127Z',
E     +                                   'creator': {'email': 'test72@example.com',
E     +                                               'first_name': '',
E     +                                               'id': 151,
E     +                                               'last_name': ''},
E     +                                   'id': 30},
E     'approved_revision_id': '4f415737bb0f7b350e546b1bd569917481ceb33f520f91749e42ea303aa2ddf4',
E     'arguments': {},
E     'channels': [],
E     'countries': [],
E     'enabled': False,
E     'extra_filter_expression': 'counter == 0',
E     'filter_expression': 'counter == 0',
E     'id': 94,
E     'is_approved': True,
E     'last_updated': '2017-04-11T23:11:21.300314Z',
E     -              'latest_revision_id': 'c6c6e466e8c551c7ed8f4b3e021433164ea195d159d414e0dead92620b7a099a',
E     +              'latest_revision_id': '4f415737bb0f7b350e546b1bd569917481ceb33f520f91749e42ea303aa2ddf4',
E     'locales': [],
E     'name': 'test recipe',
E     'revision_id': '4f415737bb0f7b350e546b1bd569917481ceb33f520f91749e42ea303aa2ddf4'},
E     'signature': {'public_key': '',
E     -                 'signature': '343230392a94cbf7f237eaf631240a6c506f4f23e40273c9be0529870c7b1bb3',
E     +                 'signature': '0d60a6d4776cfa6a6c4135d1c14d4dc552b9b1745228379bdfa0f94941773696',
E     -                 'timestamp': '2017-04-11T23:11:21.403831Z',
E     ?                                                   --  ^^
E     +                 'timestamp': '2017-04-11T23:11:21.336857Z',
E     ?                                                    ++ ^^
E     'x5u': None}}]
----------------------------- Captured stderr call -----------------------------
INFO 2017-04-11 23:11:21,294 normandy.recipes.models Requesting signatures for recipes with ids [94] from Autograph
INFO 2017-04-11 23:11:21,297 normandy.recipes.models Creating new revision for recipe ID [94]
INFO 2017-04-11 23:11:21,301 normandy.recipes.models Requesting signatures for recipes with ids [94] from Autograph
INFO 2017-04-11 23:11:21,314 request.summary 
INFO 2017-04-11 23:11:21,318 request.summary 
INFO 2017-04-11 23:11:21,321 request.summary 
INFO 2017-04-11 23:11:21,326 normandy.recipes.models Requesting signatures for recipes with ids [94] from Autograph
INFO 2017-04-11 23:11:21,339 request.summary 
INFO 2017-04-11 23:11:21,352 request.summary 
INFO 2017-04-11 23:11:21,367 request.summary 
INFO 2017-04-11 23:11:21,390 normandy.recipes.models Creating new revision for recipe ID [94]
INFO 2017-04-11 23:11:21,395 normandy.recipes.models Requesting signatures for recipes with ids [94] from Autograph
INFO 2017-04-11 23:11:21,410 request.summary 
INFO 2017-04-11 23:11:21,423 request.summary 
INFO 2017-04-11 23:11:21,436 request.summary 
!!!!!!!!!!!!!!!!!!!! Interrupted: stopping after 1 failures !!!!!!!!!!!!!!!!!!!!
```