### PR TITLE
New breadcrumbs

### DIFF
--- a/recipe-server/client/control_new/components/App.js
+++ b/recipe-server/client/control_new/components/App.js
@@ -1,7 +1,9 @@
-import { Breadcrumb, Layout, LocaleProvider } from 'antd';
+import { Layout, LocaleProvider } from 'antd';
 import enUS from 'antd/lib/locale-provider/en_US';
 import PropTypes from 'prop-types';
 import React from 'react';
+
+import NavigationCrumbs from 'control_new/components/common/NavigationCrumbs';
 
 const { Content, Header, Sider } = Layout;
 
@@ -21,9 +23,7 @@ export default function App({ children }) {
           </Sider>
 
           <Layout className="content-wrapper">
-            <Breadcrumb>
-              <Breadcrumb.Item>Home</Breadcrumb.Item>
-            </Breadcrumb>
+            <NavigationCrumbs />
 
             <Content className="content">
               {children}

--- a/recipe-server/client/control_new/components/common/NavigationCrumbs.js
+++ b/recipe-server/client/control_new/components/common/NavigationCrumbs.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import autobind from 'autobind-decorator';
+import { connect } from 'react-redux';
+import { Breadcrumb } from 'antd';
+import { Link } from 'redux-little-router';
+
+@autobind
+export class NavigationCrumbs extends React.Component {
+  static propTypes = {
+    router: PropTypes.object.isRequired,
+  };
+  state = { breadcrumbs: [] };
+
+  componentDidMount() {
+    this.updateBreadcrumbs(this.props.router);
+  }
+
+  componentWillReceiveProps({ router }) {
+    this.updateBreadcrumbs(router || this.props.router);
+  }
+
+  // Given a router, gathers the steps leading down to the current route, to be
+  // displayed as breadcrumbs.
+  updateBreadcrumbs(router) {
+    const { result, pathname } = router;
+
+    const crumbs = [];
+    let currentRoute = result;
+
+    // Walk up route tree until there are no more `parent`s.
+    while (currentRoute) {
+      crumbs.push({
+        name: currentRoute.crumb,
+        link: currentRoute.route || pathname,
+      });
+
+      currentRoute = currentRoute.parent;
+    }
+
+    this.setState({
+      breadcrumbs: crumbs.reverse(),
+    });
+  }
+
+  render() {
+    const { breadcrumbs } = this.state;
+
+    return (
+      <Breadcrumb>
+        {breadcrumbs.map((crumb, idx) =>
+          <Breadcrumb.Item key={idx}>
+            <Link href={crumb.link}>{ crumb.name }</Link>
+          </Breadcrumb.Item>
+        )}
+      </Breadcrumb>
+    );
+  }
+}
+
+export default connect(
+  state => ({
+    router: state.router,
+  }),
+  null,
+)(NavigationCrumbs);

--- a/recipe-server/client/control_new/components/common/NavigationCrumbs.js
+++ b/recipe-server/client/control_new/components/common/NavigationCrumbs.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import autobind from 'autobind-decorator';
-import { connect } from 'react-redux';
 import { Breadcrumb } from 'antd';
+import autobind from 'autobind-decorator';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'redux-little-router';
 
 @autobind
@@ -13,17 +13,32 @@ export class NavigationCrumbs extends React.Component {
   state = { breadcrumbs: [] };
 
   componentDidMount() {
-    this.updateBreadcrumbs(this.props.router);
+    this.gatherBreadcrumbs(this.props.router);
   }
 
   componentWillReceiveProps({ router }) {
-    this.updateBreadcrumbs(router || this.props.router);
+    this.gatherBreadcrumbs(router || this.props.router);
   }
 
-  // Given a router, gathers the steps leading down to the current route, to be
-  // displayed as breadcrumbs.
-  updateBreadcrumbs(router) {
-    const { result, pathname } = router;
+  // Given a route (e.g. `/hello/:id/there`), finds params that need to be
+  // populated (e.g. `:id`) and replaces the values in order to link correctly
+  // when displayed as a Breadcrumb.
+  replaceUrlVariables(url, params) {
+    let newUrl = url;
+    const urlParams = url.match(/:[a-z]+/gi);
+
+    if (urlParams) {
+      urlParams.forEach(piece => {
+        // Replace the found identifier with whatever the actual param is set to
+        newUrl = newUrl.replace(piece, params[piece.slice(1)]);
+      });
+    }
+
+    return newUrl;
+  }
+
+  gatherBreadcrumbs(router) {
+    const { result, pathname, params } = router;
 
     const crumbs = [];
     let currentRoute = result;
@@ -32,7 +47,7 @@ export class NavigationCrumbs extends React.Component {
     while (currentRoute) {
       crumbs.push({
         name: currentRoute.crumb,
-        link: currentRoute.route || pathname,
+        link: this.replaceUrlVariables(currentRoute.route || pathname, params),
       });
 
       currentRoute = currentRoute.parent;

--- a/recipe-server/client/control_new/components/common/NavigationCrumbs.js
+++ b/recipe-server/client/control_new/components/common/NavigationCrumbs.js
@@ -62,5 +62,4 @@ export default connect(
   state => ({
     router: state.router,
   }),
-  null,
 )(NavigationCrumbs);

--- a/recipe-server/client/control_new/routes.js
+++ b/recipe-server/client/control_new/routes.js
@@ -6,31 +6,43 @@ import App from 'control_new/components/App';
 import Dummy from 'control_new/components/pages/Dummy';
 import Gateway from 'control_new/components/pages/Gateway';
 
+const routes = {
+  '/': {
+    component: Gateway,
+    crumb: 'Home',
+    '/recipes': {
+      component: Dummy,
+      crumb: 'Recipes Listing',
+      '/new': {
+        component: Dummy,
+        crumb: 'New Recipe',
+      },
+      '/:pk': {
+        component: Dummy,
+        crumb: 'View Recipe',
+      },
+    },
+    '/extensions': {
+      component: Dummy,
+      crumb: 'Extensions Listing',
+      '/new': {
+        component: Dummy,
+        crumb: 'New Extension',
+      },
+      '/:pk': {
+        component: Dummy,
+        crumb: 'View Extension',
+      },
+    },
+  },
+};
+
 export const {
   reducer,
   middleware,
   enhancer,
 } = routerForBrowser({
-  routes: {
-    '/': {
-      component: Gateway,
-    },
-    '/recipes': {
-      component: Dummy,
-    },
-    '/recipes/:pk': {
-      component: Dummy,
-    },
-    '/extensions': {
-      component: Dummy,
-    },
-    '/extensions/new': {
-      component: Dummy,
-    },
-    '/extensions/:pk': {
-      component: Dummy,
-    },
-  },
+  routes,
   basename: '/control-new',
 });
 


### PR DESCRIPTION
~Depends on PR #838 .~

- Changes routes to be nested
- Adds `crumb` property to routes (displayed name in breadcrumbs)
- Adds `NavigationCrumbs` connected component
  - Takes in `router` as connected prop and builds out displayed breadcrumbs
  - Displayed in `App` component

~a28994bdf003489aa71053f3e73680a674f8088a is the commit to review while #838 's merge pends~