### PR TITLE
addon-builder: Cachebust Dockerfile to pick up Rust 1.18.0

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -22,7 +22,7 @@ tasks:
     payload:
       env:
       maxRunTime: 300 # 5 minutes
-      image: mozilla/normandy-taskcluster:v2
+      image: mozilla/normandy-taskcluster:2017-06-12
       features:
         taskclusterProxy: true
       command:

--- a/addon-builder/Dockerfile
+++ b/addon-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:zesty
 WORKDIR /root
-ENV CACHEBUST=2017-05-31
+ENV CACHEBUST=2017-06-12
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-transport-https \
         curl \

--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -70,7 +70,7 @@ def main():
                 'deadline': fromNow('1 day'),
                 'expires': fromNow('365 days'),
                 'payload': {
-                    'image': 'mozilla/normandy-taskcluster:v2',
+                    'image': 'mozilla/normandy-taskcluster:2017-06-12',
                     'command': [
                         '/bin/bash',
                         '-c',


### PR DESCRIPTION
This picks up changes to m-c's bootstrap.py that install Rust 1.18. Previously we had Rust 1.17. We are supposed to be able to deal with this without a cachebust/update, but that didn't work for some reason (See the error in #806).

Fixes #806