### PR TITLE
Refactor Storage.jsm into a class.

### DIFF
--- a/docs/dev/driver.rst
+++ b/docs/dev/driver.rst
@@ -211,3 +211,8 @@ Storage
 
       :param key: Key to remove.
       :returns: A Promise that resolves when the value has been removed.
+
+   .. js:function:: clear()
+
+      Removes all stored values.
+      :returns: A Promise that resolves when the values have been removed.

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -128,14 +128,15 @@ this.NormandyDriver = function(sandboxManager) {
 
       // Wrapped methods that we expose to the sandbox. These are documented in
       // the driver spec in docs/dev/driver.rst.
+      const storageInterface = {};
       for (const method of ["getItem", "setItem", "removeItem", "clear"]) {
-        storage[method] = sandboxManager.wrapAsync(storage[method], {
+        storageInterface[method] = sandboxManager.wrapAsync(storage[method].bind(storage), {
           cloneArguments: true,
           cloneInto: true,
         });
       }
 
-      return sandboxManager.cloneInto(storage, {cloneFunctions: true});
+      return sandboxManager.cloneInto(storageInterface, {cloneFunctions: true});
     },
 
     setTimeout(cb, time) {

--- a/recipe-client-addon/lib/Storage.jsm
+++ b/recipe-client-addon/lib/Storage.jsm
@@ -6,142 +6,84 @@
 
 const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("resource://shield-recipe-client/lib/LogManager.jsm");
 
 XPCOMUtils.defineLazyModuleGetter(this, "JSONFile", "resource://gre/modules/JSONFile.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "OS", "resource://gre/modules/osfile.jsm");
 
 this.EXPORTED_SYMBOLS = ["Storage"];
 
-const log = LogManager.getLogger("storage");
-let storePromise;
+// Lazy-load JSON file that backs Storage instances.
+XPCOMUtils.defineLazyGetter(this, "lazyStore", async function() {
+  const path = OS.Path.join(OS.Constants.Path.profileDir, "shield-recipe-client.json");
+  const store = new JSONFile({path});
+  await store.load();
+  return store;
+});
 
-function loadStorage() {
-  if (storePromise === undefined) {
-    const path = OS.Path.join(OS.Constants.Path.profileDir, "shield-recipe-client.json");
-    const storage = new JSONFile({path});
-    storePromise = (async function() {
-      await storage.load();
-      return storage;
-    })();
+this.Storage = class {
+  constructor(prefix) {
+    this.prefix = prefix;
   }
-  return storePromise;
-}
-
-this.Storage = {
-  makeStorage(prefix, sandbox) {
-    if (!sandbox) {
-      throw new Error("No sandbox passed");
-    }
-
-    const storageInterface = {
-      /**
-       * Sets an item in the prefixed storage.
-       * @returns {Promise}
-       * @resolves With the stored value, or null.
-       * @rejects Javascript exception.
-       */
-      getItem(keySuffix) {
-        return new sandbox.Promise((resolve, reject) => {
-          loadStorage()
-            .then(store => {
-              const namespace = store.data[prefix] || {};
-              const value = namespace[keySuffix] || null;
-              resolve(Cu.cloneInto(value, sandbox));
-            })
-            .catch(err => {
-              log.error(err);
-              reject(new sandbox.Error());
-            });
-        });
-      },
-
-      /**
-       * Sets an item in the prefixed storage.
-       * @returns {Promise}
-       * @resolves When the operation is completed succesfully
-       * @rejects Javascript exception.
-       */
-      setItem(keySuffix, value) {
-        return new sandbox.Promise((resolve, reject) => {
-          loadStorage()
-            .then(store => {
-              if (!(prefix in store.data)) {
-                store.data[prefix] = {};
-              }
-              store.data[prefix][keySuffix] = Cu.cloneInto(value, {});
-              store.saveSoon();
-              resolve();
-            })
-            .catch(err => {
-              log.error(err);
-              reject(new sandbox.Error());
-            });
-        });
-      },
-
-      /**
-       * Removes a single item from the prefixed storage.
-       * @returns {Promise}
-       * @resolves When the operation is completed succesfully
-       * @rejects Javascript exception.
-       */
-      removeItem(keySuffix) {
-        return new sandbox.Promise((resolve, reject) => {
-          loadStorage()
-            .then(store => {
-              if (!(prefix in store.data)) {
-                return;
-              }
-              delete store.data[prefix][keySuffix];
-              store.saveSoon();
-              resolve();
-            })
-            .catch(err => {
-              log.error(err);
-              reject(new sandbox.Error());
-            });
-        });
-      },
-
-      /**
-       * Clears all storage for the prefix.
-       * @returns {Promise}
-       * @resolves When the operation is completed succesfully
-       * @rejects Javascript exception.
-       */
-      clear() {
-        return new sandbox.Promise((resolve, reject) => {
-          return loadStorage()
-            .then(store => {
-              store.data[prefix] = {};
-              store.saveSoon();
-              resolve();
-            })
-            .catch(err => {
-              log.error(err);
-              reject(new sandbox.Error());
-            });
-        });
-      },
-    };
-
-    return Cu.cloneInto(storageInterface, sandbox, {
-      cloneFunctions: true,
-    });
-  },
 
   /**
    * Clear ALL storage data and save to the disk.
    */
-  clearAllStorage() {
-    return loadStorage()
-      .then(store => {
-        store.data = {};
-        store.saveSoon();
-      })
-      .catch(err => {
-        log.error(err);
-      });
-  },
+  static async clearAllStorage() {
+    const store = await lazyStore;
+    store.data = {};
+    store.saveSoon();
+  }
+
+  /**
+   * Sets an item in the prefixed storage.
+   * @returns {Promise}
+   * @resolves With the stored value, or null.
+   * @rejects Javascript exception.
+   */
+  async getItem(name) {
+    const store = await lazyStore;
+    const namespace = store.data[this.prefix] || {};
+    return namespace[name] || null;
+  }
+
+  /**
+   * Sets an item in the prefixed storage.
+   * @returns {Promise}
+   * @resolves When the operation is completed succesfully
+   * @rejects Javascript exception.
+   */
+  async setItem(name, value) {
+    const store = await lazyStore;
+    if (!(this.prefix in store.data)) {
+      store.data[this.prefix] = {};
+    }
+    store.data[this.prefix][name] = value;
+    store.saveSoon();
+  }
+
+  /**
+   * Removes a single item from the prefixed storage.
+   * @returns {Promise}
+   * @resolves When the operation is completed succesfully
+   * @rejects Javascript exception.
+   */
+  async removeItem(name) {
+    const store = await lazyStore;
+    if (this.prefix in store.data) {
+      delete store.data[this.prefix][name];
+      store.saveSoon();
+    }
+  }
+
+  /**
+   * Clears all storage for the prefix.
+   * @returns {Promise}
+   * @resolves When the operation is completed succesfully
+   * @rejects Javascript exception.
+   */
+  async clear() {
+    const store = await lazyStore;
+    store.data[this.prefix] = {};
+    store.saveSoon();
+  }
 };

--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -56,10 +56,18 @@ add_task(withSandboxManager(Assert, async function testCreateStorage(sandboxMana
   await sandboxManager.evalInSandbox(`
     (async function sandboxTest() {
       const store = driver.createStorage("testprefix");
+      const otherStore = driver.createStorage("othertestprefix");
       await store.clear();
+      await otherStore.clear();
 
       await store.setItem("willremove", 7);
+      await otherStore.setItem("willremove", 4);
       is(await store.getItem("willremove"), 7, "createStorage stores sandbox values");
+      is(
+        await otherStore.getItem("willremove"),
+        4,
+        "values are not shared between createStorage stores",
+      );
 
       const deepValue = {"foo": ["bar", "baz"]};
       await store.setItem("deepValue", deepValue);
@@ -67,6 +75,8 @@ add_task(withSandboxManager(Assert, async function testCreateStorage(sandboxMana
 
       await store.removeItem("willremove");
       is(await store.getItem("willremove"), null, "createStorage removes items");
+
+      is('prefix' in store, false, "createStorage doesn't expose non-whitelist attributes");
     })();
   `);
 }));


### PR DESCRIPTION
This simplifies the implementation of Storage.jsm, as well as usage
outside of the sandbox, at the cost of adding work to the driver to
make the storage instance usable within the sandbox.
SandboxManager.wrapAsync handles the heavy lifting there.