### PR TITLE
recipe-server: Update signatures when closing approval requests.

### DIFF
--- a/recipe-server/normandy/conftest.py
+++ b/recipe-server/normandy/conftest.py
@@ -4,8 +4,8 @@ import pytest
 from rest_framework.test import APIClient
 
 from normandy.base.tests import UserFactory, skip_except_in_ci
-from normandy.base.utils import canonical_json_dumps
 from normandy.recipes import geolocation as geolocation_module
+from normandy.recipes.tests import fake_sign
 
 
 @pytest.fixture
@@ -30,24 +30,5 @@ def geolocation():
 @pytest.fixture
 def mocked_autograph(mocker):
     mocked = mocker.patch('normandy.recipes.models.Autographer')
-
-    def fake_sign(datas):
-        sigs = []
-        for d in datas:
-            sigs.append({
-                'signature': hashlib.sha256(d).hexdigest()
-            })
-        return sigs
-
     mocked.return_value.sign_data.side_effect = fake_sign
-
-    def verify_api_pair(recipe_and_signature):
-        recipe = recipe_and_signature['recipe']
-        expected_signature = recipe_and_signature['signature']['signature']
-        data = canonical_json_dumps(recipe).encode()
-        actual_signature = fake_sign([data])[0]['signature']
-        assert actual_signature == expected_signature
-
-    mocked.verify_api_pair = verify_api_pair
-
     return mocked

--- a/recipe-server/normandy/conftest.py
+++ b/recipe-server/normandy/conftest.py
@@ -1,5 +1,3 @@
-import hashlib
-
 import pytest
 from rest_framework.test import APIClient
 

--- a/recipe-server/normandy/recipes/api/views.py
+++ b/recipe-server/normandy/recipes/api/views.py
@@ -219,7 +219,7 @@ class ApprovalRequestViewSet(viewsets.ReadOnlyModelViewSet):
     @detail_route(methods=['POST'])
     def close(self, request, pk=None):
         approval_request = self.get_object()
-        approval_request.delete()
+        approval_request.close()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/recipe-server/normandy/recipes/models.py
+++ b/recipe-server/normandy/recipes/models.py
@@ -446,6 +446,13 @@ class ApprovalRequest(models.Model):
         recipe.update_signature()
         recipe.save()
 
+    def close(self):
+        self.delete()
+
+        recipe = self.revision.recipe
+        recipe.update_signature()
+        recipe.save()
+
 
 @reversion.register()
 class Action(models.Model):

--- a/recipe-server/normandy/recipes/tests/__init__.py
+++ b/recipe-server/normandy/recipes/tests/__init__.py
@@ -174,3 +174,12 @@ ARGUMENTS_SCHEMA = {
         },
     },
 }
+
+
+def fake_sign(datas):
+    sigs = []
+    for d in datas:
+        sigs.append({
+            'signature': hashlib.sha256(d).hexdigest()
+        })
+    return sigs

--- a/recipe-server/normandy/recipes/tests/__init__.py
+++ b/recipe-server/normandy/recipes/tests/__init__.py
@@ -177,9 +177,4 @@ ARGUMENTS_SCHEMA = {
 
 
 def fake_sign(datas):
-    sigs = []
-    for d in datas:
-        sigs.append({
-            'signature': hashlib.sha256(d).hexdigest()
-        })
-    return sigs
+    return [{'signature': hashlib.sha256(d).hexdigest()} for d in datas]

--- a/recipe-server/normandy/recipes/tests/test_api.py
+++ b/recipe-server/normandy/recipes/tests/test_api.py
@@ -9,7 +9,7 @@ from rest_framework.reverse import reverse
 
 from normandy.base.api.permissions import AdminEnabledOrReadOnly
 from normandy.base.tests import UserFactory, Whatever
-from normandy.base.utils import aware_datetime
+from normandy.base.utils import aware_datetime, canonical_json_dumps
 from normandy.recipes.models import ApprovalRequest, Recipe
 from normandy.recipes.tests import (
     ActionFactory,
@@ -18,6 +18,7 @@ from normandy.recipes.tests import (
     CountryFactory,
     LocaleFactory,
     RecipeFactory,
+    fake_sign,
 )
 
 
@@ -664,140 +665,179 @@ class TestClassifyClient(object):
 
 
 @pytest.mark.django_db
-def test_full_approval_flow(api_client, mocked_autograph):
-    action = ActionFactory()
-    user1 = UserFactory(is_superuser=True)
-    user2 = UserFactory(is_superuser=True)
-    api_client.force_authenticate(user1)
+class TestApprovalFlow(object):
 
-    # Create a recipe
-    res = api_client.post('/api/v1/recipe/', {
-        'action': action.name,
-        'arguments': {},
-        'name': 'test recipe',
-        'extra_filter_expression': 'counter == 0',
-        'enabled': 'false',
-    })
-    assert res.status_code == 201
-    recipe_data_0 = res.json()
+    def verify_signatures(self, api_client, expected_count=None):
+        res = api_client.get('/api/v1/recipe/signed/')
+        assert res.status_code == 200
+        signed_data = res.json()
 
-    # Request approval for it
-    res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
-                          .format(recipe_data_0['revision_id']))
-    approval_data = res.json()
-    assert res.status_code == 201
+        if expected_count is not None:
+            assert len(signed_data) == expected_count
 
-    # The requester isn't allowed to approve a recipe
-    res = api_client.post('/api/v1/approval_request/{}/approve/'.format(approval_data['id']),
-                          {'comment': 'r+'})
-    assert res.status_code == 403  # Forbidden
+        for recipe_and_signature in signed_data:
+            recipe = recipe_and_signature['recipe']
+            expected_signature = recipe_and_signature['signature']['signature']
+            data = canonical_json_dumps(recipe).encode()
+            actual_signature = fake_sign([data])[0]['signature']
+            assert actual_signature == expected_signature
 
-    # Approve the recipe
-    api_client.force_authenticate(user2)
-    res = api_client.post('/api/v1/approval_request/{}/approve/'.format(approval_data['id']),
-                          {'comment': 'r+'})
-    assert res.status_code == 200
+    def test_full_approval_flow(self, api_client, mocked_autograph):
+        action = ActionFactory()
+        user1 = UserFactory(is_superuser=True)
+        user2 = UserFactory(is_superuser=True)
+        api_client.force_authenticate(user1)
 
-    # It is now visible in the API
-    res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_0['id']))
-    assert res.status_code == 200
-    recipe_data_1 = res.json()
+        # Create a recipe
+        res = api_client.post('/api/v1/recipe/', {
+            'action': action.name,
+            'arguments': {},
+            'name': 'test recipe',
+            'extra_filter_expression': 'counter == 0',
+            'enabled': 'false',
+        })
+        assert res.status_code == 201
+        recipe_data_0 = res.json()
 
-    # It is signed correctly
-    res = api_client.get('/api/v1/recipe/signed/')
-    assert res.status_code == 200
-    signed_data_1 = res.json()
-    assert len(signed_data_1) == 1
-    mocked_autograph.verify_api_pair(signed_data_1[0])
+        # Request approval for it
+        res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
+                            .format(recipe_data_0['revision_id']))
+        approval_data = res.json()
+        assert res.status_code == 201
 
-    # Make another change
-    api_client.force_authenticate(user1)
-    res = api_client.patch('/api/v1/recipe/{}/'.format(recipe_data_1['id']), {
-        'extra_filter_expression': 'counter == 1',
-    })
-    assert res.status_code == 200
+        # The requester isn't allowed to approve a recipe
+        res = api_client.post('/api/v1/approval_request/{}/approve/'.format(approval_data['id']),
+                            {'comment': 'r+'})
+        assert res.status_code == 403  # Forbidden
 
-    # The change should not be visible yet, since it isn't approved
-    res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_1['id']))
-    assert res.status_code == 200
-    recipe_data_2 = res.json()
-    assert recipe_data_2['extra_filter_expression'] == 'counter == 0'
+        # Approve the recipe
+        api_client.force_authenticate(user2)
+        res = api_client.post('/api/v1/approval_request/{}/approve/'.format(approval_data['id']),
+                            {'comment': 'r+'})
+        assert res.status_code == 200
 
-    # It is signed correctly
-    res = api_client.get('/api/v1/recipe/signed/')
-    assert res.status_code == 200
-    signed_data_2 = res.json()
-    assert len(signed_data_2) == 1
-    mocked_autograph.verify_api_pair(signed_data_2[0])
+        # It is now visible in the API
+        res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_0['id']))
+        assert res.status_code == 200
+        recipe_data_1 = res.json()
+        self.verify_signatures(api_client, expected_count=1)
 
-    # Request approval for the change
-    res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
-                          .format(recipe_data_2['latest_revision_id']))
-    approval_data = res.json()
-    recipe_data_2['approval_request'] = approval_data
-    assert res.status_code == 201
+        # Make another change
+        api_client.force_authenticate(user1)
+        res = api_client.patch('/api/v1/recipe/{}/'.format(recipe_data_1['id']), {
+            'extra_filter_expression': 'counter == 1',
+        })
+        assert res.status_code == 200
 
-    # The change should not be visible yet, since it isn't approved
-    res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_1['id']))
-    assert res.status_code == 200
-    assert res.json() == recipe_data_2
+        # The change should not be visible yet, since it isn't approved
+        res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_1['id']))
+        assert res.status_code == 200
+        recipe_data_2 = res.json()
+        assert recipe_data_2['extra_filter_expression'] == 'counter == 0'
+        self.verify_signatures(api_client, expected_count=1)
 
-    # It is signed correctly
-    res = api_client.get('/api/v1/recipe/signed/')
-    assert res.status_code == 200
-    signed_data_3 = res.json()
-    assert len(signed_data_3) == 1
-    mocked_autograph.verify_api_pair(signed_data_3[0])
+        # Request approval for the change
+        res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
+                            .format(recipe_data_2['latest_revision_id']))
+        approval_data = res.json()
+        recipe_data_2['approval_request'] = approval_data
+        assert res.status_code == 201
 
-    # Reject the change
-    api_client.force_authenticate(user2)
-    res = api_client.post('/api/v1/approval_request/{}/reject/'.format(approval_data['id']),
-                          {'comment': 'r-'})
-    recipe_data_2['approval_request'] = res.json()
-    assert res.status_code == 200
+        # The change should not be visible yet, since it isn't approved
+        res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_1['id']))
+        assert res.status_code == 200
+        assert res.json() == recipe_data_2
+        self.verify_signatures(api_client, expected_count=1)
 
-    # The change should not be visible yet, since it isn't approved
-    res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_1['id']))
-    assert res.status_code == 200
-    assert res.json() == recipe_data_2
+        # Reject the change
+        api_client.force_authenticate(user2)
+        res = api_client.post('/api/v1/approval_request/{}/reject/'.format(approval_data['id']),
+                            {'comment': 'r-'})
+        recipe_data_2['approval_request'] = res.json()
+        assert res.status_code == 200
 
-    # It is signed correctly
-    res = api_client.get('/api/v1/recipe/signed/')
-    assert res.status_code == 200
-    signed_data_4 = res.json()
-    assert len(signed_data_4) == 1
-    mocked_autograph.verify_api_pair(signed_data_4[0])
+        # The change should not be visible yet, since it isn't approved
+        res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_1['id']))
+        assert res.status_code == 200
+        assert res.json() == recipe_data_2
+        self.verify_signatures(api_client, expected_count=1)
 
-    # Make a third version of the recipe
-    api_client.force_authenticate(user1)
-    res = api_client.patch('/api/v1/recipe/{}/'.format(recipe_data_1['id']), {
-        'extra_filter_expression': 'counter == 2',
-    })
-    recipe_data_3 = res.json()
-    assert res.status_code == 200
+        # Make a third version of the recipe
+        api_client.force_authenticate(user1)
+        res = api_client.patch('/api/v1/recipe/{}/'.format(recipe_data_1['id']), {
+            'extra_filter_expression': 'counter == 2',
+        })
+        recipe_data_3 = res.json()
+        assert res.status_code == 200
 
-    # Request approval
-    res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
-                          .format(recipe_data_3['latest_revision_id']))
-    approval_data = res.json()
-    assert res.status_code == 201
+        # Request approval
+        res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
+                            .format(recipe_data_3['latest_revision_id']))
+        approval_data = res.json()
+        assert res.status_code == 201
 
-    # Approve the change
-    api_client.force_authenticate(user2)
-    res = api_client.post('/api/v1/approval_request/{}/approve/'.format(approval_data['id']),
-                          {'comment': 'r+'})
-    assert res.status_code == 200
+        # Approve the change
+        api_client.force_authenticate(user2)
+        res = api_client.post('/api/v1/approval_request/{}/approve/'.format(approval_data['id']),
+                            {'comment': 'r+'})
+        assert res.status_code == 200
 
-    # The change should be visible now, since it is approved
-    res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_1['id']))
-    assert res.status_code == 200
-    recipe_data_4 = res.json()
-    assert recipe_data_4['extra_filter_expression'] == 'counter == 2'
-    assert recipe_data_4['latest_revision_id'] == recipe_data_4['revision_id']
+        # The change should be visible now, since it is approved
+        res = api_client.get('/api/v1/recipe/{}/'.format(recipe_data_1['id']))
+        assert res.status_code == 200
+        recipe_data_4 = res.json()
+        assert recipe_data_4['extra_filter_expression'] == 'counter == 2'
+        assert recipe_data_4['latest_revision_id'] == recipe_data_4['revision_id']
+        self.verify_signatures(api_client, expected_count=1)
 
-    # It is signed correctly
-    res = api_client.get('/api/v1/recipe/signed/')
-    assert res.status_code == 200
-    signed_data_5 = res.json()
-    assert len(signed_data_5) == 1
-    mocked_autograph.verify_api_pair(signed_data_5[0])
+    def test_request_and_then_unrequest(self, api_client, mocked_autograph):
+        action = ActionFactory()
+        user1 = UserFactory(is_superuser=True)
+        user2 = UserFactory(is_superuser=True)
+        api_client.force_authenticate(user1)
+
+        # Create a recipe
+        res = api_client.post('/api/v1/recipe/', {
+            'action': action.name,
+            'arguments': {},
+            'name': 'test recipe',
+            'extra_filter_expression': 'counter == 0',
+            'enabled': 'false',
+        })
+        assert res.status_code == 201
+        recipe_id = res.json()['id']
+        revision_id = res.json()['latest_revision_id']
+
+        # Request approval
+        res = api_client.post(f'/api/v1/recipe_revision/{revision_id}/request_approval/')
+        assert res.status_code == 201
+        approval_request_id = res.json()['id']
+
+        # Approve the recipe
+        api_client.force_authenticate(user2)
+        res = api_client.post(
+            f'/api/v1/approval_request/{approval_request_id}/approve/',
+            {'comment': 'r+'}
+        )
+        assert res.status_code == 200
+
+        # Make another change
+        api_client.force_authenticate(user1)
+        res = api_client.patch(
+            f'/api/v1/recipe/{recipe_id}/',
+            {'extra_filter_expression': 'counter == 1'}
+        )
+        assert res.status_code == 200
+        revision_id = res.json()['latest_revision_id']
+
+        # Request approval for the second change
+        res = api_client.post(f'/api/v1/recipe_revision/{revision_id}/request_approval/')
+        approval_request_id = res.json()['id']
+        assert res.status_code == 201
+
+        # Cancel the approval request
+        res = api_client.post(f'/api/v1/approval_request/{approval_request_id}/close/')
+        assert res.status_code == 204
+
+        # The API should still have correct signatures
+        self.verify_signatures(api_client, expected_count=1)

--- a/recipe-server/normandy/recipes/tests/test_api.py
+++ b/recipe-server/normandy/recipes/tests/test_api.py
@@ -701,19 +701,19 @@ class TestApprovalFlow(object):
 
         # Request approval for it
         res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
-                            .format(recipe_data_0['revision_id']))
+                              .format(recipe_data_0['revision_id']))
         approval_data = res.json()
         assert res.status_code == 201
 
         # The requester isn't allowed to approve a recipe
         res = api_client.post('/api/v1/approval_request/{}/approve/'.format(approval_data['id']),
-                            {'comment': 'r+'})
+                              {'comment': 'r+'})
         assert res.status_code == 403  # Forbidden
 
         # Approve the recipe
         api_client.force_authenticate(user2)
         res = api_client.post('/api/v1/approval_request/{}/approve/'.format(approval_data['id']),
-                            {'comment': 'r+'})
+                              {'comment': 'r+'})
         assert res.status_code == 200
 
         # It is now visible in the API
@@ -738,7 +738,7 @@ class TestApprovalFlow(object):
 
         # Request approval for the change
         res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
-                            .format(recipe_data_2['latest_revision_id']))
+                              .format(recipe_data_2['latest_revision_id']))
         approval_data = res.json()
         recipe_data_2['approval_request'] = approval_data
         assert res.status_code == 201
@@ -752,7 +752,7 @@ class TestApprovalFlow(object):
         # Reject the change
         api_client.force_authenticate(user2)
         res = api_client.post('/api/v1/approval_request/{}/reject/'.format(approval_data['id']),
-                            {'comment': 'r-'})
+                              {'comment': 'r-'})
         recipe_data_2['approval_request'] = res.json()
         assert res.status_code == 200
 
@@ -772,14 +772,14 @@ class TestApprovalFlow(object):
 
         # Request approval
         res = api_client.post('/api/v1/recipe_revision/{}/request_approval/'
-                            .format(recipe_data_3['latest_revision_id']))
+                              .format(recipe_data_3['latest_revision_id']))
         approval_data = res.json()
         assert res.status_code == 201
 
         # Approve the change
         api_client.force_authenticate(user2)
         res = api_client.post('/api/v1/approval_request/{}/approve/'.format(approval_data['id']),
-                            {'comment': 'r+'})
+                              {'comment': 'r+'})
         assert res.status_code == 200
 
         # The change should be visible now, since it is approved
@@ -790,7 +790,7 @@ class TestApprovalFlow(object):
         assert recipe_data_4['latest_revision_id'] == recipe_data_4['revision_id']
         self.verify_signatures(api_client, expected_count=1)
 
-    def test_request_and_then_unrequest(self, api_client, mocked_autograph):
+    def test_cancel_approval(self, api_client, mocked_autograph):
         action = ActionFactory()
         user1 = UserFactory(is_superuser=True)
         user2 = UserFactory(is_superuser=True)


### PR DESCRIPTION
This fixes the issue we saw on prod today where closing an approval request broke signatures, and thus heartbeat.

Sorry about the diff here, I indented the whole flow test case, which is a big diff. The behavior of the old test didn't change, but I did extract some behavior out of it.