### PR TITLE
Re-add preprocessor directive and modify make-xpi.sh to strip it.

### DIFF
--- a/recipe-client-addon/bin/make-xpi.sh
+++ b/recipe-client-addon/bin/make-xpi.sh
@@ -24,6 +24,7 @@ version=$(git describe --dirty | sed -e 's/^v//' -e 's/-/./g')
 sed -e "s/@NORMANDY_VERSION@/${version}/" \
     -e 's/@MOZ_APP_VERSION@/52/' \
     -e 's/@MOZ_APP_MAXVERSION@/*/' \
+    -e '/^#filter substitution$/d' \
     "${DEST}/install.rdf.in" \
     > "${DEST}/install.rdf"
 rm "${DEST}/install.rdf.in"

--- a/recipe-client-addon/install.rdf.in
+++ b/recipe-client-addon/install.rdf.in
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+#filter substitution
+
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
   <Description about="urn:mozilla:install-manifest">
     <em:id>shield-recipe-client@mozilla.org</em:id>


### PR DESCRIPTION
Did I say I was removing a comment? I was mistaken. We need this
directive for the in-tree version of the add-on so that MOZ_APP_VERSION
and MOZ_APP_MAXVERSION get substituted properly, but we need to remove
it when generating an XPI file.