### PR TITLE
Fix channels, locales on recipe form

### DIFF
--- a/recipe-server/client/control/components/Fields.js
+++ b/recipe-server/client/control/components/Fields.js
@@ -140,10 +140,8 @@ export class CheckboxGroup extends React.Component {
    * @param  {Event} onChange event object
    */
   handleChange({ target }) {
-    const {
-      value = [],
-      onChange,
-    } = this.props;
+    const { onChange } = this.props;
+    const value = this.props.value || [];
 
     let newValue = [];
 
@@ -204,10 +202,10 @@ export function FileInput({
     value: omitValue, // eslint-disable-line no-unused-vars
     onChange,
     onBlur,
-    ...inputProps,
+    ...inputProps
   },
   meta: omitMeta, // eslint-disable-line no-unused-vars
-  ...props,
+  ...props
 }) {
   return (
     <input

--- a/recipe-server/client/control/components/MultiPicker.js
+++ b/recipe-server/client/control/components/MultiPicker.js
@@ -236,12 +236,10 @@ export default class MultiPicker extends React.Component {
    * @param  {Array<string>}  selection   Array of selected values to apply
    */
   handleApplySelection(selection = []) {
-    const {
-      value = [],
-    } = this.props;
+    const val = this.props.value || [];
 
     // Get a set of unique selected values from existing values and those coming in
-    const uniqueSelections = new Set(value.concat(selection));
+    const uniqueSelections = new Set(val.concat(selection));
 
     // Convert the Set of unique values into an array.
     const newEnabled = Array.from(uniqueSelections);


### PR DESCRIPTION
- Fixes bug in `MultiPicker` and `CheckboxGroup` components where an empty/null `value` prop would submit erroneous data when contacting the API. (This fixes the bug that Emily brought to our attention at the SF All Hands)
- Fixes some lint issues, apparently

@Osmose This PR exists in case we need it - if we scrap it in favor of the new UI stuff, that's totally fine.