### PR TITLE
taskcluster: Use hg robustcheckout to clone mozilla-central.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -22,7 +22,7 @@ tasks:
     payload:
       env:
       maxRunTime: 300 # 5 minutes
-      image: mozilla/normandy-taskcluster:latest
+      image: mozilla/normandy-taskcluster:v2
       features:
         taskclusterProxy: true
       command:

--- a/addon-builder/Dockerfile
+++ b/addon-builder/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:zesty
 WORKDIR /root
+ENV CACHEBUST=2017-05-31
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-transport-https \
         curl \
@@ -25,3 +26,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN curl -O https://hg.mozilla.org/mozilla-central/raw-file/tip/python/mozboot/bin/bootstrap.py && \
     python2.7 bootstrap.py --no-interactive --application-choice=browser_artifact_mode
+
+RUN hg clone https://hg.mozilla.org/hgcustom/version-control-tools/
+
+COPY dot.hgrc ./.hgrc

--- a/addon-builder/README.md
+++ b/addon-builder/README.md
@@ -5,5 +5,5 @@ is not currently built in any automation, and must be manually updated if
 changes are made.
 
 It's primary purpose is to install the packages needed to succesfully build
-recipe-client-addon and mozilla-central. It's canonical location is
+recipe-client-addon and mozilla-central. It's canonical image name is
 mozilla/normandy-taskcluster.

--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -70,7 +70,7 @@ def main():
                 'deadline': fromNow('1 day'),
                 'expires': fromNow('365 days'),
                 'payload': {
-                    'image': 'mozilla/normandy-taskcluster:latest',
+                    'image': 'mozilla/normandy-taskcluster:v2',
                     'command': [
                         '/bin/bash',
                         '-c',

--- a/recipe-client-addon/bin/tc/build_test.sh
+++ b/recipe-client-addon/bin/tc/build_test.sh
@@ -6,7 +6,7 @@ export SHELL=$(which bash)
 
 # Creates mozilla-central
 echo 'Downloading mozilla-central...'
-hg clone http://hg.mozilla.org/mozilla-central/
+hg robustcheckout http://hg.mozilla.org/mozilla-central/ mozilla-central --branch default
 
 echo 'Pulling tags from mozilla/normandy repo on Github...'
 pushd normandy

--- a/recipe-client-addon/bin/tc/lint.sh
+++ b/recipe-client-addon/bin/tc/lint.sh
@@ -6,7 +6,7 @@ export SHELL=$(which bash)
 
 # Creates mozilla-central
 echo 'Downloading mozilla-central...'
-hg clone http://hg.mozilla.org/mozilla-central/
+hg robustcheckout http://hg.mozilla.org/mozilla-central/ mozilla-central --branch default
 
 echo 'Pulling tags from mozilla/normandy repo on Github...'
 pushd normandy


### PR DESCRIPTION
This should help with #757.

I've already pushed mozilla/normandy-taskcluster:v2.