### PR TITLE
recipe-client-addon: Fix test failure in PreferenceExperiments.

### DIFF
--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -367,6 +367,9 @@ add_task(withMockExperiments(withMockPreferences(async function(experiments, moc
 // stop should also support user pref experiments
 add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
   const stopObserver = sinon.stub(PreferenceExperiments, "stopObserver");
+  const hasObserver = sinon.stub(PreferenceExperiments, "hasObserver");
+  hasObserver.returns(true);
+
   mockPreferences.set("fake.preference", "experimentvalue", "user");
   experiments["test"] = experimentFactory({
     name: "test",
@@ -377,7 +380,6 @@ add_task(withMockExperiments(withMockPreferences(async function(experiments, moc
     previousPreferenceValue: "oldvalue",
     preferenceBranchType: "user",
   });
-  PreferenceExperiments.startObserver("test", "fake.preference", "experimentvalue");
 
   await PreferenceExperiments.stop("test");
   ok(stopObserver.calledWith("test"), "stop removed an observer");
@@ -389,6 +391,7 @@ add_task(withMockExperiments(withMockPreferences(async function(experiments, moc
   );
 
   stopObserver.restore();
+  hasObserver.restore();
 })));
 
 // stop should not call stopObserver if there is no observer registered.


### PR DESCRIPTION
Fixes #789.

I tried to bisect this, and it just tracked it down to #685 (Merge master into preference-experiments branch).

@Osmose I'm feeling a lot of déjà vu fixing this. Do you think this was messed up in the merge?