### PR TITLE
Watch experiment prefs

### DIFF
--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -126,7 +126,6 @@ add_task(withMockExperiments(withMockPreferences(async function(experiments, moc
 // start should modify the user preference for the user branch type
 add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const startObserver = sinon.stub(PreferenceExperiments, "startObserver");
-  mockPreferences.set("fake.preference", "defaultvalue", "default");
   mockPreferences.set("fake.preference", "oldvalue", "user");
   mockPreferences.set("fake.preference", "olddefaultvalue", "default");
 
@@ -312,8 +311,6 @@ add_task(withMockExperiments(async function(experiments) {
 // preference value.
 add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const stopObserver = sinon.spy(PreferenceExperiments, "stopObserver");
-  const hasObserver = sinon.stub(PreferenceExperiments, "hasObserver");
-  hasObserver.returns(Promise.resolve(true));
 
   mockPreferences.set("fake.preference", "experimentvalue", "default");
   experiments["test"] = experimentFactory({
@@ -335,7 +332,6 @@ add_task(withMockExperiments(withMockPreferences(async function(experiments, moc
     "stop reverted the preference to its previous value",
   );
 
-  hasObserver.restore();
   stopObserver.restore();
   PreferenceExperiments.stopAllObservers();
 })));
@@ -381,7 +377,6 @@ add_task(withMockExperiments(withMockPreferences(async function(experiments) {
 // stop should remove a preference that had no value prior to an experiment for user prefs
 add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
-  mockPreferences.set("fake.preference", "defaultvalue", "default");
   mockPreferences.set("fake.preference", "experimentvalue", "user");
   experiments["test"] = experimentFactory({
     name: "test",

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -197,26 +197,6 @@ add_task(withMockExperiments(withMockPreferences(async function(mockExperiments,
   stop.restore();
 })));
 
-// startObserver should observe changes to the default preference value.
-add_task(withMockExperiments(withMockPreferences(async function(mockExperiments, mockPreferences) {
-  const stop = sinon.stub(PreferenceExperiments, "stop");
-  mockPreferences.set("fake.preference", "startvalue", "default");
-
-  // NOTE: startObserver does not modify the pref
-  PreferenceExperiments.startObserver("test", "fake.preference", "experimentvalue");
-
-  // Setting it to the experimental value should not trigger the call.
-  DefaultPreferences.set("fake.preference", "experimentvalue");
-  ok(!stop.called, "Changing to the experimental pref value did not trigger the observer");
-
-  // Setting it to something different should trigger the call.
-  DefaultPreferences.set("fake.preference", "newvalue");
-  ok(stop.called, "Changing to a different value triggered the observer");
-
-  PreferenceExperiments.stopAllObservers();
-  stop.restore();
-})));
-
 add_task(withMockExperiments(async function testHasObserver() {
   PreferenceExperiments.startObserver("test", "fake.preference", "experimentValue");
 


### PR DESCRIPTION
This is based on #674, to use the addition of the `init` method to `PreferenceExperiments`. The relevant commit is 13628fa.

Fixes #645.

The issue mentioned "Register the preference observer that monitors for changes to the preference." This was already done.