### PR TITLE
recipe-server/contract-tests: Skip cache tests on api URLs.

### DIFF
--- a/recipe-server/contract-tests/test_performance.py
+++ b/recipe-server/contract-tests/test_performance.py
@@ -38,6 +38,8 @@ class TestHotPaths(object):
         assert 'cookie' not in r.headers.get('vary', '').lower()
 
     def test_cache_headers(self, conf, requests_session, path, only_readonly):
+        if path.startswith('/api/'):
+            pytest.xfail('caching temporarily hidden on api by nginx')
         r = requests_session.get(conf.getoption('server') + path)
         r.raise_for_status()
         cache_control = r.headers.get('cache-control')


### PR DESCRIPTION
To work around Firefox caching bugs, we are hiding the the cache headers on API views in Nginx. These cache headers are still used server side to cache requests on webheads, but sending them to Firefox currently (on Beta 53) causes it to serve very stale requests.

This is temporary, and should be removed when the Firefox bug is fixed.

CC @relud 