### PR TITLE
Bump TC max run time to 8 hours and deadline to 1 day.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -16,6 +16,9 @@ tasks:
     workerType: "{{ taskcluster.docker.workerType }}"
     scopes:
       - queue:create-task:aws-provisioner-v1/github-worker
+      # the decision task creates tasks that run on the gecko worker for speed
+      # and to ensure the same execution environment as "regular" gecko builds
+      - queue:create-task:aws-provisioner-v1/gecko-1-b-linux
     payload:
       env:
       maxRunTime: 300 # 5 minutes

--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -100,6 +100,9 @@ def main():
                             'expires': fromNow('364 days'),  # must expire before task
                         },
                     },
+                    'features': {
+                        'taskclusterProxy': True,
+                    },
                 },
                 'dependencies': dependencies,
             }))

--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -21,7 +21,7 @@ tasks = [
         'artifacts_from': [
             {
                 'task_name': 'recipe-client-addon:build',
-                'path': 'build.tar.gz',
+                'path': 'public/build.tar.gz',
                 'env_var': 'BUILD_RESULT',
             },
         ],

--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -68,7 +68,7 @@ def main():
                     'source': source,
                 },
                 'provisionerId': 'aws-provisioner-v1',
-                'workerType': 'github-worker',
+                'workerType': 'gecko-1-b-linux',
                 'schedulerId': 'taskcluster-github',
                 'taskGroupId': decisionTaskId,
                 'created': fromNow('0 seconds'),

--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -72,7 +72,7 @@ def main():
                 'schedulerId': 'taskcluster-github',
                 'taskGroupId': decisionTaskId,
                 'created': fromNow('0 seconds'),
-                'deadline': fromNow('4 hours'),
+                'deadline': fromNow('1 day'),
                 'expires': fromNow('365 days'),
                 'payload': {
                     'image': 'mozilla/normandy-taskcluster:latest',
@@ -91,7 +91,7 @@ def main():
                             task['command'],
                         ])
                     ],
-                    'maxRunTime': 14400,  # 4 hours
+                    'maxRunTime': 28800,  # 8 hours
                     'env': env,
                     'artifacts': {
                         'public': {

--- a/recipe-client-addon/bin/tc/test.sh
+++ b/recipe-client-addon/bin/tc/test.sh
@@ -6,7 +6,7 @@ export SHELL=$(which bash)
 
 # Fetches build results, and creates ./gecko-dev-master/
 echo 'Downloading build result'
-curl --location --fail "$BUILD_RESULT" | tar xz
+curl --location --fail --silent --show-error "$BUILD_RESULT" | tar xz
 
 echo 'Setting up environment'
 pushd gecko-dev-master

--- a/recipe-client-addon/bin/tc/test.sh
+++ b/recipe-client-addon/bin/tc/test.sh
@@ -6,7 +6,9 @@ export SHELL=$(which bash)
 
 # Fetches build results, and creates ./gecko-dev-master/
 echo 'Downloading build result'
-curl -sfL --retry 5 "$BUILD_RESULT" | tar xz
+curl --location --fail --retry 5 "$BUILD_RESULT" -O ./gecko-dev-master.tar.gz
+ls -l ./gecko-dev-master.tar.gz
+tar xzvf ./gecko-dev-master.tar.gz
 
 echo 'Setting up environment'
 pushd gecko-dev-master

--- a/recipe-client-addon/bin/tc/test.sh
+++ b/recipe-client-addon/bin/tc/test.sh
@@ -6,9 +6,7 @@ export SHELL=$(which bash)
 
 # Fetches build results, and creates ./gecko-dev-master/
 echo 'Downloading build result'
-curl --location --fail --retry 5 "$BUILD_RESULT" -O ./gecko-dev-master.tar.gz
-ls -l ./gecko-dev-master.tar.gz
-tar xzvf ./gecko-dev-master.tar.gz
+curl --location --fail "$BUILD_RESULT" | tar xz
 
 echo 'Setting up environment'
 pushd gecko-dev-master

--- a/recipe-client-addon/bin/tc/test.sh
+++ b/recipe-client-addon/bin/tc/test.sh
@@ -6,7 +6,7 @@ export SHELL=$(which bash)
 
 # Fetches build results, and creates ./gecko-dev-master/
 echo 'Downloading build result'
-curl -sfL "$BUILD_RESULT" | tar xz
+curl -sfL --retry 5 "$BUILD_RESULT" | tar xz
 
 echo 'Setting up environment'
 pushd gecko-dev-master


### PR DESCRIPTION
@djmitche recommended, as a temporary fix, that we bump up our build times to get our PRs green again.
