### PR TITLE
#698: Treat malformed lastShown dates as valid in show-heartbeat.

### DIFF
--- a/recipe-server/client/actions/show-heartbeat/index.js
+++ b/recipe-server/client/actions/show-heartbeat/index.js
@@ -84,17 +84,16 @@ export default class ShowHeartbeatAction extends Action {
   }
 
   /**
-   * Checks when this survey was last shown,
-   * and returns a boolean indicating if the
-   * user has ever seen this survey or not.
-   *
+   * Return whether this survey has been seen by the user before.
+
    * @async
-   * @return {Boolean}  Has the survey ever been shown?
+   * @return {Boolean}
    */
   async hasShownBefore() {
-    const lastShown = await this.getLastShown();
-    // If no survey has been shown, lastShown will be falsey.
-    return !!lastShown;
+    // Even if the stored date is unparsable due to weirdness in the user's
+    // storage, if there's _something_ stored then we probably have shown at
+    // least once.
+    return await this.storage.getItem('lastShown') !== null;
   }
 
   /**

--- a/recipe-server/client/actions/tests/test_show-heartbeat.js
+++ b/recipe-server/client/actions/tests/test_show-heartbeat.js
@@ -120,6 +120,15 @@ describe('ShowHeartbeatAction', () => {
 
         jasmine.clock().uninstall();
       });
+
+      it('should NOT show even if the lastShown date is malformed', async() => {
+        const onceRecipe = recipeFactory();
+        const action = new ShowHeartbeatAction(normandy, onceRecipe);
+        normandy.mock.storage.data.lastShown = 'ROYALTY GOT LOYALTY INSIDE MY DNA';
+
+        await action.execute();
+        expect(normandy.showHeartbeat).not.toHaveBeenCalled();
+      });
     });
 
 


### PR DESCRIPTION
Previously, we tried to parse the lastShown date when checking if the
user has ever seen a heartbeat prompt. If the parsing failed, we
treated the resulting value (NaN) as false, which triggered
reprompting the user.

With this change, we treat _any_ stored value for lastShown as meaning
that the user saw the prompt at least once. This avoids reprompting
users with buggy storage, as well as issues with our own code writing
incorrect values to localStorage.