### PR TITLE
Fix #764: Add PEER_APPROVAL_ENFORCED setting.

### DIFF
--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -255,6 +255,16 @@ in other Django projects.
    If :envvar:`DJANGO_USE_OIDC` is set to ``True``, this settings must be set to
    the URL that a user can visit to logout. It may be a relative URL.
 
+.. envvar:: DJANGO_PEER_APPROVAL_ENFORCED
+
+   :default: ``True``
+
+   If ``True``, approval requests for recipe changes can only be approved by a
+   different user than the one who created the request. If ``False``, approval
+   requests can be approved by the same user who created it.
+
+   This defaults to ``False`` for local developer instances.
+
 Gunicorn settings
 -----------------
 These settings control how Gunicorn starts, when the default command of the

--- a/recipe-server/client/control/components/RecipeForm.js
+++ b/recipe-server/client/control/components/RecipeForm.js
@@ -170,6 +170,7 @@ export class RecipeForm extends React.Component {
     return {
       isCloning: !!(route && route.isCloning),
       isUserRequester: requestAuthorID === currentUserID,
+      isPeerApprovalEnforced: document.documentElement.dataset.peerApprovalEnforced === 'true',
       isAlreadySaved: !!recipeId,
       isFormPristine: pristine,
       isApproved: !!recipeId && requestDetails && requestDetails.approved,

--- a/recipe-server/client/control/components/RecipeFormActions.js
+++ b/recipe-server/client/control/components/RecipeFormActions.js
@@ -60,6 +60,7 @@ export default class RecipeFormActions extends React.Component {
     isRejected: pt.bool,
     hasApprovalRequest: pt.bool,
     recipeId: pt.number,
+    isPeerApprovalEnforced: pt.bool,
   };
 
   constructor(props) {
@@ -93,6 +94,7 @@ export default class RecipeFormActions extends React.Component {
     isFormDisabled,
     hasApprovalRequest,
     recipeId,
+    isPeerApprovalEnforced,
   }) {
     return [
       // delete
@@ -151,7 +153,7 @@ export default class RecipeFormActions extends React.Component {
         useClick
         trigger={
           <FormButton
-            disabled={isUserRequester}
+            disabled={isUserRequester && isPeerApprovalEnforced}
             className="action-approve submit"
             label="Approve"
           />
@@ -185,7 +187,7 @@ export default class RecipeFormActions extends React.Component {
         useClick
         trigger={
           <FormButton
-            disabled={isUserRequester}
+            disabled={isUserRequester && isPeerApprovalEnforced}
             className="action-reject submit delete"
             label="Reject"
           />

--- a/recipe-server/client/control/tests/components/test_RecipeFormActions.js
+++ b/recipe-server/client/control/tests/components/test_RecipeFormActions.js
@@ -16,6 +16,7 @@ const propFactory = props => ({
   isRecipeApproved: false,
   isEnabled: false,
   recipeId: 12345,
+  isPeerApprovalEnforced: true,
   ...props,
 });
 
@@ -109,16 +110,35 @@ describe('<RecipeFormActions>', () => {
       expect(wrapper.find('.action-reject').length).toBe(0);
     });
 
-    it('should NOT be enabled when user is the approval requester', () => {
-      const wrapper = mount(<RecipeFormActions
-        {...propFactory({
-          ...displayCriteria,
-          isUserRequester: true,
-        })}
-      />);
-      expect(wrapper.find('.action-approve').prop('disabled')).toBe(true);
-      expect(wrapper.find('.action-reject').prop('disabled')).toBe(true);
-    });
+    it(
+      'should NOT be enabled when user is the approval requester and peer approval is enforced',
+      () => {
+        const wrapper = mount(<RecipeFormActions
+          {...propFactory({
+            ...displayCriteria,
+            isUserRequester: true,
+            isPeerApprovalEnforced: true,
+          })}
+        />);
+        expect(wrapper.find('.action-approve').prop('disabled')).toBe(true);
+        expect(wrapper.find('.action-reject').prop('disabled')).toBe(true);
+      },
+    );
+
+    it(
+      'should be enabled when user is the approval requester and peer approval is not enforced',
+      () => {
+        const wrapper = mount(<RecipeFormActions
+          {...propFactory({
+            ...displayCriteria,
+            isUserRequester: true,
+            isPeerApprovalEnforced: false,
+          })}
+        />);
+        expect(wrapper.find('.action-approve').prop('disabled')).toBe(false);
+        expect(wrapper.find('.action-reject').prop('disabled')).toBe(false);
+      },
+    );
 
     it('should display with proper criteria', () => {
       const wrapper = mount(<RecipeFormActions {...propFactory(displayCriteria)} />);

--- a/recipe-server/normandy/control/templates/control/admin/base.html
+++ b/recipe-server/normandy/control/templates/control/admin/base.html
@@ -8,6 +8,7 @@
   lang="{{ LANGUAGE_CODE|default:"en-us" }}"
   data-csrf="{{csrf_token}}"
   {% if request.user.is_authenticated %}data-current-user="{{ request.user.id }}"{% endif %}
+  data-peer-approval-enforced="{{ PEER_APPROVAL_ENFORCED|yesno:'true,false' }}"
 >
   <head>
     <title>SHIELD Control Panel</title>

--- a/recipe-server/normandy/control/views.py
+++ b/recipe-server/normandy/control/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.shortcuts import render, redirect
 
 
@@ -5,4 +6,6 @@ def IndexView(request):
     if not request.user.is_authenticated():
         return redirect('%s?next=%s' % ('/control/login/', request.path))
     else:
-        return render(request, 'control/index.html')
+        return render(request, 'control/index.html', {
+            'PEER_APPROVAL_ENFORCED': settings.PEER_APPROVAL_ENFORCED,
+        })

--- a/recipe-server/normandy/recipes/models.py
+++ b/recipe-server/normandy/recipes/models.py
@@ -3,6 +3,7 @@ import json
 import logging
 from collections import defaultdict
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models, transaction
@@ -24,6 +25,7 @@ from normandy.recipes.validators import validate_json
 
 INFO_REQUESTING_RECIPE_SIGNATURES = 'normandy.recipes.I001'
 INFO_CREATE_REVISION = 'normandy.recipes.I002'
+WARNING_BYPASSING_PEER_APPROVAL = 'normandy.recipes.W001'
 
 
 logger = logging.getLogger(__name__)
@@ -423,12 +425,25 @@ class ApprovalRequest(models.Model):
     class CannotActOnOwnRequest(Exception):
         pass
 
+    def verify_approver(self, approver):
+        if approver == self.creator:
+            if settings.PEER_APPROVAL_ENFORCED:
+                raise self.CannotActOnOwnRequest()
+            else:
+                logger.warning(
+                    f'Bypassing peer approver verification because it is disabled.',
+                    extra={
+                        'code': WARNING_BYPASSING_PEER_APPROVAL,
+                        'approval_id': self.id,
+                        'approver': approver
+                    },
+                )
+
     def approve(self, approver, comment):
         if self.approved is not None:
             raise self.NotActionable()
 
-        if approver == self.creator:
-            raise self.CannotActOnOwnRequest()
+        self.verify_approver(approver)
 
         self.approved = True
         self.approver = approver
@@ -443,8 +458,7 @@ class ApprovalRequest(models.Model):
         if self.approved is not None:
             raise self.NotActionable()
 
-        if approver == self.creator:
-            raise self.CannotActOnOwnRequest()
+        self.verify_approver(approver)
 
         self.approved = False
         self.approver = approver

--- a/recipe-server/normandy/recipes/models.py
+++ b/recipe-server/normandy/recipes/models.py
@@ -431,7 +431,7 @@ class ApprovalRequest(models.Model):
                 raise self.CannotActOnOwnRequest()
             else:
                 logger.warning(
-                    f'Bypassing peer approver verification because it is disabled.',
+                    'Bypassing peer approver verification because it is disabled.',
                     extra={
                         'code': WARNING_BYPASSING_PEER_APPROVAL,
                         'approval_id': self.id,

--- a/recipe-server/normandy/recipes/tests/api/v1/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v1/test_api.py
@@ -682,7 +682,9 @@ class TestApprovalFlow(object):
             actual_signature = fake_sign([data])[0]['signature']
             assert actual_signature == expected_signature
 
-    def test_full_approval_flow(self, api_client, mocked_autograph):
+    def test_full_approval_flow(self, settings, api_client, mocked_autograph):
+        settings.PEER_APPROVAL_ENFORCED = True
+
         action = ActionFactory()
         user1 = UserFactory(is_superuser=True)
         user2 = UserFactory(is_superuser=True)

--- a/recipe-server/normandy/recipes/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_api.py
@@ -546,8 +546,10 @@ class TestApprovalFlow(object):
             actual_signature = fake_sign([data])[0]['signature']
             assert actual_signature == expected_signature
 
-    def test_full_approval_flow(self, api_client, mocked_autograph):
+    def test_full_approval_flow(self, settings, api_client, mocked_autograph):
         # The `mocked_autograph` fixture is provided so that recipes can be signed
+
+        settings.PEER_APPROVAL_ENFORCED = True
 
         action = ActionFactory()
         user1 = UserFactory(is_superuser=True)

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -311,6 +311,11 @@ class Base(Core):
     NUM_PROXIES = values.IntegerValue(0)
     API_CACHE_TIME = values.IntegerValue(30)
     API_CACHE_ENABLED = values.BooleanValue(True)
+
+    # If true, approvals must come from two separate users. If false, the same
+    # user can approve their own request.
+    PEER_APPROVAL_ENFORCED = values.BooleanValue(True)
+
     # Autograph settings
     AUTOGRAPH_URL = values.Value()
     AUTOGRAPH_HAWK_ID = values.Value()
@@ -332,6 +337,7 @@ class Development(Base):
     EMAIL_BACKEND = values.Value('django.core.mail.backends.console.EmailBackend')
     SECURE_SSL_REDIRECT = values.Value(False)
     REQUIRE_RECIPE_AUTH = values.BooleanValue(False)
+    PEER_APPROVAL_ENFORCED = values.BooleanValue(False)
 
     API_CACHE_ENABLED = values.BooleanValue(False)
     API_CACHE_TIME = values.IntegerValue(0)


### PR DESCRIPTION
The setting controls whether the rule that an approver on an approval
request must not be the same user who created it is enforced or not.

Disabling this setting makes local development (as well as QA in
testing environments) more convenient.