### PR TITLE
Lint: Enforce order and grouping of JS imports.

### DIFF
--- a/recipe-server/.eslintrc
+++ b/recipe-server/.eslintrc
@@ -1,16 +1,21 @@
 env:
   es6: true
+
 extends:
   - airbnb
   - plugin:react/recommended
+
 parser: babel-eslint
+
 plugins:
   - jasmine
   - babel
   - react
+
 globals:
   PRODUCTION: false
   DEVELOPMENT: false
+
 rules:
   arrow-parens: [warn, as-needed]
   comma-dangle: [warn]
@@ -28,6 +33,14 @@ rules:
   import/no-extraneous-dependencies: [error, {devDependencies: true}]
   import/no-mutable-exports: [off]
   import/no-named-as-default: [off]
+  import/order:
+    - error
+    - newlines-between: always-and-inside-groups
+      groups:
+      - [builtin, external]
+      - [internal]
+      - [parent, index, sibling]
+
   react/jsx-filename-extension: [error, { extensions: [.js] }]
   react/no-multi-comp: [off]
   react/jsx-no-bind: [error]
@@ -39,6 +52,7 @@ rules:
   jsx-a11y/label-has-for: [off]
 
   generator-star-spacing: [warn]
+
 settings:
   import/resolver:
     webpack:

--- a/recipe-server/client/control/actions/FilterActions.js
+++ b/recipe-server/client/control/actions/FilterActions.js
@@ -1,3 +1,5 @@
+import titleize from 'underscore.string/titleize';
+
 import makeApiRequest from 'control/api';
 
 import {
@@ -9,7 +11,6 @@ import {
   getFilterParamString,
 } from 'control/selectors/FiltersSelector';
 
-import titleize from 'underscore.string/titleize';
 
 export const SET_FILTER = 'SET_FILTER';
 export const SET_TEXT_FILTER = 'SET_TEXT_FILTER';

--- a/recipe-server/client/control/components/ControlApp.js
+++ b/recipe-server/client/control/components/ControlApp.js
@@ -1,4 +1,5 @@
 import React, { PropTypes as pt } from 'react';
+
 import Header from 'control/components/Header';
 import Notifications from 'control/components/Notifications';
 import DevTools from 'control/components/DevTools';

--- a/recipe-server/client/control/components/DeleteRecipe.js
+++ b/recipe-server/client/control/components/DeleteRecipe.js
@@ -1,5 +1,6 @@
 import React, { PropTypes as pt } from 'react';
 import { push } from 'react-router-redux';
+
 import makeApiRequest from 'control/api';
 import { recipeDeleted } from 'control/actions/RecipeActions';
 import composeRecipeContainer from 'control/components/RecipeContainer';

--- a/recipe-server/client/control/components/DisableRecipe.js
+++ b/recipe-server/client/control/components/DisableRecipe.js
@@ -1,5 +1,6 @@
 import React, { PropTypes as pt } from 'react';
 import { push } from 'react-router-redux';
+
 import makeApiRequest from 'control/api';
 import { singleRecipeReceived } from 'control/actions/RecipeActions';
 import composeRecipeContainer from 'control/components/RecipeContainer';

--- a/recipe-server/client/control/components/DraftStatus.js
+++ b/recipe-server/client/control/components/DraftStatus.js
@@ -1,4 +1,5 @@
 import React, { PropTypes as pt } from 'react';
+
 import RecipeStatus from 'control/components/RecipeStatus';
 import DraftStatusIcon from 'control/components/DraftStatusIcon';
 

--- a/recipe-server/client/control/components/EnableRecipe.js
+++ b/recipe-server/client/control/components/EnableRecipe.js
@@ -1,5 +1,6 @@
 import React, { PropTypes as pt } from 'react';
 import { push } from 'react-router-redux';
+
 import makeApiRequest from 'control/api';
 import { singleRecipeReceived } from 'control/actions/RecipeActions';
 import composeRecipeContainer from 'control/components/RecipeContainer';

--- a/recipe-server/client/control/components/MultiPicker.js
+++ b/recipe-server/client/control/components/MultiPicker.js
@@ -1,5 +1,6 @@
 import React, { PropTypes as pt } from 'react';
 import cx from 'classnames';
+
 import Frame from 'control/components/Frame';
 
 /**

--- a/recipe-server/client/control/components/Notifications.js
+++ b/recipe-server/client/control/components/Notifications.js
@@ -1,6 +1,7 @@
 import React, { PropTypes as pt } from 'react';
 import { connect } from 'react-redux';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+
 import { dismissNotification } from 'control/actions/NotificationActions';
 
 const notificationPropType = pt.shape({

--- a/recipe-server/client/control/components/RecipeCombobox.js
+++ b/recipe-server/client/control/components/RecipeCombobox.js
@@ -1,5 +1,4 @@
 import React, { PropTypes as pt } from 'react';
-
 import { omit } from 'underscore';
 
 import DropdownMenu from 'control/components/DropdownMenu';

--- a/recipe-server/client/control/components/RecipeFilters.js
+++ b/recipe-server/client/control/components/RecipeFilters.js
@@ -1,11 +1,10 @@
 import React, { PropTypes as pt } from 'react';
 import { connect } from 'react-redux';
+import { isEqual } from 'underscore';
 
 import ColumnMenu from 'control/components/ColumnMenu';
 import ActiveFilters from 'control/components/ActiveFilters';
 import RecipeCombobox from 'control/components/RecipeCombobox';
-
-import { isEqual } from 'underscore';
 
 import {
   loadLocalColumns,

--- a/recipe-server/client/control/components/form_fields/FormFieldWrapper.js
+++ b/recipe-server/client/control/components/form_fields/FormFieldWrapper.js
@@ -1,4 +1,5 @@
 import React, { PropTypes as pt } from 'react';
+
 import NumberField from 'control/components/form_fields/NumberField';
 
 const SelectMenu = props => {

--- a/recipe-server/client/control/index.js
+++ b/recipe-server/client/control/index.js
@@ -1,4 +1,5 @@
 import ReactDOM from 'react-dom';
+
 import { createApp } from 'control/app';
 
 // Initialize the control app and render it.

--- a/recipe-server/client/control/reducers/ColumnReducer.js
+++ b/recipe-server/client/control/reducers/ColumnReducer.js
@@ -1,10 +1,10 @@
+import { isEqual } from 'underscore';
+
 import {
   LOAD_SAVED_COLUMNS,
   UPDATE_COLUMN,
   saveLocalColumns as saveState,
 } from 'control/actions/ColumnActions';
-
-import { isEqual } from 'underscore';
 
 const initialState = [{
   label: 'Name',

--- a/recipe-server/client/control/routes.js
+++ b/recipe-server/client/control/routes.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { IndexRedirect, IndexRoute, Route } from 'react-router';
+
 import ControlApp from 'control/components/ControlApp';
 import ExtensionForm from 'control/components/ExtensionForm';
 import ExtensionList from 'control/components/ExtensionList';

--- a/recipe-server/client/control/stores/configureStore.js
+++ b/recipe-server/client/control/stores/configureStore.js
@@ -2,8 +2,8 @@ import { compose, createStore, applyMiddleware } from 'redux';
 import { browserHistory } from 'react-router';
 import { routerMiddleware } from 'react-router-redux';
 import thunk from 'redux-thunk';
-import DevTools from 'control/components/DevTools.js';
 
+import DevTools from 'control/components/DevTools.js';
 import reducers from 'control/reducers';
 
 const reduxRouterMiddleware = routerMiddleware(browserHistory);

--- a/recipe-server/client/control/tests/components/test_MultiPicker.js
+++ b/recipe-server/client/control/tests/components/test_MultiPicker.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+
 import MultiPicker from 'control/components/MultiPicker';
 
 const propFactory = props => ({

--- a/recipe-server/client/control/tests/components/test_Notifications.js
+++ b/recipe-server/client/control/tests/components/test_Notifications.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+
 import { DisconnectedNotifications, Notification } from 'control/components/Notifications.js';
 
 describe('Notification components', () => {

--- a/recipe-server/client/control/tests/components/test_RecipeCombobox.js
+++ b/recipe-server/client/control/tests/components/test_RecipeCombobox.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { mount } from 'enzyme';
-import { multiStubbedFilters } from 'control/tests/fixtures';
 
+import { multiStubbedFilters } from 'control/tests/fixtures';
 import RecipeCombobox from 'control/components/RecipeCombobox';
 
 const noop = () => {};

--- a/recipe-server/client/control/tests/components/test_RecipeFilters.js
+++ b/recipe-server/client/control/tests/components/test_RecipeFilters.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { shallow } from 'enzyme';
-import { multiStubbedFilters } from 'control/tests/fixtures';
 
+import { multiStubbedFilters } from 'control/tests/fixtures';
 import { RecipeFilters } from 'control/components/RecipeFilters';
 
 const noop = () => {};

--- a/recipe-server/client/control/tests/components/test_RecipeForm.js
+++ b/recipe-server/client/control/tests/components/test_RecipeForm.js
@@ -5,6 +5,7 @@ import { SubmissionError } from 'redux-form';
 
 import { RecipeForm, formConfig, initialValuesWrapper } from 'control/components/RecipeForm.js';
 import ConsoleLogFields from 'control/components/action_fields/ConsoleLogFields.js';
+
 // import HeartbeatFields from 'control/components/action_fields/HeartbeatFields.js';
 import { recipeFactory } from '../../../tests/utils.js';
 

--- a/recipe-server/client/control/tests/components/test_RecipeHistory.js
+++ b/recipe-server/client/control/tests/components/test_RecipeHistory.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+
 import { HistoryItem, HistoryList } from 'control/components/RecipeHistory';
 import DraftStatus, { STATUS_MESSAGES } from 'control/components/DraftStatus';
 import DraftStatusIcon, { STATUS_ICONS } from 'control/components/DraftStatusIcon';

--- a/recipe-server/client/control/tests/components/test_RecipeList.js
+++ b/recipe-server/client/control/tests/components/test_RecipeList.js
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Tr } from 'reactable';
+
 import appReducer from 'control/reducers';
 import * as actions from 'control/actions/RecipeActions';
 import { initialState } from 'control/tests/fixtures';
-
-import { Tr } from 'reactable';
 import { DisconnectedRecipeList as RecipeList } from 'control/components/RecipeList';
 
 const propFactory = props => ({

--- a/recipe-server/client/control/tests/test_routes.js
+++ b/recipe-server/client/control/tests/test_routes.js
@@ -2,7 +2,6 @@ import { replace } from 'react-router-redux';
 import { shallow } from 'enzyme';
 
 import { createApp } from 'control/app';
-
 import NoMatch from 'control/components/NoMatch.js';
 
 describe('Control routes', () => {

--- a/recipe-server/package.json
+++ b/recipe-server/package.json
@@ -74,7 +74,7 @@
     "eslint-config-airbnb": "10.0.1",
     "eslint-import-resolver-webpack": "0.7.0",
     "eslint-plugin-babel": "4.1.1",
-    "eslint-plugin-import": "1.14.0",
+    "eslint-plugin-import": "2.6.0",
     "eslint-plugin-jasmine": "1.8.1",
     "eslint-plugin-jsx-a11y": "2.2.1",
     "eslint-plugin-react": "6.2.0",


### PR DESCRIPTION
This lints that we group dependencies, and the order of those groups. It doesn't enforce the order of imports.