### PR TITLE
recipe-client-addon: Lazy load applicable modules in RecipeRunner

### DIFF
--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -6,22 +6,31 @@
 
 const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
-Cu.import("resource://shield-recipe-client/lib/NormandyDriver.jsm");
-Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm");
-Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm");
-Cu.import("resource://shield-recipe-client/lib/SandboxManager.jsm");
-Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm");
-Cu.import("resource://shield-recipe-client/lib/CleanupManager.jsm");
-Cu.import("resource://shield-recipe-client/lib/ActionSandboxManager.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "Preferences", "resource://gre/modules/Preferences.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "Storage",
-                                  "resource://shield-recipe-client/lib/Storage.jsm");
 XPCOMUtils.defineLazyServiceGetter(this, "timerManager",
                                    "@mozilla.org/updates/timer-manager;1",
                                    "nsIUpdateTimerManager");
+XPCOMUtils.defineLazyModuleGetter(this, "Preferences", "resource://gre/modules/Preferences.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "Storage",
+                                  "resource://shield-recipe-client/lib/Storage.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "NormandyDriver",
+                                  "resource://shield-recipe-client/lib/NormandyDriver.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "FilterExpressions",
+                                  "resource://shield-recipe-client/lib/FilterExpressions.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "NormandyApi",
+                                  "resource://shield-recipe-client/lib/NormandyApi.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "SandboxManager",
+                                  "resource://shield-recipe-client/lib/SandboxManager.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "ClientEnvironment",
+                                  "resource://shield-recipe-client/lib/ClientEnvironment.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "CleanupManager",
+                                  "resource://shield-recipe-client/lib/CleanupManager.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "ActionSandboxManager",
+                                  "resource://shield-recipe-client/lib/ActionSandboxManager.jsm");
+
+Cu.importGlobalProperties(["fetch"]); /* globals fetch */
 
 this.EXPORTED_SYMBOLS = ["RecipeRunner"];
 


### PR DESCRIPTION
This file is loaded at browser startup, so lazily loading modules that aren't needed immediately drastically decreases the amount of time we block startup. In my tests, this patch changed the time we blocked startup from 22ms to 6ms.

@kmaglione To ease integration, we require that changes to the add-on in this repo get reviewed by a Firefox peer. Can you review this as if it were a patch to m-c?