### PR TITLE
recipe-server: Cachebust the x5u url for recipe signatures.

### DIFF
--- a/recipe-server/normandy/base/tests/__init__.py
+++ b/recipe-server/normandy/base/tests/__init__.py
@@ -23,7 +23,7 @@ class Whatever(object):
 
     @classmethod
     def contains(cls, *values):
-        name_values = ''.join(str(v) for v in values)
+        name_values = ', '.join(str(v) for v in values)
         return cls(lambda s: all(value in s for value in values), name=f'contains {name_values}')
 
     @classmethod

--- a/recipe-server/normandy/base/tests/__init__.py
+++ b/recipe-server/normandy/base/tests/__init__.py
@@ -30,7 +30,7 @@ class Whatever(object):
     def iso8601(cls):
         def is_iso8601_date(s):
             # Will throw is it does not match
-            d = datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%fZ')
+            datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%fZ')
             return True
 
         return cls(is_iso8601_date, name='datetime')

--- a/recipe-server/normandy/base/tests/__init__.py
+++ b/recipe-server/normandy/base/tests/__init__.py
@@ -1,4 +1,6 @@
 import os
+import re
+from datetime import datetime
 
 from django.contrib.auth.models import User
 
@@ -7,19 +9,41 @@ import pytest
 
 
 class Whatever(object):
-    def __init__(self, test=lambda x: True):
+    def __init__(self, test=lambda x: True, name='unnamed'):
         self.test = test
+        self.name = name
+
+    @classmethod
+    def startswith(cls, prefix):
+        return cls(lambda s: s.startswith(prefix), name=f'startswith {prefix}')
 
     @classmethod
     def endswith(cls, suffix):
-        return cls(lambda s: s.endswith(suffix))
+        return cls(lambda s: s.endswith(suffix), name=f'endswith {suffix}')
 
     @classmethod
     def contains(cls, *values):
-        return cls(lambda s: all(value in s for value in values))
+        name_values = ''.join(str(v) for v in values)
+        return cls(lambda s: all(value in s for value in values), name=f'contains {name_values}')
+
+    @classmethod
+    def iso8601(cls):
+        def is_iso8601_date(s):
+            # Will throw is it does not match
+            d = datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%fZ')
+            return True
+
+        return cls(is_iso8601_date, name='datetime')
+
+    @classmethod
+    def regex(cls, regex):
+        return cls(lambda s: re.match(regex, s), name=f'regex {regex}')
 
     def __eq__(self, other):
         return self.test(other)
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} named "{self.name}">'
 
 
 class FuzzyUnicode(fuzzy.FuzzyText):

--- a/recipe-server/normandy/recipes/api/v1/serializers.py
+++ b/recipe-server/normandy/recipes/api/v1/serializers.py
@@ -221,10 +221,12 @@ class SignatureSerializer(serializers.ModelSerializer):
         if x5u is None:
             return None
 
-        # Add cachebust parameter to x5u URL with the current time
+        # Add cachebust parameter to x5u URL that changes once per hour.
         url_parts = list(urlparse.urlparse(x5u))
-        query = dict(urlparse.parse_qsl(url_parts[4]))
-        query['cachebust'] = str(int(time.time()))
+        query = urlparse.parse_qs(url_parts[4])
+        cachebust = int(time.time())
+        cachebust -= cachebust % 3600
+        query['cachebust'] = cachebust
         url_parts[4] = urlencode(query)
         return urlparse.urlunparse(url_parts)
 

--- a/recipe-server/normandy/recipes/tests/api/v1/test_serializers.py
+++ b/recipe-server/normandy/recipes/tests/api/v1/test_serializers.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import re
+import urllib.parse as urlparse
 
 import pytest
 from rest_framework import serializers
@@ -243,4 +243,9 @@ class TestSignatureSerializer:
     def test_it_cachebusts_x5u(self):
         signature = SignatureFactory()
         serializer = SignatureSerializer(instance=signature)
-        assert 'cachebust=' in serializer.data['x5u']
+
+        url_parts = list(urlparse.urlparse(serializer.data['x5u']))
+        query = urlparse.parse_qs(url_parts[4])
+        assert 'cachebust' in query
+        assert len(query['cachebust']) == 1
+        assert re.match('^\d+$', query['cachebust'][0])

--- a/recipe-server/normandy/recipes/tests/api/v1/test_serializers.py
+++ b/recipe-server/normandy/recipes/tests/api/v1/test_serializers.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+import re
+
 import pytest
 from rest_framework import serializers
 
@@ -10,12 +13,14 @@ from normandy.recipes.tests import (
     CountryFactory,
     LocaleFactory,
     RecipeFactory,
+    SignatureFactory,
 )
 from normandy.recipes.api.v1.serializers import (
     ActionSerializer,
     MinimalRecipeSerializer,
     RecipeSerializer,
     SignedRecipeSerializer,
+    SignatureSerializer,
 )
 
 
@@ -220,3 +225,22 @@ class TestSignedRecipeSerializer:
                 'is_approved': False,
             }
         }
+
+
+@pytest.mark.django_db()
+class TestSignatureSerializer:
+    def test_it_works(self):
+        signature = SignatureFactory()
+        serializer = SignatureSerializer(instance=signature)
+
+        assert serializer.data == {
+            'signature': Whatever.regex(r'[a-f0-9]{40}'),
+            'x5u': Whatever.startswith(signature.x5u),
+            'timestamp': Whatever.iso8601(),
+            'public_key': Whatever.regex(r'[a-zA-Z0-9/+]{160}')
+        }
+
+    def test_it_cachebusts_x5u(self):
+        signature = SignatureFactory()
+        serializer = SignatureSerializer(instance=signature)
+        assert 'cachebust=' in serializer.data['x5u']


### PR DESCRIPTION
We are seeing weird caching issues on this URL, and this should help fix them.

I also improved test coverage for `SignatureSerializer` made our `Whatever` test helper a little nicer to use.