### PR TITLE
Do not break `this` in functions wrapped with SandboxManager.wrapAsync.

### DIFF
--- a/recipe-client-addon/test/unit/test_SandboxManager.js
+++ b/recipe-client-addon/test/unit/test_SandboxManager.js
@@ -15,10 +15,15 @@ add_task(function* () {
     wrapped: manager.wrapAsync(async function() {
       return "wrapped";
     }),
+    aValue: "aValue",
+    wrappedThis: manager.wrapAsync(async function() {
+      return this.aValue;
+    }),
   }, {cloneFunctions: true});
 
   // Assertion helpers
   manager.addGlobal("ok", ok);
+  manager.addGlobal("equal", equal);
 
   const sandboxResult = yield new Promise(resolve => {
     manager.addGlobal("resolve", result => resolve(result));
@@ -39,6 +44,16 @@ add_task(function* () {
     `);
   });
   equal(sandboxResult, "wrapped", "wrapAsync methods return Promises that work in the sandbox");
+
+  yield manager.evalInSandbox(`
+    (async function sandboxTest() {
+      equal(
+        await driver.wrappedThis(),
+        "aValue",
+        "wrapAsync preserves the behavior of the this keyword",
+      );
+    })();
+  `);
 
   manager.removeHold("testing");
 });


### PR DESCRIPTION
wrapAsync now returns a non-arrow function, and binds the `this` value within the wrapper to `this` in the wrapped function.

(SandboxManager tests still use generators... that will change. Soon. But not in this PR.)