### PR TITLE
Bug 1345650 - Backport preference fix

### DIFF
--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -149,6 +149,11 @@ add_task(async function testClientClassificationCache() {
   const getStub = sinon.stub(ClientEnvironment, "getClientClassification")
     .returns(Promise.resolve(false));
 
+  yield SpecialPowers.pushPrefEnv({set: [
+    ["extensions.shield-recipe-client.api_url",
+     "https://example.com/selfsupport-dummy"],
+  ]});
+
   // When the experiment pref is false, eagerly call getClientClassification.
   await SpecialPowers.pushPrefEnv({set: [
     ["extensions.shield-recipe-client.experiments.lazy_classify", false],

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -149,7 +149,7 @@ add_task(async function testClientClassificationCache() {
   const getStub = sinon.stub(ClientEnvironment, "getClientClassification")
     .returns(Promise.resolve(false));
 
-  yield SpecialPowers.pushPrefEnv({set: [
+  await SpecialPowers.pushPrefEnv({set: [
     ["extensions.shield-recipe-client.api_url",
      "https://example.com/selfsupport-dummy"],
   ]});


### PR DESCRIPTION
> [Bug 1345650](https://bugzilla.mozilla.org/show_bug.cgi?id=1345650) - use https://%(server)s/ for shield/self-support URLs to not break web-platform-tests on beta, and set shield-recipe-client.api_url to a working value in browser_RecipeRunner.js

This backports a change that was made during the beta merge cycle by @philor. Presumably it only needs `rs?` here.