### PR TITLE
Add Rollout UI

### DIFF
--- a/recipe-server/client/actions/preference-experiment/index.js
+++ b/recipe-server/client/actions/preference-experiment/index.js
@@ -24,7 +24,7 @@ export default class PreferenceExperimentAction extends Action {
     // Once we remove self-repair support, we should be able to use native
     // async/await anyway, which solves the issue.
     const {
-      slug, preferenceName, preferenceBranchType, branches, preferenceType
+      slug, preferenceName, preferenceBranchType, branches, preferenceType,
     } = this.recipe.arguments;
     const experiments = this.normandy.preferenceExperiments;
 

--- a/recipe-server/client/actions/preference-rollout/index.js
+++ b/recipe-server/client/actions/preference-rollout/index.js
@@ -1,0 +1,10 @@
+import { Action, registerAction } from '../utils';
+
+export default class PreferenceRollout extends Action {
+  async execute() {
+    // Stub - wait a second to 'execute'
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+}
+
+registerAction('preference-rollout', PreferenceRollout);

--- a/recipe-server/client/actions/preference-rollout/package.json
+++ b/recipe-server/client/actions/preference-rollout/package.json
@@ -28,16 +28,17 @@
                     "type": ["string", "number", "boolean"],
                     "default": ""
                 },
+                "preferenceType": {
+                    "description": "Data type of the preference that controls this experiment",
+                    "type": "string",
+                    "enum": ["string", "integer", "boolean"],
+                    "default": "boolean"
+                },
                 "preferenceBranch": {
                     "descript": "Controls whether the default or user value of the preference is modified",
                     "type": "string",
                     "enum": ["user", "default"],
                     "default": "default"
-                },
-                "branchConfirmation": {
-                    "descript": "Controls whether the default or user value of the preference is modified",
-                    "type": "boolean",
-                    "default": false
                 }
             }
         }

--- a/recipe-server/client/actions/preference-rollout/package.json
+++ b/recipe-server/client/actions/preference-rollout/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "preference-rollout",
+    "version": "0.0.1",
+    "private": true,
+    "main": "./index.js",
+    "normandy": {
+        "driverVersion": "1.x",
+        "argumentsSchema": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "title": "Change a preference for a portion of the population",
+            "type": "object",
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "name": {
+                    "description": "Rollout name",
+                    "type": "string",
+                    "default": ""
+                },
+                "preferenceName": {
+                    "description": "Preference to change",
+                    "type": "string",
+                    "default": ""
+                },
+                "preferenceValue": {
+                    "description": "Value to set preference to.",
+                    "type": ["string", "number", "boolean"],
+                    "default": ""
+                },
+                "preferenceBranch": {
+                    "descript": "Controls whether the default or user value of the preference is modified",
+                    "type": "string",
+                    "enum": ["user", "default"],
+                    "default": "default"
+                },
+                "branchConfirmation": {
+                    "descript": "Controls whether the default or user value of the preference is modified",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        }
+    }
+}

--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -37,10 +37,14 @@ import {
 import composeRecipeContainer from 'control/components/RecipeContainer';
 import { ControlField } from 'control/components/Fields';
 import RecipeFormActions from 'control/components/RecipeFormActions';
+
 import HeartbeatFields from 'control/components/action_fields/HeartbeatFields';
 import ConsoleLogFields from 'control/components/action_fields/ConsoleLogFields';
 import PreferenceExperimentFields from
   'control/components/action_fields/PreferenceExperimentFields';
+import RolloutFields from 'control/components/action_fields/RolloutFields';
+
+
 import RecipeStatus from 'control/components/RecipeStatus';
 import DraftStatus from 'control/components/DraftStatus';
 import BooleanIcon from 'control/components/BooleanIcon';
@@ -85,6 +89,7 @@ export class RecipeForm extends React.Component {
     'console-log': ConsoleLogFields,
     'show-heartbeat': HeartbeatFields,
     'preference-experiment': PreferenceExperimentFields,
+    'preference-rollout': RolloutFields,
   };
 
   static LoadingSpinner = (
@@ -411,6 +416,7 @@ export class RecipeForm extends React.Component {
           <option value="console-log">Log to Console</option>
           <option value="show-heartbeat">Heartbeat Prompt</option>
           <option value="preference-experiment">Preference Experiment</option>
+          <option value="preference-rollout">Preference Rollout</option>
         </ControlField>
 
         <ArgumentsFields disabled={isFormDisabled} />

--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -37,17 +37,15 @@ import {
 import composeRecipeContainer from 'control/components/RecipeContainer';
 import { ControlField } from 'control/components/Fields';
 import RecipeFormActions from 'control/components/RecipeFormActions';
+import RecipeStatus from 'control/components/RecipeStatus';
+import DraftStatus from 'control/components/DraftStatus';
+import BooleanIcon from 'control/components/BooleanIcon';
 
 import HeartbeatFields from 'control/components/action_fields/HeartbeatFields';
 import ConsoleLogFields from 'control/components/action_fields/ConsoleLogFields';
 import PreferenceExperimentFields from
   'control/components/action_fields/PreferenceExperimentFields';
 import RolloutFields from 'control/components/action_fields/RolloutFields';
-
-
-import RecipeStatus from 'control/components/RecipeStatus';
-import DraftStatus from 'control/components/DraftStatus';
-import BooleanIcon from 'control/components/BooleanIcon';
 
 export const selector = formValueSelector('recipe');
 

--- a/recipe-server/client/control/components/action_fields/HeartbeatFields.js
+++ b/recipe-server/client/control/components/action_fields/HeartbeatFields.js
@@ -10,12 +10,16 @@ import ActionFields from 'control/components/action_fields/ActionFields';
  */
 export class HeartbeatFields extends ActionFields {
   static propTypes = {
-    recipeArguments: pt.object.required,
+    recipeArguments: pt.object.isRequired,
     disabled: pt.bool,
   }
 
   render() {
-    const { recipeArguments, disabled } = this.props;
+    const {
+      recipeArguments,
+      disabled,
+    } = this.props;
+
     return (
       <div className="arguments-fields">
         <p className="info">
@@ -87,7 +91,7 @@ export class HeartbeatFields extends ActionFields {
           `}</option>
           <option value="xdays">{`
             Allow re-prompting users who have already seen this prompt
-            after ${(recipeArguments && recipeArguments.repeatEvery) || 'X'}
+            after ${recipeArguments.repeatEvery || 'X'}
             days since they last saw it.
           `}</option>
         </ControlField>
@@ -117,6 +121,6 @@ export class HeartbeatFields extends ActionFields {
 
 export default connect(
   state => ({
-    recipeArguments: selector(state, 'arguments'),
+    recipeArguments: selector(state, 'arguments') || {},
   })
 )(HeartbeatFields);

--- a/recipe-server/client/control/components/action_fields/HeartbeatFields.js
+++ b/recipe-server/client/control/components/action_fields/HeartbeatFields.js
@@ -10,15 +10,12 @@ import ActionFields from 'control/components/action_fields/ActionFields';
  */
 export class HeartbeatFields extends ActionFields {
   static propTypes = {
-    recipeArguments: pt.object.isRequired,
+    recipeArguments: pt.object.required,
     disabled: pt.bool,
   }
 
   render() {
-    const {
-      recipeArguments,
-      disabled,
-    } = this.props;
+    const { recipeArguments, disabled } = this.props;
 
     return (
       <div className="arguments-fields">
@@ -91,7 +88,7 @@ export class HeartbeatFields extends ActionFields {
           `}</option>
           <option value="xdays">{`
             Allow re-prompting users who have already seen this prompt
-            after ${recipeArguments.repeatEvery || 'X'}
+            after ${(recipeArguments && recipeArguments.repeatEvery) || 'X'}
             days since they last saw it.
           `}</option>
         </ControlField>
@@ -121,6 +118,6 @@ export class HeartbeatFields extends ActionFields {
 
 export default connect(
   state => ({
-    recipeArguments: selector(state, 'arguments') || {},
+    recipeArguments: selector(state, 'arguments'),
   })
 )(HeartbeatFields);

--- a/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
+++ b/recipe-server/client/control/components/action_fields/PreferenceExperimentFields.js
@@ -49,7 +49,16 @@ export class PreferenceExperimentFields extends ActionFields {
     const { preferenceBranchType } = this.props;
     return (
       <div className="arguments-fields">
-        <p className="info">Run a feature experiment activated by a preference.</p>
+        <div className="info">
+          <p>
+            Run a feature experiment activated by a preference.
+            <br />
+            <br />
+            Experiments are intended for features that require testing and are NOT ready for wide
+            release. If you are aiming to permanently change a preference, use a <b>Preference
+            Rollout</b> action instead.
+          </p>
+        </div>
         <ControlField
           label="Slug"
           name="arguments.slug"

--- a/recipe-server/client/control/components/action_fields/RolloutFields.js
+++ b/recipe-server/client/control/components/action_fields/RolloutFields.js
@@ -21,22 +21,26 @@ export class RolloutFields extends ActionFields {
 
     return (
       <div className="arguments-fields">
-        <p className="info">
-          Change a preference for a portion of the population.
-          <br /><br />
-          Supports gradually increasing the number of users that get a feature, multiple features
-          rolling out at once to in/dependent groups, and rolling back a deployment entirely
-          (if problems arise).
-        </p>
+        <div className="info">
+          <p>
+            Change a preference permanently for a variable portion of the population.
+            <br />
+            <br />
+            Rollouts are intended for features that have been tested and are ready for release. If
+            you are aiming to test preference changes, use a <b>Preference Experiment</b> action
+            instead.
+          </p>
+        </div>
+
         <ControlField
           disabled={disabled}
-          label="Rollout name"
+          label="Rollout Name"
           name="arguments.name"
           component="input"
           type="text"
         />
         <ControlField
-          label="Preference to change"
+          label="Preference Name"
           name="arguments.preferenceName"
           component="input"
           type="text"
@@ -48,23 +52,28 @@ export class RolloutFields extends ActionFields {
           type="text"
         />
         <ControlField
+          label="Preference Type"
+          name="arguments.preferenceType"
+          component="select"
+        >
+          <option value="boolean">Boolean</option>
+          <option value="integer">Integer</option>
+          <option value="string">String</option>
+        </ControlField>
+        <ControlField
           label="Preference Branch"
           name="arguments.preferenceBranch"
           component="select"
         >
           <option value="default">Default</option>
-          <option value="user">User*</option>
+          <option value="user">User</option>
         </ControlField>
         {
           recipeArguments.preferenceBranch === 'user' &&
-            <ControlField
-              name="arguments.branchConfirmation"
-              label="* I understand this will override existing user-set preferences."
-              component="input"
-              type="checkbox"
-              className="checkbox-field"
-              required
-            />
+            <div className="callout-warning has-arrow user-branch-warning">
+              Using the <b>User</b> preference branch will override existing user-set preferences.
+              Use with caution.
+            </div>
         }
       </div>
     );

--- a/recipe-server/client/control/components/action_fields/RolloutFields.js
+++ b/recipe-server/client/control/components/action_fields/RolloutFields.js
@@ -1,0 +1,78 @@
+import React, { PropTypes as pt } from 'react';
+import { connect } from 'react-redux';
+import { selector } from 'control/components/RecipeForm';
+import { ControlField } from 'control/components/Fields';
+import ActionFields from 'control/components/action_fields/ActionFields';
+
+/**
+ * Form fields for the preference-rollout action.
+ */
+export class RolloutFields extends ActionFields {
+  static propTypes = {
+    recipeArguments: pt.object.isRequired,
+    disabled: pt.bool,
+  }
+
+  render() {
+    const {
+      recipeArguments,
+      disabled,
+    } = this.props;
+
+    return (
+      <div className="arguments-fields">
+        <p className="info">
+          Change a preference for a portion of the population.
+          <br /><br />
+          Supports gradually increasing the number of users that get a feature, multiple features
+          rolling out at once to in/dependent groups, and rolling back a deployment entirely
+          (if problems arise).
+        </p>
+        <ControlField
+          disabled={disabled}
+          label="Rollout name"
+          name="arguments.name"
+          component="input"
+          type="text"
+        />
+        <ControlField
+          label="Preference to change"
+          name="arguments.preferenceName"
+          component="input"
+          type="text"
+        />
+        <ControlField
+          label="Preference Value"
+          name="arguments.preferenceValue"
+          component="input"
+          type="text"
+        />
+        <ControlField
+          label="Preference Branch"
+          name="arguments.preferenceBranch"
+          component="select"
+        >
+          <option value="default">Default</option>
+          <option value="user">User*</option>
+        </ControlField>
+        {
+          recipeArguments.preferenceBranch === 'user' &&
+            <ControlField
+              name="arguments.branchConfirmation"
+              label="* I understand this will override existing user-set preferences."
+              component="input"
+              type="checkbox"
+              className="checkbox-field"
+              required
+            />
+        }
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    recipeArguments: selector(state, 'arguments') || {},
+  })
+)(RolloutFields);

--- a/recipe-server/client/control/sass/control.scss
+++ b/recipe-server/client/control/sass/control.scss
@@ -264,6 +264,11 @@
     line-height: 1.3em;
     margin: 0 0 1em;
     padding: 1em;
+
+    p {
+      line-height: 1.5em;
+      max-width: 581px;
+    }
   }
 }
 

--- a/recipe-server/client/control/sass/control.scss
+++ b/recipe-server/client/control/sass/control.scss
@@ -259,9 +259,11 @@
   }
 
   .info {
+    background: rgba(#FFF, 0.9);
     color: $darkBrown;
+    line-height: 1.3em;
     margin: 0 0 1em;
-    width: 50%;
+    padding: 1em;
   }
 }
 

--- a/recipe-server/client/control/sass/partials/_common.scss
+++ b/recipe-server/client/control/sass/partials/_common.scss
@@ -323,13 +323,32 @@ i {
 }
 
 
-.callout {
+.callout,
+.callout-warning {
   background: rgba(19, 124, 189, 0.15);
   border-radius: 4px;
   display: block;
   padding: 1em;
   text-align: center;
   width: 100%;
+}
+
+.callout-warning {
+  background: $yellow;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.1));
+  position: relative;
+
+  &.has-arrow {
+    &::before {
+      border: solid;
+      border-color: $yellow transparent;
+      border-width: 0 8px 8px;
+      content: "";
+      left: 15px;
+      position: absolute;
+      top: -8px;
+    }
+  }
 }
 
 .recipe-form {

--- a/recipe-server/client/control/tests/components/test_RolloutFields.js
+++ b/recipe-server/client/control/tests/components/test_RolloutFields.js
@@ -1,0 +1,22 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { RolloutFields } from 'control/components/action_fields/RolloutFields';
+
+describe('<RolloutFields>', () => {
+  it('should render when a `recipeArguments` prop is given', () => {
+    const wrapper = () => shallow(<RolloutFields recipeArguments={{}} />);
+    expect(wrapper).not.toThrow();
+  });
+
+  it('should not display a warning message when given a non-"user" preference branch', () => {
+    const wrapper = shallow(<RolloutFields recipeArguments={{ preferenceBranch: 'default' }} />);
+    expect(wrapper.find('.user-branch-warning').length).toBe(0);
+  });
+
+  it('should display a warning message when given a `user` preference branch', () => {
+    const wrapper = shallow(<RolloutFields recipeArguments={{ preferenceBranch: 'user' }} />);
+    expect(wrapper.find('.user-branch-warning').length).toBe(1);
+  });
+});

--- a/recipe-server/webpack.config.js
+++ b/recipe-server/webpack.config.js
@@ -117,6 +117,7 @@ module.exports = [
       'console-log': './client/actions/console-log/index',
       'show-heartbeat': './client/actions/show-heartbeat/index',
       'preference-experiment': './client/actions/preference-experiment/index',
+      'preference-rollout': './client/actions/preference-rollout/index',
     },
 
     plugins: [


### PR DESCRIPTION
Fixes #712 

---

![screen shot 2017-04-26 at 11 48 41 am](https://cloud.githubusercontent.com/assets/2767162/25448636/5b520406-2a76-11e7-8607-0d6b0dc97aa3.png)

This is pretty simple, but figured the PR was ready for a quick pass before it gets any bigger. Some notes:

- When the user selects the `user` preference branch, a checkbox appears to confirm that the user understands the ramifications (`I understand this will override existing user-set preferences.`)

- The selfrepair'd action has just been stubbed out at this point. The driver needs a bunch of things added to it, which I'd consider out of scope for this PR (but maybe I'm wrong!)