### PR TITLE
recipe-client-addon: Ensure trailing slash on API root.

### DIFF
--- a/recipe-client-addon/lib/NormandyApi.jsm
+++ b/recipe-client-addon/lib/NormandyApi.jsm
@@ -63,8 +63,8 @@ this.NormandyApi = {
 
   async getApiUrl(name) {
     let apiBase = new URL(prefs.getCharPref("api_url"));
-    if (!apiBase.pathname.endsWith('/')) {
-      apiBase.pathname += '/';
+    if (!apiBase.pathname.endsWith("/")) {
+      apiBase.pathname += "/";
     }
     if (!indexPromise) {
       indexPromise = this.get(apiBase.toString()).then(res => res.json());

--- a/recipe-client-addon/lib/NormandyApi.jsm
+++ b/recipe-client-addon/lib/NormandyApi.jsm
@@ -62,7 +62,10 @@ this.NormandyApi = {
   },
 
   async getApiUrl(name) {
-    const apiBase = prefs.getCharPref("api_url");
+    let apiBase = prefs.getCharPref("api_url");
+    if (!apiBase.endsWith('/')) {
+      apiBase += '/';
+    }
     if (!indexPromise) {
       indexPromise = this.get(apiBase).then(res => res.json());
     }

--- a/recipe-client-addon/lib/NormandyApi.jsm
+++ b/recipe-client-addon/lib/NormandyApi.jsm
@@ -62,11 +62,11 @@ this.NormandyApi = {
   },
 
   async getApiUrl(name) {
-    let apiBase = new URL(prefs.getCharPref("api_url"));
-    if (!apiBase.pathname.endsWith("/")) {
-      apiBase.pathname += "/";
-    }
     if (!indexPromise) {
+      let apiBase = new URL(prefs.getCharPref("api_url"));
+      if (!apiBase.pathname.endsWith("/")) {
+        apiBase.pathname += "/";
+      }
       indexPromise = this.get(apiBase.toString()).then(res => res.json());
     }
     const index = await indexPromise;

--- a/recipe-client-addon/lib/NormandyApi.jsm
+++ b/recipe-client-addon/lib/NormandyApi.jsm
@@ -62,12 +62,12 @@ this.NormandyApi = {
   },
 
   async getApiUrl(name) {
-    let apiBase = prefs.getCharPref("api_url");
-    if (!apiBase.endsWith('/')) {
-      apiBase += '/';
+    let apiBase = new URL(prefs.getCharPref("api_url"));
+    if (!apiBase.pathname.endsWith('/')) {
+      apiBase.pathname += '/';
     }
     if (!indexPromise) {
-      indexPromise = this.get(apiBase).then(res => res.json());
+      indexPromise = this.get(apiBase.toString()).then(res => res.json());
     }
     const index = await indexPromise;
     if (!(name in index)) {

--- a/recipe-client-addon/test/unit/test_NormandyApi.js
+++ b/recipe-client-addon/test/unit/test_NormandyApi.js
@@ -105,7 +105,7 @@ add_task(withMockApiServer(async function test_getApiUrlSlashes(serverUrl, prefe
     equal(endpoint, `${serverUrl}/test/`);
     ok(mockGet.calledWithExactly(`${serverUrl}/api/v1/`), "trailing slash was added");
     mockGet.reset();
-  };
+  }
 
   // with slash
   {
@@ -117,6 +117,7 @@ add_task(withMockApiServer(async function test_getApiUrlSlashes(serverUrl, prefe
     mockGet.reset();
   }
 
+  NormandyApi.clearIndexCache();
   mockGet.restore();
 }));
 

--- a/recipe-client-addon/test/unit/test_NormandyApi.js
+++ b/recipe-client-addon/test/unit/test_NormandyApi.js
@@ -77,7 +77,7 @@ function withMockApiServer(task) {
 
 add_task(withMockApiServer(async function test_get(serverUrl) {
   // Test that NormandyApi can fetch from the test server.
-  const response = await NormandyApi.get(`${serverUrl}/api/v1`);
+  const response = await NormandyApi.get(`${serverUrl}/api/v1/`);
   const data = await response.json();
   equal(data["recipe-list"], "/api/v1/recipe/", "Expected data in response");
 }));

--- a/recipe-client-addon/test/unit/test_NormandyApi.js
+++ b/recipe-client-addon/test/unit/test_NormandyApi.js
@@ -92,16 +92,16 @@ add_task(withMockApiServer(async function test_getApiUrl(serverUrl) {
 add_task(withMockApiServer(async function test_getApiUrlSlashes(serverUrl, preferences) {
   const fakeResponse = {
     async json() {
-      return { "test-endpoint": `${serverUrl}/test/` };
+      return {"test-endpoint": `${serverUrl}/test/`};
     },
   };
-  const mockGet = sinon.stub(NormandyApi, "get", async () => fakeResponse)
+  const mockGet = sinon.stub(NormandyApi, "get", async () => fakeResponse);
 
   // without slash
   {
     NormandyApi.clearIndexCache();
-    preferences.set("extensions.shield-recipe-client.api_url", `${serverUrl}/api/v1`)
-    let endpoint = await NormandyApi.getApiUrl("test-endpoint")
+    preferences.set("extensions.shield-recipe-client.api_url", `${serverUrl}/api/v1`);
+    const endpoint = await NormandyApi.getApiUrl("test-endpoint");
     equal(endpoint, `${serverUrl}/test/`);
     ok(mockGet.calledWithExactly(`${serverUrl}/api/v1/`), "trailing slash was added");
     mockGet.reset();
@@ -110,8 +110,8 @@ add_task(withMockApiServer(async function test_getApiUrlSlashes(serverUrl, prefe
   // with slash
   {
     NormandyApi.clearIndexCache();
-    preferences.set("extensions.shield-recipe-client.api_url", `${serverUrl}/api/v1/`)
-    let endpoint = await NormandyApi.getApiUrl("test-endpoint")
+    preferences.set("extensions.shield-recipe-client.api_url", `${serverUrl}/api/v1/`);
+    const endpoint = await NormandyApi.getApiUrl("test-endpoint");
     equal(endpoint, `${serverUrl}/test/`);
     ok(mockGet.calledWithExactly(`${serverUrl}/api/v1/`), "existing trailing slash was preserved");
     mockGet.reset();


### PR DESCRIPTION
This fixes one of the lack of trailing slashes identified in #719. The other one, related to actions, was redesigned away in c4690415ac6ace78f2f3202cbfc161ac728c64cf.

@rnewman Can you review this as if it were a patch against mozilla-central? Eventually we will merge this into mozilla-central, and having reviews here makes that merge process easier.

Fixes #719.