### PR TITLE
recipe-client-addon: Remove unnecessary globals definition for ESLint, since eslint-plugin-mozilla is working correctly now.

### DIFF
--- a/recipe-client-addon/test/browser/.eslintrc.js
+++ b/recipe-client-addon/test/browser/.eslintrc.js
@@ -8,10 +8,4 @@ module.exports = {
   plugins: [
     "mozilla"
   ],
-
-  globals: {
-    // Bug 1366720 - SimpleTest isn't being exported correctly, so list
-    // it here for now.
-    "SimpleTest": false
-  }
 };


### PR DESCRIPTION
This was fixed in 0.3.2, which you already have.