### PR TITLE
Fix bug 1368703: Validate preference experiment slugs.

### DIFF
--- a/recipe-server/client/actions/preference-experiment/package.json
+++ b/recipe-server/client/actions/preference-experiment/package.json
@@ -19,7 +19,7 @@
                 "slug": {
                     "description": "Unique identifier for this experiment",
                     "type": "string",
-                    "default": ""
+                    "pattern": "^[A-Za-z0-9\\-_]+$"
                 },
                 "experimentDocumentUrl": {
                     "description": "URL of a document describing the experiment",
@@ -59,7 +59,7 @@
                             "slug": {
                                 "description": "Unique identifier for this branch of the experiment",
                                 "type": "string",
-                                "default": ""
+                                "pattern": "^[A-Za-z0-9\\-_]+$"
                             },
                             "value": {
                                 "description": "Value to set the preference to for this branch",

--- a/recipe-server/package.json
+++ b/recipe-server/package.json
@@ -46,6 +46,7 @@
     "underscore.string": "3.3.4"
   },
   "devDependencies": {
+    "ajv": "5.2.0",
     "babel-core": "6.24.1",
     "babel-eslint": "7.2.3",
     "babel-loader": "6.2.5",

--- a/recipe-server/webpack.config.js
+++ b/recipe-server/webpack.config.js
@@ -40,11 +40,16 @@ var plugins = [
 if (production) {
   plugins = plugins.concat([
     new webpack.optimize.DedupePlugin(),
-    new BabiliPlugin({}, {
-      // Use our own pinned versions of babel and babili in case deduplication fails
-      babel: babelCore,
-      babili: babiliPreset,
-    }),
+    new BabiliPlugin(
+      { // babiliOptions
+        evaluate: false, // mozilla/normandy#827
+      },
+      { // overrides
+        // Use our own pinned versions of babel and babili in case deduplication fails
+        babel: babelCore,
+        babili: babiliPreset,
+      }
+    ),
   ]);
 } else {
   plugins = plugins.concat([


### PR DESCRIPTION
If we wanted to auto-trim slugs, we'd want to do it server-side to
avoid issues with other clients submitting non-compliant slugs. We don't
yet have a good solution for server-side transformations on a per-action
basis. To avoid addressing that large issue, for now we can just validate
the slugs going forward. Long-term we'll want to address per-action
customization in a better way.