### PR TITLE
recipe-client-addon: Convert PreferenceExperiments tests to mochitest.

### DIFF
--- a/recipe-client-addon/test/browser/.eslintrc.js
+++ b/recipe-client-addon/test/browser/.eslintrc.js
@@ -18,5 +18,6 @@ module.exports = {
     withSandboxManager: false,
     withDriver: false,
     withMockNormandyApi: false,
+    withMockPreferences: false,
   },
 };

--- a/recipe-client-addon/test/browser/browser.ini
+++ b/recipe-client-addon/test/browser/browser.ini
@@ -11,3 +11,4 @@ support-files =
 [browser_LogManager.js]
 [browser_ClientEnvironment.js]
 [browser_bootstrap.js]
+[browser_PreferenceExperiments.js]

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -127,6 +127,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 add_task(withMockExperiments(withMockPreferences(async function (experiments, mockPreferences) {
   const startObserver = sinon.stub(PreferenceExperiments, "startObserver");
   mockPreferences.set("fake.preference", "oldvalue", "user");
+  mockPreferences.set("fake.preference", "olddefaultvalue", "default");
 
   await PreferenceExperiments.start({
     name: "test",
@@ -339,6 +340,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
     previousPreferenceValue: "oldvalue",
     preferenceBranchType: "default",
   });
+  PreferenceExperiments.startObserver("test", "fake.preference", "experimentvalue");
 
   await PreferenceExperiments.stop("test");
   ok(stopObserver.calledWith("test"), "stop removed an observer");
@@ -350,6 +352,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
   );
 
   stopObserver.restore();
+  PreferenceExperiments.stopAllObservers();
 })));
 
 // stop should also support user pref experiments
@@ -376,6 +379,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
   );
 
   stopObserver.restore();
+  PreferenceExperiments.stopAllObservers();
 })));
 
 // stop should not call stopObserver if there is no observer registered.
@@ -387,6 +391,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments) {
   ok(!stopObserver.called, "stop did not bother to stop an observer that wasn't active");
 
   stopObserver.restore();
+  PreferenceExperiments.stopAllObservers();
 })));
 
 // stop should remove a preference that had no value prior to an experiment for user prefs
@@ -404,7 +409,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 
   await PreferenceExperiments.stop("test");
   ok(
-    !Preferences.has("fake.preference"),
+    !Preferences.isSet("fake.preference"),
     "stop removed the preference that had no value prior to the experiment",
   );
 

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -1,10 +1,8 @@
 "use strict";
 
-Cu.import("resource://gre/modules/Preferences.jsm");
-Cu.import("resource://gre/modules/TelemetryEnvironment.jsm");
-Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm");
-
-load("utils.js"); /* globals withMockPreferences */
+Cu.import("resource://gre/modules/Preferences.jsm", this);
+Cu.import("resource://gre/modules/TelemetryEnvironment.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm", this);
 
 // Save ourselves some typing
 const {withMockExperiments} = PreferenceExperiments;
@@ -109,14 +107,14 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
   };
   const experiment = {};
   Object.keys(expectedExperiment).forEach(key => experiment[key] = experiments.test[key]);
-  deepEqual(experiment, expectedExperiment, "start saved the experiment");
+  Assert.deepEqual(experiment, expectedExperiment, "start saved the experiment");
 
-  equal(
+  is(
     DefaultPreferences.get("fake.preference"),
     "newvalue",
     "start modified the default preference",
   );
-  equal(
+  is(
     Preferences.get("fake.preference"),
     "uservalue",
     "start did not modify the user preference",
@@ -153,14 +151,14 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
   };
   const experiment = {};
   Object.keys(expectedExperiment).forEach(key => experiment[key] = experiments.test[key]);
-  deepEqual(experiment, expectedExperiment, "start saved the experiment");
+  Assert.deepEqual(experiment, expectedExperiment, "start saved the experiment");
 
-  notEqual(
+  Assert.notEqual(
     DefaultPreferences.get("fake.preference"),
     "newvalue",
     "start did not modify the default preference",
   );
-  equal(Preferences.get("fake.preference"), "newvalue", "start modified the user preference");
+  is(Preferences.get("fake.preference"), "newvalue", "start modified the user preference");
 
   startObserver.restore();
 })));
@@ -304,7 +302,7 @@ add_task(withMockExperiments(async function (experiments) {
   const oldDate = new Date(1988, 10, 1).toJSON();
   experiments["test"] = experimentFactory({name: "test", lastSeen: oldDate});
   await PreferenceExperiments.markLastSeen("test");
-  notEqual(
+  Assert.notEqual(
     experiments["test"].lastSeen,
     oldDate,
     "markLastSeen updated the experiment lastSeen date",
@@ -344,8 +342,8 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 
   await PreferenceExperiments.stop("test");
   ok(stopObserver.calledWith("test"), "stop removed an observer");
-  equal(experiments["test"].expired, true, "stop marked the experiment as expired");
-  equal(
+  is(experiments["test"].expired, true, "stop marked the experiment as expired");
+  is(
     DefaultPreferences.get("fake.preference"),
     "oldvalue",
     "stop reverted the preference to its previous value",
@@ -370,8 +368,8 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
 
   await PreferenceExperiments.stop("test");
   ok(stopObserver.calledWith("test"), "stop removed an observer");
-  equal(experiments["test"].expired, true, "stop marked the experiment as expired");
-  equal(
+  is(experiments["test"].expired, true, "stop marked the experiment as expired");
+  is(
     Preferences.get("fake.preference"),
     "oldvalue",
     "stop reverted the preference to its previous value",
@@ -427,7 +425,7 @@ add_task(withMockExperiments(withMockPreferences(async function (experiments, mo
   });
 
   await PreferenceExperiments.stop("test", false);
-  equal(
+  is(
     DefaultPreferences.get("fake.preference"),
     "customvalue",
     "stop did not modify the preference",
@@ -450,11 +448,11 @@ add_task(withMockExperiments(async function (experiments) {
   experiments["test"] = experiment;
 
   const fetchedExperiment = await PreferenceExperiments.get("test");
-  deepEqual(fetchedExperiment, experiment, "get fetches the correct experiment");
+  Assert.deepEqual(fetchedExperiment, experiment, "get fetches the correct experiment");
 
   // Modifying the fetched experiment must not edit the data source.
   fetchedExperiment.name = "othername";
-  equal(experiments["test"].name, "test", "get returns a copy of the experiment");
+  is(experiments["test"].name, "test", "get returns a copy of the experiment");
 }));
 
 add_task(withMockExperiments(async function testGetAll(experiments) {
@@ -464,21 +462,21 @@ add_task(withMockExperiments(async function testGetAll(experiments) {
   experiments["experiment2"] = experiment2;
 
   const fetchedExperiments = await PreferenceExperiments.getAll();
-  equal(fetchedExperiments.length, 2, "getAll returns a list of all stored experiments");
-  deepEqual(
+  is(fetchedExperiments.length, 2, "getAll returns a list of all stored experiments");
+  Assert.deepEqual(
     fetchedExperiments.find(e => e.name === "experiment1"),
     experiment1,
     "getAll returns a list with the correct experiments",
   );
   const fetchedExperiment2 = fetchedExperiments.find(e => e.name === "experiment2");
-  deepEqual(
+  Assert.deepEqual(
     fetchedExperiment2,
     experiment2,
     "getAll returns a list with the correct experiments, including disabled ones",
   );
 
   fetchedExperiment2.name = "othername";
-  equal(experiment2.name, "experiment2", "getAll returns copies of the experiments");
+  is(experiment2.name, "experiment2", "getAll returns copies of the experiments");
 }));
 
 add_task(withMockExperiments(withMockPreferences(async function testGetAllActive(experiments) {
@@ -492,14 +490,14 @@ add_task(withMockExperiments(withMockPreferences(async function testGetAllActive
   });
 
   const activeExperiments = await PreferenceExperiments.getAllActive();
-  deepEqual(
+  Assert.deepEqual(
     activeExperiments,
     [experiments["active"]],
     "getAllActive only returns active experiments",
   );
 
   activeExperiments[0].name = "newfakename";
-  notEqual(
+  Assert.notEqual(
     experiments["active"].name,
     "newfakename",
     "getAllActive returns copies of stored experiments",
@@ -540,13 +538,13 @@ add_task(withMockExperiments(withMockPreferences(async function testInit(experim
 
   await PreferenceExperiments.init();
 
-  equal(DefaultPreferences.get("user"), false, "init ignored a user pref experiment");
-  equal(
+  is(DefaultPreferences.get("user"), false, "init ignored a user pref experiment");
+  is(
     DefaultPreferences.get("expireddefault"),
     false,
     "init ignored an expired default pref experiment",
   );
-  equal(
+  is(
     DefaultPreferences.get("default"),
     true,
     "init set the value for a default pref experiment",

--- a/recipe-client-addon/test/unit/utils.js
+++ b/recipe-client-addon/test/unit/utils.js
@@ -8,6 +8,7 @@ const preferenceBranches = {
   default: new Preferences({defaultBranch: true}),
 };
 
+// duplicated from test/browser/head.js until we move everything over to mochitests.
 function withMockPreferences(testFunction) {
   return async function inner(...args) {
     const prefManager = new MockPreferences();

--- a/recipe-client-addon/test/unit/xpcshell.ini
+++ b/recipe-client-addon/test/unit/xpcshell.ini
@@ -7,6 +7,5 @@ support-files =
   utils.js
 
 [test_NormandyApi.js]
-[test_PreferenceExperiments.js]
 [test_Sampling.js]
 [test_SandboxManager.js]


### PR DESCRIPTION
I'm having some trouble here. Most of the tests are passing, but a few aren't, and I haven't been able to figure out why.

Here are the failing tests when I run locally:

```
405 INFO TEST-UNEXPECTED-FAIL | browser/extensions/shield-recipe-client/test/browser/browser_PreferenceExperiments.js | start did not modify the default preference - "newvalue" != "newvalue" - JS frame :: chrome://mochitests/content/browser/browser/extensions/shield-recipe-client/test/browser/browser_PreferenceExperiments.js :: <TOP_LEVEL> :: line 156
Stack trace:
chrome://mochitests/content/browser/browser/extensions/shield-recipe-client/test/browser/browser_PreferenceExperiments.js:null:156

406 INFO TEST-UNEXPECTED-FAIL | browser/extensions/shield-recipe-client/test/browser/browser_PreferenceExperiments.js | stop removed an observer - 
Stack trace:
chrome://mochitests/content/browser/browser/extensions/shield-recipe-client/test/browser/browser_PreferenceExperiments.js:null:344

407 INFO TEST-UNEXPECTED-FAIL | browser/extensions/shield-recipe-client/test/browser/browser_PreferenceExperiments.js | stop did not bother to stop an observer that wasn't active - 
Stack trace:
chrome://mochitests/content/browser/browser/extensions/shield-recipe-client/test/browser/browser_PreferenceExperiments.js:null:387

408 INFO TEST-UNEXPECTED-FAIL | browser/extensions/shield-recipe-client/test/browser/browser_PreferenceExperiments.js | stop removed the preference that had no value prior to the experiment - 
Stack trace:
chrome://mochitests/content/browser/browser/extensions/shield-recipe-client/test/browser/browser_PreferenceExperiments.js:null:406
```