### PR TITLE
Backport changes from mozilla-central

### DIFF
--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -255,7 +255,8 @@ this.PreferenceExperiments = {
       preferenceName,
       observer(newValue) {
         if (newValue !== preferenceValue) {
-          PreferenceExperiments.stop(experimentName, false);
+          PreferenceExperiments.stop(experimentName, false)
+                               .catch(Cu.reportError);
         }
       },
     };

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -70,7 +70,7 @@ add_task(withMockNormandyApi(async function testClientClassificationCache() {
 
   await SpecialPowers.pushPrefEnv({set: [
     ["extensions.shield-recipe-client.api_url",
-     "https://example.com/selfsupport-dummy"],
+      "https://example.com/selfsupport-dummy"],
   ]});
 
   // When the experiment pref is false, eagerly call getClientClassification.

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -11,7 +11,7 @@ Cu.import("resource://shield-recipe-client/lib/Utils.jsm", this);
 // docs: http://sinonjs.org/docs/
 const loader = Cc["@mozilla.org/moz/jssubscript-loader;1"].getService(Ci.mozIJSSubScriptLoader);
 /* global sinon */
-loader.loadSubScript("resource://testing-common/sinon-1.16.1.js");
+loader.loadSubScript("resource://testing-common/sinon-2.3.2.js");
 
 // Make sinon assertions fail in a way that mochitest understands
 sinon.assert.fail = function(message) {
@@ -21,8 +21,6 @@ sinon.assert.fail = function(message) {
 registerCleanupFunction(async function() {
   // Cleanup window or the test runner will throw an error
   delete window.sinon;
-  delete window.setImmediate;
-  delete window.clearImmediate;
 });
 
 

--- a/recipe-client-addon/test/unit/head_xpc.js
+++ b/recipe-client-addon/test/unit/head_xpc.js
@@ -20,13 +20,22 @@ if (!extensionDir.exists()) {
 }
 Components.manager.addBootstrappedManifestLocation(extensionDir);
 
-// Load Sinon for mocking/stubbing during tests.
-// Sinon assumes that setTimeout and friends are available, and looks for a
-// global object named self during initialization.
+// ================================================
+// Load mocking/stubbing library, sinon
+// docs: http://sinonjs.org/releases/v2.3.2/
 Cu.import("resource://gre/modules/Timer.jsm");
-const self = {}; // eslint-disable-line no-unused-vars
-
-/* global sinon */
-/* exported sinon */
-const loader = Cc["@mozilla.org/moz/jssubscript-loader;1"].getService(Ci.mozIJSSubScriptLoader);
-loader.loadSubScript("resource://testing-common/sinon-1.16.1.js");
+const {Loader} = Cu.import("resource://gre/modules/commonjs/toolkit/loader.js", {});
+const loader = new Loader.Loader({
+  paths: {
+    "": "resource://testing-common/",
+  },
+  globals: {
+    setTimeout,
+    setInterval,
+    clearTimeout,
+    clearInterval,
+  },
+});
+const require = Loader.Require(loader, {id: ""});
+const sinon = require("sinon-2.3.2");
+// ================================================

--- a/recipe-client-addon/test/unit/head_xpc.js
+++ b/recipe-client-addon/test/unit/head_xpc.js
@@ -23,6 +23,7 @@ Components.manager.addBootstrappedManifestLocation(extensionDir);
 // ================================================
 // Load mocking/stubbing library, sinon
 // docs: http://sinonjs.org/releases/v2.3.2/
+/* exported sinon */
 Cu.import("resource://gre/modules/Timer.jsm");
 const {Loader} = Cu.import("resource://gre/modules/commonjs/toolkit/loader.js", {});
 const loader = new Loader.Loader({

--- a/recipe-client-addon/test/unit/test_NormandyApi.js
+++ b/recipe-client-addon/test/unit/test_NormandyApi.js
@@ -1,3 +1,4 @@
+/* globals sinon */
 "use strict";
 
 Cu.import("resource://gre/modules/Services.jsm");


### PR DESCRIPTION
This backports [bug 1370652](https://bugzilla.mozilla.org/show_bug.cgi?id=1370652) and [bug 1369855](https://bugzilla.mozilla.org/show_bug.cgi?id=1369855) from mozilla-central.

This includes an upgrade to Sinon, so it should fix #809.

@Osmose rs?