### PR TITLE
Fix bug 1368977: Remove es2015 and stage-0 preset from Babel.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,11 @@ dependencies:
     # CI requirements.
     - pip install -r ./ci/circleci/requirements/pip.txt
     - pip install -r ./ci/circleci/requirements/default.txt -c ./ci/circleci/requirements/constraints.txt
+    # Install latest firefox, and remove firefox-mozilla-build, which diverts
+    # the Firefox binary to an old version.
+    - sudo apt-get update
+    - sudo apt-get install firefox
+    - sudo apt-get remove firefox-mozilla-build
   override:
     - ./ci/circleci/bin/runner.sh dependencies
 

--- a/lints/Dockerfile
+++ b/lints/Dockerfile
@@ -5,11 +5,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl apt-transport-https git
 
 # Install node from NodeSource
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo 'deb https://deb.nodesource.com/node_6.x jessie main' > /etc/apt/sources.list.d/nodesource.list && \
-    echo 'deb-src https://deb.nodesource.com/node_6.x jessie main' >> /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && apt-get install -y nodejs
-RUN npm install -g npm@4.x.x
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+	apt-get update && apt-get install -y nodejs && \
+	npm install npm@latest -g
 
 COPY ./requirements /app/requirements
 COPY ./package.json /app/package.json

--- a/lints/Dockerfile
+++ b/lints/Dockerfile
@@ -1,13 +1,26 @@
 FROM python:3.6.0-slim
 WORKDIR /app
+
+# Create app user and chown directories it needs access to
 RUN groupadd --gid 1001 app && useradd -g app --uid 1001 --shell /usr/sbin/nologin app
+RUN mkdir -p /home/app
+RUN chown -R app /app && \
+    chown -R app /usr/local && \
+    chown -R app /home/app
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl apt-transport-https git
 
 # Install node from NodeSource
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
-	apt-get update && apt-get install -y nodejs && \
+	apt-get update && \
+    apt-get install -y nodejs && \
 	npm install npm@latest -g
+
+# Switch to app user BEFORE running npm install to avoid issue with Docker on
+# CircleCI (see https://github.com/npm/npm/issues/16766 and
+# https://github.com/npm/npm/issues/16892).
+USER app
 
 COPY ./requirements /app/requirements
 COPY ./package.json /app/package.json
@@ -17,6 +30,5 @@ RUN pip install -U 'pip>=8' && \
 
 COPY . /app
 ENV PATH="/app/node_modules/.bin:$PATH"
-USER app
 
 CMD ["/app/bin/default_command"]

--- a/lints/package.json
+++ b/lints/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "babel-polyfill": "6.13.0",
-    "babel-preset-stage-0": "6.5.0",
     "babel-runtime": "6.11.6",
     "classnames": "2.2.5",
     "cssmin": "0.4.3",
@@ -34,17 +33,23 @@
     "redux-form": "6.1.0",
     "redux-thunk": "2.1.0",
     "sha.js": "2.4.5",
-    "uglifyjs": "2.4.10",
     "underscore": "1.8.3",
     "underscore.string": "3.3.4"
   },
   "devDependencies": {
-    "babel-core": "6.14.0",
+    "babel-core": "6.24.1",
     "babel-eslint": "7.2.3",
     "babel-loader": "6.2.5",
+    "babel-plugin-syntax-async-functions": "6.13.0",
+    "babel-plugin-transform-class-properties": "6.24.1",
+    "babel-plugin-transform-es2015-destructuring": "6.23.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+    "babel-plugin-transform-export-extensions": "6.22.0",
+    "babel-plugin-transform-function-bind": "6.22.0",
+    "babel-plugin-transform-object-rest-spread": "6.23.0",
     "babel-plugin-transform-runtime": "6.15.0",
-    "babel-preset-es2015": "6.14.0",
     "babel-preset-react": "6.11.1",
+    "babili-webpack-plugin": "^0.1.1",
     "css-loader": "0.24.0",
     "enzyme": "2.4.1",
     "eslint": "3.19.0",
@@ -86,6 +91,7 @@
     "stylelint-config-standard": "15.0.0",
     "stylelint-order": "0.2.2",
     "webpack": "1.13.2",
+    "webpack-async-await": "1.0.4",
     "webpack-bundle-tracker": "0.0.93",
     "yargs": "4.8.1"
   }

--- a/recipe-server/.babelrc
+++ b/recipe-server/.babelrc
@@ -1,3 +1,12 @@
 {
-  "presets": ["react", "es2015", "stage-0"]
+  "presets": ["react"],
+  "plugins": [
+    "transform-object-rest-spread",
+    "transform-es2015-modules-commonjs",
+    "transform-export-extensions",
+    "transform-function-bind",
+    "syntax-async-functions",
+    "transform-es2015-destructuring",
+    "transform-class-properties"
+  ]
 }

--- a/recipe-server/karma.conf.js
+++ b/recipe-server/karma.conf.js
@@ -27,7 +27,10 @@ module.exports = function (config) {
 
     // The first config is for the control interface. It is only coincidence
     // that this config works for the action code/tests as well.
-    webpack: Object.assign(WEBPACK_CONFIG[0], { devtool: '#cheap-module-eval-source-map' }),
+    webpack: Object.assign(WEBPACK_CONFIG[0], {
+      entry: undefined,
+      devtool: undefined,
+    }),
 
     webpackMiddleware: {
       stats: 'errors-only', // Only show errors during webpack builds.

--- a/recipe-server/package.json
+++ b/recipe-server/package.json
@@ -17,7 +17,6 @@
   "license": "MPL-2.0",
   "dependencies": {
     "babel-polyfill": "6.13.0",
-    "babel-preset-stage-0": "6.5.0",
     "babel-runtime": "6.11.6",
     "classnames": "2.2.5",
     "cssmin": "0.4.3",
@@ -43,17 +42,23 @@
     "redux-form": "6.5.0",
     "redux-thunk": "2.1.0",
     "sha.js": "2.4.5",
-    "uglifyjs": "2.4.10",
     "underscore": "1.8.3",
     "underscore.string": "3.3.4"
   },
   "devDependencies": {
-    "babel-core": "6.14.0",
+    "babel-core": "6.24.1",
     "babel-eslint": "7.2.3",
     "babel-loader": "6.2.5",
+    "babel-plugin-syntax-async-functions": "6.13.0",
+    "babel-plugin-transform-class-properties": "6.24.1",
+    "babel-plugin-transform-es2015-destructuring": "6.23.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+    "babel-plugin-transform-export-extensions": "6.22.0",
+    "babel-plugin-transform-function-bind": "6.22.0",
+    "babel-plugin-transform-object-rest-spread": "6.23.0",
     "babel-plugin-transform-runtime": "6.15.0",
-    "babel-preset-es2015": "6.14.0",
     "babel-preset-react": "6.11.1",
+    "babili-webpack-plugin": "^0.1.1",
     "css-loader": "0.24.0",
     "enzyme": "2.4.1",
     "eslint": "3.19.0",
@@ -93,6 +98,7 @@
     "stylelint-config-standard": "15.0.0",
     "stylelint-order": "0.2.2",
     "webpack": "1.13.2",
+    "webpack-async-await": "1.0.4",
     "webpack-bundle-tracker": "0.0.93",
     "yargs": "5.0.0"
   }


### PR DESCRIPTION
The minimum Firefox version that we target for both the system add-on
and the website is Firefox 52, which includes support for most es2015
features, including native async/await syntax. This means we can safely
switch to using those features without transpiling them via Babel.

This removes both the es2015 and stage-0 presets from Babel, and
includes a few individual plugins that we still need support for.
This also adds a new Webpack plugin to enable it to parse async/await
syntax while resolving modules.

UglifyJS can't parse async/await syntax, even on the harmony branch, so
this switches to using Babili for minification. We use the webpack
plugin instead of including it in the Babel config so that code inside
node_modules, which is ignored by babel-loader, also gets minified.

This change has implications to our CDN request size, so we should be prepared to revert it if the deploy makes us push the average below the minimum level.