### PR TITLE
Fix #861 octothrope comments

### DIFF
--- a/mozjexl/README.md
+++ b/mozjexl/README.md
@@ -118,7 +118,6 @@ Access Jexl the same way, backend or front:
 | Subtract         |         -        |
 | Multiply         |         *        |
 | Divide           |         /        |
-| Divide and floor |        //        |
 | Modulus          |         %        |
 | Power of         |         ^        |
 | Logical AND      |        &&        |

--- a/mozjexl/lib/Lexer.js
+++ b/mozjexl/lib/Lexer.js
@@ -14,7 +14,9 @@ var numericRegex = /^-?(?:(?:[0-9]*\.[0-9]+)|[0-9]+)$/,
 		'\\s+',
 		// Booleans
 		'\\btrue\\b',
-		'\\bfalse\\b'
+		'\\bfalse\\b',
+		// Octothorpe comments #861
+		'#.*[\\n\\r]?'
 	],
 	postOpRegexElems = [
 		// Identifiers
@@ -71,6 +73,8 @@ Lexer.prototype.getTokens = function(elements) {
 			if (tokens.length)
 				tokens[tokens.length - 1].raw += elements[i];
 		}
+		else if (this._isComment(elements[i]))
+			continue;
 		else if (elements[i] === '-' && this._isNegative(tokens))
 			negate = true;
 		else {
@@ -217,6 +221,16 @@ Lexer.prototype._isNegative = function(tokens) {
 var _whitespaceRegex = /^\s*$/;
 Lexer.prototype._isWhitespace = function(str) {
 	return _whitespaceRegex.test(str);
+};
+
+/**
+ * A utility function to determine if a string is an octothorpe comment
+ * @param {string} str A string to be tested
+ * @returns {boolean} true if the string is a comment, false otherwise.
+ * @private
+ */
+Lexer.prototype._isComment = function(str) {
+	return str.startsWith('#');
 };
 
 /**

--- a/mozjexl/lib/Lexer.js
+++ b/mozjexl/lib/Lexer.js
@@ -15,8 +15,8 @@ var numericRegex = /^-?(?:(?:[0-9]*\.[0-9]+)|[0-9]+)$/,
 		// Booleans
 		'\\btrue\\b',
 		'\\bfalse\\b',
-		// Octothorpe comments #861
-		'#.*[\\n\\r]?'
+		// comments
+		'//.*[\\n\\r]?'
 	],
 	postOpRegexElems = [
 		// Identifiers
@@ -224,13 +224,13 @@ Lexer.prototype._isWhitespace = function(str) {
 };
 
 /**
- * A utility function to determine if a string is an octothorpe comment
+ * A utility function to determine if a string is a comment
  * @param {string} str A string to be tested
  * @returns {boolean} true if the string is a comment, false otherwise.
  * @private
  */
 Lexer.prototype._isComment = function(str) {
-	return str.startsWith('#');
+	return str.startsWith('//');
 };
 
 /**

--- a/mozjexl/lib/grammar.js
+++ b/mozjexl/lib/grammar.js
@@ -28,8 +28,6 @@ exports.elements = {
 		eval: function(left, right) { return left * right; }},
 	'/': {type: 'binaryOp', precedence: 40,
 		eval: function(left, right) { return left / right; }},
-	'//': {type: 'binaryOp', precedence: 40,
-		eval: function(left, right) { return Math.floor(left / right); }},
 	'%': {type: 'binaryOp', precedence: 50,
 		eval: function(left, right) { return left % right; }},
 	'^': {type: 'binaryOp', precedence: 50,

--- a/mozjexl/test/Lexer.js
+++ b/mozjexl/test/Lexer.js
@@ -125,6 +125,41 @@ describe('Lexer', function() {
 			fn.should.throw();
 		});
 	});
+	describe('Comments', function() {
+	 	it("should handle a complex mix of octothrope comments in single, multiline and value contexts", function () {
+	 		var expression = [
+				'6+x -  -17.55*y #end comment',
+				'<= !foo.bar["baz\\"foz"] # with space',
+				'&& b=="not a #comment" # is a comment',
+		 		"# comment # 2nd comment"
+		 	].join("\n");
+	 		var tokens = inst.tokenize(expression);
+	 		var ans = [
+				{ type: 'literal', value: 6, raw: '6' },
+			  { type: 'binaryOp', value: '+', raw: '+' },
+			  { type: 'identifier', value: 'x', raw: 'x ' },
+			  { type: 'binaryOp', value: '-', raw: '-  ' },
+			  { type: 'literal', value: -17.55, raw: '-17.55' },
+			  { type: 'binaryOp', value: '*', raw: '*' },
+			  { type: 'identifier', value: 'y', raw: 'y ' },
+			  { type: 'binaryOp', value: '<=', raw: '<= ' },
+			  { type: 'unaryOp', value: '!', raw: '!' },
+			  { type: 'identifier', value: 'foo', raw: 'foo' },
+			  { type: 'dot', value: '.', raw: '.' },
+			  { type: 'identifier', value: 'bar', raw: 'bar' },
+			  { type: 'openBracket', value: '[', raw: '[' },
+			  { type: 'literal', value: 'baz"foz', raw: '"baz\\"foz"' },
+			  { type: 'closeBracket', value: ']', raw: '] ' },
+			  { type: 'binaryOp', value: '&&', raw: '&& ' },
+			  { type: 'identifier', value: 'b', raw: 'b' },
+			  { type: 'binaryOp', value: '==', raw: '==' },
+			  { type: 'literal',
+			    value: 'not a #comment',
+			    raw: '"not a #comment" ' }
+			];
+			tokens.should.deep.equal(ans);
+	 	});
+	});
 	it("should tokenize a full expression", function() {
 		var tokens = inst.tokenize('6+x -  -17.55*y<= !foo.bar["baz\\"foz"]');
 		tokens.should.deep.equal([

--- a/mozjexl/test/Lexer.js
+++ b/mozjexl/test/Lexer.js
@@ -126,16 +126,16 @@ describe('Lexer', function() {
 		});
 	});
 	describe('Comments', function() {
-	 	it("should handle a complex mix of octothrope comments in single, multiline and value contexts", function () {
+	 	it("should handle a complex mix of comments in single, multiline and value contexts", function () {
 	 		var expression = [
-				'6+x -  -17.55*y #end comment',
-				'<= !foo.bar["baz\\"foz"] # with space',
-				'&& b=="not a #comment" # is a comment',
-		 		"# comment # 2nd comment"
+				'6+x -  -17.55*y //end comment',
+				'<= !foo.bar["baz\\"foz"] // with space',
+				'&& b=="not a //comment" // is a comment',
+		 		"// comment // 2nd comment"
 		 	].join("\n");
 	 		var tokens = inst.tokenize(expression);
 	 		var ans = [
-				{ type: 'literal', value: 6, raw: '6' },
+			  { type: 'literal', value: 6, raw: '6' },
 			  { type: 'binaryOp', value: '+', raw: '+' },
 			  { type: 'identifier', value: 'x', raw: 'x ' },
 			  { type: 'binaryOp', value: '-', raw: '-  ' },
@@ -154,8 +154,8 @@ describe('Lexer', function() {
 			  { type: 'identifier', value: 'b', raw: 'b' },
 			  { type: 'binaryOp', value: '==', raw: '==' },
 			  { type: 'literal',
-			    value: 'not a #comment',
-			    raw: '"not a #comment" ' }
+			    value: 'not a //comment',
+			    raw: '"not a //comment" ' }
 			];
 			tokens.should.deep.equal(ans);
 	 	});

--- a/mozjexl/test/evaluator/Evaluator.js
+++ b/mozjexl/test/evaluator/Evaluator.js
@@ -107,10 +107,6 @@ describe('Evaluator', function() {
 		var e = new Evaluator(grammar);
 		return e.eval(toTree('"hello"|world')).should.reject;
 	});
-	it('should apply the DivFloor operator', function() {
-		var e = new Evaluator(grammar);
-		return e.eval(toTree('7 // 2')).should.become(3);
-	});
 	it('should evaluate an object literal', function() {
 		var e = new Evaluator(grammar);
 		return e.eval(toTree('{foo: {bar: "tek"}}'))


### PR DESCRIPTION
So I did a LOT MORE WORK ON THIS.

What does this do?

1.  In the `Lexer` catches OCTOTHORPE comments using a REGEX, and DROPS those tokens.  Thus the parser never has to see them, and never has to do anything.
2.  If we can write a regex for C-comments, we could do the same thing.  PS, those comments are much harder to regex, and I gave up with trying to get the right level of slash escaping to work :) , but it's easy to extend.
3.  PARSING the C-Comments is a LOT MORE CONFUSING for me.  I tried writing some grammar above, but I got totally lost in `states.js`.
4.  PS, I don't know how you are handling multi-line.  I wrote a test for that in the jexl, and it fell-apart. 