### PR TITLE
recipe-server: Add build time to __version__ endpoint

### DIFF
--- a/recipe-server/bin/ci/dependencies
+++ b/recipe-server/bin/ci/dependencies
@@ -5,9 +5,13 @@ set -eu
 mkdir -p __version__
 git rev-parse HEAD > __version__/commit
 git describe --tags --exact-match > __version__/tag || true # may fail if not on a tag
+date '+%s' > __version__/build_time
+
 # build image
 docker build -t mozilla/normandy:latest .
+
 # pull other docker images used below
 docker pull giorgos/takis
+
 # get MaxMind GeoIP database for tests
 ./bin/download_geolite2.sh

--- a/recipe-server/normandy/health/api/views.py
+++ b/recipe-server/normandy/health/api/views.py
@@ -21,6 +21,13 @@ logger = logging.getLogger(__name__)
 
 @lru_cache(maxsize=1)
 def get_version_info():
+    """
+    Gets data about the current build.
+
+    This pulls the data from files in a directory named __version__ in
+    the root of the project. The files in this directory are generated
+    during the CI build by the script `bin/ci/dependencies`.
+    """
 
     def fetch_key(name):
         path = os.path.join(settings.BASE_DIR, '__version__', name)
@@ -48,6 +55,9 @@ def get_version_info():
 
 @api_view(['GET'])
 def version(request):
+    """
+    Return data for developers and users to inspect the state of a server.
+    """
     repo_url = 'https://github.com/mozilla/normandy'
     version_info = get_version_info()
 

--- a/recipe-server/normandy/health/api/views.py
+++ b/recipe-server/normandy/health/api/views.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+from functools import lru_cache
+from datetime import datetime
 
 from django.conf import settings
 from django.core.checks.registry import registry as checks_registry
@@ -15,42 +17,51 @@ from normandy.base.decorators import short_circuit_middlewares
 
 
 logger = logging.getLogger(__name__)
-_commit = None
-_tag = None
 
 
+@lru_cache(maxsize=1)
 def get_version_info():
-    global _commit, _tag
-    if _commit is None:
-        path = os.path.join(settings.BASE_DIR, '__version__', 'commit')
+
+    def fetch_key(name):
+        path = os.path.join(settings.BASE_DIR, '__version__', name)
+        val = None
         try:
             with open(path) as f:
-                _commit = f.read().strip() or 'unknown'
+                val = f.read().strip()
         except OSError:
-            _commit = 'unknown'
+            pass
+        return val or None
 
-    if _tag is None:
-        path = os.path.join(settings.BASE_DIR, '__version__', 'tag')
-        try:
-            with open(path) as f:
-                _tag = f.read().strip() or 'unknown'
-        except OSError:
-            _tag = 'unknown'
+    try:
+        build_time = datetime.utcfromtimestamp(int(fetch_key('build_time')))
+    except (ValueError, TypeError) as e:
+        build_time = None
 
-    return _commit, _tag
+    version_info = {
+        'commit': fetch_key('commit'),
+        'version': fetch_key('tag'),
+        'build_time': build_time,
+    }
+
+    return version_info
 
 
 @api_view(['GET'])
 def version(request):
     repo_url = 'https://github.com/mozilla/normandy'
-    commit, tag = get_version_info()
+    version_info = get_version_info()
+
+    commit = version_info['commit']
+    version = version_info['version']
+    build_time = version_info['build_time']
 
     return Response({
         'source': repo_url,
         'commit': commit,
         'commit_link': '{0}/commit/{1}'.format(repo_url, commit) if commit else None,
         'configuration': os.environ.get('DJANGO_CONFIGURATION'),
-        'version': tag,
+        'version': version,
+        'build_time': build_time.isoformat(),
     })
 
 

--- a/recipe-server/normandy/health/tests/test_api.py
+++ b/recipe-server/normandy/health/tests/test_api.py
@@ -1,14 +1,21 @@
+from datetime import datetime
+
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
 import pytest
 
 from normandy.health.api import views
+from normandy.base.tests import Whatever
 
 
 def test_version(client, mocker):
     get_version_info = mocker.patch('normandy.health.api.views.get_version_info')
-    get_version_info.return_value = ('<git hash>', '<tag>')
+    get_version_info.return_value = {
+        'commit': '<git hash>',
+        'version': '<tag>',
+        'build_time': datetime.now(),
+    }
 
     res = client.get('/__version__')
     assert res.status_code == 200
@@ -18,6 +25,7 @@ def test_version(client, mocker):
         'commit_link': 'https://github.com/mozilla/normandy/commit/<git hash>',
         'configuration': 'Test',
         'version': '<tag>',
+        'build_time': Whatever(),
     }
 
 
@@ -42,39 +50,66 @@ class TestGetVersionInfo(object):
     @pytest.fixture
     def commit_file(self, version_info_dir):
         f = version_info_dir.join('commit')
-        f.write('bc685e4be05a182ae819990509c92affa3d882ab\n')
+        f.commit = 'bc685e4be05a182ae819990509c92affa3d882ab'
+        f.write(f.commit + '\n')
         return f
 
     @pytest.fixture
     def tag_file(self, version_info_dir):
         f = version_info_dir.join('tag')
-        f.write('v20\n')
+        f.tag = 'v20'
+        f.write(f.tag + '\n')
         return f
 
-    def test_with_both(self, commit_file, tag_file):
-        commit, tag = views.get_version_info()
-        assert commit == 'bc685e4be05a182ae819990509c92affa3d882ab'
-        assert tag == 'v20'
+    @pytest.fixture
+    def build_time_file(self, version_info_dir):
+        f = version_info_dir.join('build_time')
+        ts = 1493051820
+        f.write('1493051820\n')
+        f.datetime = datetime.utcfromtimestamp(ts)
+        return f
 
-    def test_with_only_commit(self, commit_file):
-        commit, tag = views.get_version_info()
-        assert commit == 'bc685e4be05a182ae819990509c92affa3d882ab'
-        assert tag == 'unknown'
+    @pytest.fixture
+    def clear_version_info_cache(self):
+        """Clear the cache for get_version_info() after each test run"""
+        try:
+            yield
+        finally:
+            views.get_version_info.cache_clear()
 
-    def test_with_only_tag(self, tag_file):
-        commit, tag = views.get_version_info()
-        assert commit == 'unknown'
-        assert tag == 'v20'
+    def test_with_everything(self, commit_file, tag_file, build_time_file, clear_version_info_cache):
+        version_info = views.get_version_info()
+        assert version_info['commit'] == commit_file.commit
+        assert version_info['version'] == tag_file.tag
+        assert version_info['build_time'] == build_time_file.datetime
 
-    def test_with_nothing(self, version_info_dir):
-        commit, tag = views.get_version_info()
-        assert commit == 'unknown'
-        assert tag == 'unknown'
+    def test_with_only_commit(self, commit_file, clear_version_info_cache):
+        version_info = views.get_version_info()
+        assert version_info['commit'] == commit_file.commit
+        assert version_info['version'] == None
+        assert version_info['build_time'] == None
 
-    def test_it_is_cached(self, commit_file, tag_file):
-        commit, tag = views.get_version_info()
-        assert commit == 'bc685e4be05a182ae819990509c92affa3d882ab'
-        assert tag == 'v20'
+    def test_with_only_tag(self, tag_file, clear_version_info_cache):
+        version_info = views.get_version_info()
+        assert version_info['commit'] == None
+        assert version_info['version'] == tag_file.tag
+        assert version_info['build_time'] == None
+
+    def test_with_only_build_time(self, build_time_file, clear_version_info_cache):
+        version_info = views.get_version_info()
+        assert version_info['commit'] == None
+        assert version_info['version'] == None
+        assert version_info['build_time'] == build_time_file.datetime
+
+    def test_with_nothing(self, version_info_dir, clear_version_info_cache):
+        version_info = views.get_version_info()
+        assert version_info['commit'] == None
+        assert version_info['version'] == None
+        assert version_info['build_time'] == None
+
+    def test_it_is_cached(self, commit_file, tag_file, build_time_file, clear_version_info_cache):
+        version_info = views.get_version_info()
         commit_file.remove()
         tag_file.remove()
-        assert (commit, tag) == views.get_version_info()
+        build_time_file.remove()
+        assert version_info == views.get_version_info()

--- a/recipe-server/normandy/health/tests/test_api.py
+++ b/recipe-server/normandy/health/tests/test_api.py
@@ -70,44 +70,44 @@ class TestGetVersionInfo(object):
         return f
 
     @pytest.fixture
-    def clear_version_info_cache(self):
+    def clear_version_info(self):
         """Clear the cache for get_version_info() after each test run"""
         try:
             yield
         finally:
             views.get_version_info.cache_clear()
 
-    def test_with_everything(self, commit_file, tag_file, build_time_file, clear_version_info_cache):
+    def test_with_everything(self, commit_file, tag_file, build_time_file, clear_version_info):
         version_info = views.get_version_info()
         assert version_info['commit'] == commit_file.commit
         assert version_info['version'] == tag_file.tag
         assert version_info['build_time'] == build_time_file.datetime
 
-    def test_with_only_commit(self, commit_file, clear_version_info_cache):
+    def test_with_only_commit(self, commit_file, clear_version_info):
         version_info = views.get_version_info()
         assert version_info['commit'] == commit_file.commit
-        assert version_info['version'] == None
-        assert version_info['build_time'] == None
+        assert version_info['version'] is None
+        assert version_info['build_time'] is None
 
-    def test_with_only_tag(self, tag_file, clear_version_info_cache):
+    def test_with_only_tag(self, tag_file, clear_version_info):
         version_info = views.get_version_info()
-        assert version_info['commit'] == None
+        assert version_info['commit'] is None
         assert version_info['version'] == tag_file.tag
-        assert version_info['build_time'] == None
+        assert version_info['build_time'] is None
 
-    def test_with_only_build_time(self, build_time_file, clear_version_info_cache):
+    def test_with_only_build_time(self, build_time_file, clear_version_info):
         version_info = views.get_version_info()
-        assert version_info['commit'] == None
-        assert version_info['version'] == None
+        assert version_info['commit'] is None
+        assert version_info['version'] is None
         assert version_info['build_time'] == build_time_file.datetime
 
-    def test_with_nothing(self, version_info_dir, clear_version_info_cache):
+    def test_with_nothing(self, version_info_dir, clear_version_info):
         version_info = views.get_version_info()
-        assert version_info['commit'] == None
-        assert version_info['version'] == None
-        assert version_info['build_time'] == None
+        assert version_info['commit'] is None
+        assert version_info['version'] is None
+        assert version_info['build_time'] is None
 
-    def test_it_is_cached(self, commit_file, tag_file, build_time_file, clear_version_info_cache):
+    def test_it_is_cached(self, commit_file, tag_file, build_time_file, clear_version_info):
         version_info = views.get_version_info()
         commit_file.remove()
         tag_file.remove()


### PR DESCRIPTION
This came from a desire to know when we deployed a version to prod. It isn't quite the same, as we build the docker images at least an hour before they actually get deployed. This would also show the same time on both stage and prod, and won't take into account re-deploys. This is better than nothing though.

The code here is starting to get a little unwieldy, but I think the best next step is to start using [python-dockerflow](https://github.com/mozilla-services/python-dockerflow) instead of continuing on our own custom thing.

@milescrabill Does this look like an ok thing to add to our version endpoint? Is it possible to get the actual deploy time as an envvar or a file injected into our image?