### PR TITLE
Fix try builds of the system add-on

### DIFF
--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -53,6 +53,19 @@ tasks = [
         ],
     },
     {
+        'name': 'recipe-client-addon:package',
+        'description': 'Package the built Firefox (with shield-recipe-client) for distribution',
+        'command': 'normandy/recipe-client-addon/bin/tc/package.sh',
+        'dependencies': ['recipe-client-addon:build'],
+        'artifacts_from': [
+            {
+                'task_name': 'recipe-client-addon:build',
+                'path': 'public/build.tar.gz',
+                'env_var': 'BUILD_RESULT',
+            },
+        ],
+    },
+    {
         'name': 'recipe-client-addon:make-xpi',
         'description': 'Build XPI for recipe-client-addon',
         'command': 'normandy/recipe-client-addon/bin/tc/make-xpi.sh',

--- a/recipe-client-addon/bin/tc/package.sh
+++ b/recipe-client-addon/bin/tc/package.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eu
+
+# mach wants this
+export SHELL=$(which bash)
+
+# Fetches build results, and creates ./gecko-dev-master/
+echo 'Downloading build result'
+curl --location --fail --silent --show-error "$BUILD_RESULT" | tar xz
+
+echo 'Setting up environment'
+pushd gecko-dev-master
+source /root/.cargo/env
+python2.7 ./python/mozboot/bin/bootstrap.py --no-interactive --application-choice=browser
+source /root/.cargo/env
+
+echo 'Packaging Firefox'
+./mach package
+popd

--- a/recipe-client-addon/jar.mn
+++ b/recipe-client-addon/jar.mn
@@ -6,5 +6,4 @@
 % resource shield-recipe-client %content/
   content/lib/ (./lib/*)
   content/data/ (./data/*)
-  content/bootstrap.js (./bootstrap.js)
   content/node_modules/jexl/ (./node_modules/jexl/*)

--- a/recipe-client-addon/lib/ShieldRecipeClient.jsm
+++ b/recipe-client-addon/lib/ShieldRecipeClient.jsm
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const {utils: Cu} = Components;
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/Preferences.jsm");
+Cu.import("resource://gre/modules/Log.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(this, "LogManager",
+  "resource://shield-recipe-client/lib/LogManager.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "RecipeRunner",
+  "resource://shield-recipe-client/lib/RecipeRunner.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "CleanupManager",
+  "resource://shield-recipe-client/lib/CleanupManager.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PreferenceExperiments",
+  "resource://shield-recipe-client/lib/PreferenceExperiments.jsm");
+
+this.EXPORTED_SYMBOLS = ["ShieldRecipeClient"];
+
+const REASONS = {
+  APP_STARTUP: 1,      // The application is starting up.
+  APP_SHUTDOWN: 2,     // The application is shutting down.
+  ADDON_ENABLE: 3,     // The add-on is being enabled.
+  ADDON_DISABLE: 4,    // The add-on is being disabled. (Also sent during uninstallation)
+  ADDON_INSTALL: 5,    // The add-on is being installed.
+  ADDON_UNINSTALL: 6,  // The add-on is being uninstalled.
+  ADDON_UPGRADE: 7,    // The add-on is being upgraded.
+  ADDON_DOWNGRADE: 8,  // The add-on is being downgraded.
+};
+const PREF_BRANCH = "extensions.shield-recipe-client.";
+const DEFAULT_PREFS = {
+  api_url: "https://normandy.cdn.mozilla.net/api/v1",
+  dev_mode: false,
+  enabled: true,
+  startup_delay_seconds: 300,
+  "logging.level": Log.Level.Warn,
+  user_id: "",
+  run_interval_seconds: 86400, // 24 hours
+};
+const PREF_DEV_MODE = "extensions.shield-recipe-client.dev_mode";
+const PREF_SELF_SUPPORT_ENABLED = "browser.selfsupport.enabled";
+const PREF_LOGGING_LEVEL = PREF_BRANCH + "logging.level";
+
+let log = null;
+
+/**
+ * Handles startup and shutdown of the entire add-on. Bootsrap.js defers to this
+ * module for most tasks so that we can more easily test startup and shutdown
+ * (bootstrap.js is difficult to import in tests).
+ */
+this.ShieldRecipeClient = {
+  async startup() {
+    ShieldRecipeClient.setDefaultPrefs();
+
+    // Disable self-support, since we replace its behavior.
+    // Self-support only checks its pref on start, so if we disable it, wait
+    // until next startup to run, unless the dev_mode preference is set.
+    if (Preferences.get(PREF_SELF_SUPPORT_ENABLED, true)) {
+      Preferences.set(PREF_SELF_SUPPORT_ENABLED, false);
+      if (!Preferences.get(PREF_DEV_MODE, false)) {
+        return;
+      }
+    }
+
+    // Setup logging and listen for changes to logging prefs
+    LogManager.configure(Services.prefs.getIntPref(PREF_LOGGING_LEVEL));
+    Preferences.observe(PREF_LOGGING_LEVEL, LogManager.configure);
+    CleanupManager.addCleanupHandler(
+      () => Preferences.ignore(PREF_LOGGING_LEVEL, LogManager.configure),
+    );
+    log = LogManager.getLogger("bootstrap");
+
+    // Initialize experiments first to avoid a race between initializing prefs
+    // and recipes rolling back pref changes when experiments end.
+    try {
+      await PreferenceExperiments.init();
+    } catch (err) {
+      log.error("Failed to initialize preference experiments:", err);
+    }
+
+    await RecipeRunner.init();
+  },
+
+  shutdown(reason) {
+    CleanupManager.cleanup();
+
+    // Re-enable self-support if we're being disabled.
+    if (reason === REASONS.ADDON_DISABLE || reason === REASONS.ADDON_UNINSTALL) {
+      Services.prefs.setBoolPref(PREF_SELF_SUPPORT_ENABLED, true);
+    }
+  },
+
+  setDefaultPrefs() {
+    for (const [key, val] of Object.entries(DEFAULT_PREFS)) {
+      const fullKey = PREF_BRANCH + key;
+      // If someone beat us to setting a default, don't overwrite it.
+      if (!Preferences.isSet(fullKey)) {
+        Preferences.set(fullKey, val);
+      }
+    }
+  },
+};

--- a/recipe-client-addon/lib/ShieldRecipeClient.jsm
+++ b/recipe-client-addon/lib/ShieldRecipeClient.jsm
@@ -55,6 +55,14 @@ this.ShieldRecipeClient = {
   async startup() {
     ShieldRecipeClient.setDefaultPrefs();
 
+    // Setup logging and listen for changes to logging prefs
+    LogManager.configure(Services.prefs.getIntPref(PREF_LOGGING_LEVEL));
+    Preferences.observe(PREF_LOGGING_LEVEL, LogManager.configure);
+    CleanupManager.addCleanupHandler(
+      () => Preferences.ignore(PREF_LOGGING_LEVEL, LogManager.configure),
+    );
+    log = LogManager.getLogger("bootstrap");
+
     // Disable self-support, since we replace its behavior.
     // Self-support only checks its pref on start, so if we disable it, wait
     // until next startup to run, unless the dev_mode preference is set.
@@ -64,14 +72,6 @@ this.ShieldRecipeClient = {
         return;
       }
     }
-
-    // Setup logging and listen for changes to logging prefs
-    LogManager.configure(Services.prefs.getIntPref(PREF_LOGGING_LEVEL));
-    Preferences.observe(PREF_LOGGING_LEVEL, LogManager.configure);
-    CleanupManager.addCleanupHandler(
-      () => Preferences.ignore(PREF_LOGGING_LEVEL, LogManager.configure),
-    );
-    log = LogManager.getLogger("bootstrap");
 
     // Initialize experiments first to avoid a race between initializing prefs
     // and recipes rolling back pref changes when experiments end.

--- a/recipe-client-addon/test/browser/browser.ini
+++ b/recipe-client-addon/test/browser/browser.ini
@@ -10,5 +10,5 @@ support-files =
   action_server.sjs
 [browser_LogManager.js]
 [browser_ClientEnvironment.js]
-[browser_bootstrap.js]
+[browser_ShieldRecipeClient.js]
 [browser_PreferenceExperiments.js]

--- a/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
+++ b/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const bootstrap = Cu.import("resource://shield-recipe-client/bootstrap.js", {});
+Cu.import("resource://shield-recipe-client/lib/ShieldRecipeClient.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/RecipeRunner.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm", this);
 
@@ -8,7 +8,7 @@ add_task(async function testStartup() {
   sinon.stub(RecipeRunner, "init");
   sinon.stub(PreferenceExperiments, "init");
 
-  await bootstrap.startup();
+  await ShieldRecipeClient.startup();
   ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
   ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
 
@@ -20,7 +20,7 @@ add_task(async function testStartupPrefInitFail() {
   sinon.stub(RecipeRunner, "init");
   sinon.stub(PreferenceExperiments, "init").returns(Promise.reject(new Error("oh no")));
 
-  await bootstrap.startup();
+  await ShieldRecipeClient.startup();
   ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
   // Even if PreferenceExperiments.init fails, RecipeRunner.init should be called.
   ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");


### PR DESCRIPTION
There are failures with our add-on that can happen only during
packaging of Firefox, such as duplicate bootstrap.js files. We should
run that step in TaskCluster CI so we can catch those issues early.

This should catch the issue from #718 and fail. I'm still working on a fix, but want to run this in the meantime.