### PR TITLE
Gracefully handle rendering null attributes in the Recipe list view.

### DIFF
--- a/recipe-server/client/control/components/RecipeList.js
+++ b/recipe-server/client/control/components/RecipeList.js
@@ -2,6 +2,7 @@ import React, { PropTypes as pt } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { Table, Thead, Th, Tr, Td } from 'reactable';
+import { isObject } from 'underscore';
 
 import makeApiRequest from 'control/api';
 
@@ -139,7 +140,7 @@ export class DisconnectedRecipeList extends React.Component {
             value={displayValue}
           />
         );
-      } else if (typeof displayValue === 'object') {
+      } else if (isObject(displayValue)) {
         displayValue = (
           <ul className="nested-list">
             {

--- a/recipe-server/client/control/tests/components/test_RecipeList.js
+++ b/recipe-server/client/control/tests/components/test_RecipeList.js
@@ -48,4 +48,14 @@ describe('<RecipeList>', () => {
 
     expect(wrapper.find(Tr).length).toBe(1);
   });
+
+  describe('renderTableCell', () => {
+    it('should not throw if the recipe attribute being displayed is null', () => {
+      const recipeList = shallow(<RecipeList {...propFactory()} />).instance();
+
+      const recipe = { foo: null };
+      const wrapper = () => shallow(recipeList.renderTableCell(recipe)({ slug: 'foo' }));
+      expect(wrapper).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
Staging is throwing the following error on the recipe listing: 

```
TypeError: r is null[Learn More] control.4b9008bfd6711a2221a7.js:59:27176
```

A snippet of the minified code around that line/column:

```js
"object"===("undefined"==typeof r?"undefined":s(r))&&(r=f["default"].createElement("ul",{className:"nested-list"},r.map(function(e,t){return f["default"].createElement("
```

Searching for `nested-list` is what landed me at `renderTableCell`, where I noticed the `typeof` check.

`typeof null === 'object'`, which means the check to see if a value is an object will pass for null attributes. However, calling .map on the value afterwards will throw if it is null. Instead, this fix uses the isObject helper from underscore.

This leaves the question of why we have null attributes in the first place, which may be related to this Sentry issue: https://sentry.prod.mozaws.net/operations/normandy-stage/issues/608396/