### PR TITLE
Fix #811: Do not execute action hooks if fetching recipes fails.

### DIFF
--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -105,6 +105,16 @@ this.RecipeRunner = {
       await ClientEnvironment.getClientClassification();
     }
 
+    // Fetch recipes before execution in case we fail and exit early.
+    let recipes;
+    try {
+      recipes = await NormandyApi.fetchRecipes({enabled: true});
+    } catch (e) {
+      const apiUrl = prefs.getCharPref("api_url");
+      log.error(`Could not fetch recipes from ${apiUrl}: "${e}"`);
+      return;
+    }
+
     const actionSandboxManagers = await this.loadActionSandboxManagers();
     Object.values(actionSandboxManagers).forEach(manager => manager.addHold("recipeRunner"));
 
@@ -118,16 +128,6 @@ this.RecipeRunner = {
         log.error(`Could not run pre-execution hook for ${actionName}:`, err.message);
         manager.disabled = true;
       }
-    }
-
-    // Fetch recipes from the API
-    let recipes;
-    try {
-      recipes = await NormandyApi.fetchRecipes({enabled: true});
-    } catch (e) {
-      const apiUrl = prefs.getCharPref("api_url");
-      log.error(`Could not fetch recipes from ${apiUrl}: "${e}"`);
-      return;
     }
 
     // Evaluate recipe filters

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -51,21 +51,26 @@ this.withMockNormandyApi = function(testFunction) {
   return async function inner(...args) {
     const mockApi = {actions: [], recipes: [], implementations: {}};
 
-    sinon.stub(NormandyApi, "fetchActions", async () => mockApi.actions);
-    sinon.stub(NormandyApi, "fetchRecipes", async () => mockApi.recipes);
-    sinon.stub(NormandyApi, "fetchImplementation", async action => {
-      const impl = mockApi.implementations[action.name];
-      if (!impl) {
-        throw new Error("Missing");
+    // Use callsFake instead of resolves so that the current values in mockApi are used.
+    mockApi.fetchActions = sinon.stub(NormandyApi, "fetchActions").callsFake(async () => mockApi.actions);
+    mockApi.fetchRecipes = sinon.stub(NormandyApi, "fetchRecipes").callsFake(async () => mockApi.recipes);
+    mockApi.fetchImplementation = sinon.stub(NormandyApi, "fetchImplementation").callsFake(
+      async action => {
+        const impl = mockApi.implementations[action.name];
+        if (!impl) {
+          throw new Error("Missing");
+        }
+        return impl;
       }
-      return impl;
-    });
+    );
 
-    await testFunction(mockApi, ...args);
-
-    NormandyApi.fetchActions.restore();
-    NormandyApi.fetchRecipes.restore();
-    NormandyApi.fetchImplementation.restore();
+    try {
+      await testFunction(mockApi, ...args);
+    } finally {
+      mockApi.fetchActions.restore();
+      mockApi.fetchRecipes.restore();
+      mockApi.fetchImplementation.restore();
+    }
   };
 };
 


### PR DESCRIPTION
This explicitly prevents side-effects from running pre-execution hooks
and then returning before we run the post-execution hooks.

After thinking a bit more, I'm more confident this is the behavior we want. If we want users to be unenrolled from an experiment when a recipe fetch goes wrong, we should be expiring them after not hearing from the server instead of running pre- and post-execution hooks even when recipe fetches fail.

Also, it turns out the sinon upgrade changed how you create a stub with a fake function. The old form still works, but a spy is returned instead of a stub, which breaks some things.