### PR TITLE
Document code owners for automatic review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # Later rules override earlier rules
 
 # As a fallback, ping the team
-* @mozilla/normandy-comitters
+* @mozilla/normandy-owners
 
 # add-on work needs to be reviewed by both a Firefox Peer and a comitter
-* @mozilla/normandy-comitters @mozilla/normandy-firefox-peers
+recipe-client-addon/* @mozilla/normandy-owners @mozilla/normandy-firefox-peers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# This file creates automatic review requests for PRs based on the files touched.
+# See this blog post for more info: https://github.com/blog/2392-introducing-code-owners
+
+# Later rules override earlier rules
+
+# As a fallback, ping the team
+* @mozilla/normandy-comitters
+
+# add-on work needs to be reviewed by both a Firefox Peer and a comitter
+* @mozilla/normandy-comitters @mozilla/normandy-firefox-peers


### PR DESCRIPTION
This is a new feature that Github just added. It lets us enforce the implicit rules we have about who must review what.

See https://github.com/blog/2392-introducing-code-owners for more details.