### PR TITLE
Support loading arbitrary npm dependencies in the add-on via webpack.

### DIFF
--- a/docs/dev/recipe-client-addon/install.rst
+++ b/docs/dev/recipe-client-addon/install.rst
@@ -15,6 +15,27 @@ These docs assume a Unix-like operating system.
 .. _Git: https://git-scm.com/
 .. _Node.js: https://nodejs.org/en/
 
+Installation
+------------
+1. Clone this repository or your fork_:
+
+   .. code-block:: bash
+
+      git clone https://github.com/mozilla/normandy.git
+      cd normandy
+
+2. Install dependencies and build them using npm:
+
+   .. code-block:: bash
+
+      npm install
+      npm run build
+
+Once you've finished these steps, you should be ready to build an XPI or copy
+your checkout to mozilla-central.
+
+.. _fork: http://help.github.com/fork-a-repo/
+
 Building an XPI
 ---------------
 The easiest way to build and run the system add-on is to build an XPI file and

--- a/docs/dev/recipe-client-addon/workflow.rst
+++ b/docs/dev/recipe-client-addon/workflow.rst
@@ -4,6 +4,61 @@ The following is a list of things you'll probably need to do at some point while
 working on the recipe client. The majority of these steps assume that you have
 a working :ref:`mozilla-central checkout <build-moz-central>`.
 
+Building and Using Dependencies
+-------------------------------
+Before building an XPI or syncing changes to mozilla-central, you must first
+install and build the latest dependencies:
+
+.. code-block:: bash
+
+   cd recipe-client-addon
+   npm install
+   npm run build
+
+This will create a ``vendor`` directory containing a ``.js`` for each
+third-party library that the add-on uses. They can be imported like other
+JavaScript files:
+
+.. code-block:: javascript
+
+   Cu.import("resource://shield-recipe-client/vendor/mozjexl.js");
+   const jexl = new mozjexl.Jexl();
+
+Adding New Dependencies
+-----------------------
+To add a dependency:
+
+1. Install the dependency and add it to ``package.json``:
+
+   .. code-block:: bash
+
+      npm install --save ajv@5.2.2
+
+   Version numbers in ``package.json`` must be set to an exact match to avoid
+   bugs from downloading newer versions of libraries that we haven't tested
+   the add-on against yet.
+
+2. Add the dependency to ``recipe-client-addon/webpack.config.js`` using the
+   ``libraryConfig`` function:
+
+   .. code-block:: javascript
+
+      module.exports = [
+        // First argument is the name to export the library under
+        // Second argument is a path to the library's folder in node_modules
+        libraryConfig("ajv", "./node_modules/ajv"),
+      ];
+
+3. Re-build the vendor directory via ``npm run build``. Ensure that a
+   ``libraryName_LICENSE`` file was generated withing ``vendor`` so that we have
+   licensing information for our dependencies.
+
+.. note::
+
+   Currently, we do not expose certain browser globals (such as ``fetch``) that
+   libraries may depend on. Be sure to test that libraries you add will work
+   properly in a chrome environment that they may not have been built for.
+
 Building an XPI
 ---------------
 The ``make-xpi.sh`` script builds an XPI file from the current recipe-client

--- a/docs/dev/recipe-client-addon/workflow.rst
+++ b/docs/dev/recipe-client-addon/workflow.rst
@@ -38,20 +38,22 @@ To add a dependency:
    bugs from downloading newer versions of libraries that we haven't tested
    the add-on against yet.
 
-2. Add the dependency to ``recipe-client-addon/webpack.config.js`` using the
-   ``libraryConfig`` function:
+2. Add the dependency to ``recipe-client-addon/webpack.config.js`` as an entry
+   point:
 
    .. code-block:: javascript
 
-      module.exports = [
-        // First argument is the name to export the library under
-        // Second argument is a path to the library's folder in node_modules
-        libraryConfig("ajv", "./node_modules/ajv"),
-      ];
+      module.exports = {
+        entry: {
+          // The key is the name to export the library under
+          // The value is the path to the library's folder in node_modules
+          ajv: "./node_modules/ajv",
+        },
+      };
 
-3. Re-build the vendor directory via ``npm run build``. Ensure that a
-   ``libraryName_LICENSE`` file was generated withing ``vendor`` so that we have
-   licensing information for our dependencies.
+3. Re-build the vendor directory via ``npm run build``. Ensure that licensing
+   info for the library was added to the ``LICENSE_THIRDPARTY`` file generated
+   within ``vendor`` so that we have licensing information for our dependencies.
 
 .. note::
 

--- a/recipe-client-addon/.gitignore
+++ b/recipe-client-addon/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 /*.xpi
 npm-debug.log
+vendor/

--- a/recipe-client-addon/bin/make-xpi.sh
+++ b/recipe-client-addon/bin/make-xpi.sh
@@ -14,6 +14,11 @@ function cleanup {
 }
 trap cleanup EXIT
 
+# Build vendor files
+pushd $BASE_DIR
+npm run build
+popd
+
 while read -r LINE || [[ -n "${LINE}" ]]; do
   mkdir -p "$(dirname "${DEST}/${LINE}")"
   cp -r "${BASE_DIR}/${LINE}" "$(dirname "${DEST}/${LINE}")"

--- a/recipe-client-addon/bin/update-mozilla-central.sh
+++ b/recipe-client-addon/bin/update-mozilla-central.sh
@@ -18,6 +18,11 @@ fi
 
 rm -rf "${dest}"/*
 
+# Build vendor files
+pushd $baseDir
+npm run build
+popd
+
 while read -r line || [[ -n "${line}" ]]; do
   mkdir -p "$(dirname "${dest}/${line}")"
   cp -r "${baseDir}/${line}" "$(dirname "${dest}/${line}")"

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -40,6 +40,7 @@ this.shutdown = function(data, reason) {
     "lib/ShieldRecipeClient.jsm",
     "lib/Storage.jsm",
     "lib/Utils.jsm",
+    "vendor/mozjexl.js",
   ];
   for (const module of modules) {
     log.debug(`Unloading ${module}`);

--- a/recipe-client-addon/build-includes.txt
+++ b/recipe-client-addon/build-includes.txt
@@ -3,7 +3,6 @@ install.rdf.in
 jar.mn
 lib
 moz.build
-node_modules/mozjexl/lib
-node_modules/mozjexl/LICENSE.txt
+vendor
 test
 skin

--- a/recipe-client-addon/jar.mn
+++ b/recipe-client-addon/jar.mn
@@ -6,5 +6,5 @@
 % resource shield-recipe-client %content/
   content/lib/ (./lib/*)
   content/data/ (./data/*)
-  content/node_modules/mozjexl/ (./node_modules/mozjexl/*)
   content/skin/  (skin/*)
+  content/vendor/ (./vendor/*)

--- a/recipe-client-addon/lib/FilterExpressions.jsm
+++ b/recipe-client-addon/lib/FilterExpressions.jsm
@@ -9,21 +9,12 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://shield-recipe-client/lib/Sampling.jsm");
 Cu.import("resource://shield-recipe-client/lib/PreferenceFilters.jsm");
 
+XPCOMUtils.defineLazyModuleGetter(this, "mozjexl", "resource://shield-recipe-client/vendor/mozjexl.js");
+
 this.EXPORTED_SYMBOLS = ["FilterExpressions"];
 
-XPCOMUtils.defineLazyGetter(this, "nodeRequire", () => {
-  const {Loader, Require} = Cu.import("resource://gre/modules/commonjs/toolkit/loader.js", {});
-  const loader = new Loader({
-    paths: {
-      "": "resource://shield-recipe-client/node_modules/",
-    },
-  });
-  return new Require(loader, {});
-});
-
 XPCOMUtils.defineLazyGetter(this, "jexl", () => {
-  const {Jexl} = nodeRequire("mozjexl/lib/Jexl.js");
-  const jexl = new Jexl();
+  const jexl = new mozjexl.Jexl();
   jexl.addTransforms({
     date: dateString => new Date(dateString),
     stableSample: Sampling.stableSample,

--- a/recipe-client-addon/package.json
+++ b/recipe-client-addon/package.json
@@ -7,9 +7,8 @@
   "repository": "https://github.com/mozilla/normandy-addon",
   "license": "MPL-2.0",
   "scripts": {
-    "watch-vendor": "webpack --config ./webpack.config.js --watch",
-    "build-vendor": "webpack --config ./webpack.config.js",
-    "build": "webpack --config ./webpack.config.js && ./bin/make-xpi.sh"
+    "watch": "webpack --config ./webpack.config.js --watch",
+    "build": "webpack --config ./webpack.config.js"
   },
   "devDependencies": {
     "babel-eslint": "7.2.3",

--- a/recipe-client-addon/package.json
+++ b/recipe-client-addon/package.json
@@ -5,11 +5,10 @@
   "main": "index.js",
   "author": "Mike Cooper <mcooper@mozilla.com>",
   "repository": "https://github.com/mozilla/normandy-addon",
-  "scripts": {},
   "license": "MPL-2.0",
   "scripts": {
     "watch-vendor": "webpack --config ./webpack.config.js --watch",
-    "build-bendor": "webpack --config ./webpack.config.js",
+    "build-vendor": "webpack --config ./webpack.config.js",
     "build": "webpack --config ./webpack.config.js && ./bin/make-xpi.sh"
   },
   "devDependencies": {

--- a/recipe-client-addon/package.json
+++ b/recipe-client-addon/package.json
@@ -5,15 +5,20 @@
   "main": "index.js",
   "author": "Mike Cooper <mcooper@mozilla.com>",
   "repository": "https://github.com/mozilla/normandy-addon",
-  "scripts": {
-  },
+  "scripts": {},
   "license": "MPL-2.0",
+  "scripts": {
+    "watch-vendor": "webpack --config ./webpack.config.js --watch",
+    "build-bendor": "webpack --config ./webpack.config.js",
+    "build": "webpack --config ./webpack.config.js && ./bin/make-xpi.sh"
+  },
   "devDependencies": {
     "babel-eslint": "7.2.3",
-    "eslint": "^3.19.0",
+    "eslint": "3.19.0",
     "eslint-config-normandy": "1.0.0",
     "eslint-plugin-babel": "4.1.1",
-    "eslint-plugin-mozilla": "0.3.2"
+    "eslint-plugin-mozilla": "0.3.2",
+    "webpack": "3.1.0"
   },
   "dependencies": {
     "mozjexl": "1.1.5"

--- a/recipe-client-addon/package.json
+++ b/recipe-client-addon/package.json
@@ -17,6 +17,7 @@
     "eslint-config-normandy": "1.0.0",
     "eslint-plugin-babel": "4.1.1",
     "eslint-plugin-mozilla": "0.3.2",
+    "license-webpack-plugin": "^0.5.1",
     "webpack": "3.1.0"
   },
   "dependencies": {

--- a/recipe-client-addon/webpack.config.js
+++ b/recipe-client-addon/webpack.config.js
@@ -3,52 +3,38 @@ var path = require("path");
 var ConcatSource = require("webpack-sources").ConcatSource;
 var LicenseWebpackPlugin = require("license-webpack-plugin");
 
-/**
- * Create a webpack config object for a library. The compiled library will be
- * output to the vendor directory.
- *
- * @param {String} name
- *   Library name. This generally should match the name used on npm.
- * @param {String} entryPoint
- *   Path to the entry point of the library. Webpack can handle directories with
- *   a package.json file, so normally this is "./node_modules/libname".
- */
-function libraryConfig(name, entryPoint) {
-  return {
-    context: __dirname,
-    entry: {
-      [name]: entryPoint,
-    },
-    output: {
-      path: path.resolve(__dirname, "vendor/"),
-      filename: "[name].js",
-      library: name,
-      libraryTarget: "this",
-    },
-    plugins: [
-      /**
-       * Plugin that appends "this.EXPORTED_SYMBOLS = ["libname"]" to assets
-       * output by webpack. This allows built assets to be imported using
-       * Cu.import.
-       */
-      function ExportedSymbols() {
-        this.plugin("emit", function(compilation, callback) {
-          const assetName = `${name}.js`;
+module.exports = {
+  context: __dirname,
+  entry: {
+    mozjexl: "./node_modules/mozjexl/",
+  },
+  output: {
+    path: path.resolve(__dirname, "vendor/"),
+    filename: "[name].js",
+    library: "[name]",
+    libraryTarget: "this",
+  },
+  plugins: [
+    /**
+     * Plugin that appends "this.EXPORTED_SYMBOLS = ["libname"]" to assets
+     * output by webpack. This allows built assets to be imported using
+     * Cu.import.
+     */
+    function ExportedSymbols() {
+      this.plugin("emit", function(compilation, callback) {
+        for (const libraryName in compilation.entrypoints) {
+          const assetName = `${libraryName}.js`; // Matches output.filename
           compilation.assets[assetName] = new ConcatSource(
             compilation.assets[assetName],
-            `this.EXPORTED_SYMBOLS = ["${name}"];`
+            `this.EXPORTED_SYMBOLS = ["${libraryName}"];` // Matches output.library
           );
-          callback();
-        });
-      },
-      new LicenseWebpackPlugin({
-        pattern: /^(MIT|ISC|MPL.*|Apache.*|BSD.*)$/,
-        filename: `${name}_LICENSE`,
-      }),
-    ],
-  };
-}
-
-module.exports = [
-  libraryConfig("mozjexl", "./node_modules/mozjexl"),
-];
+        }
+        callback();
+      });
+    },
+    new LicenseWebpackPlugin({
+      pattern: /^(MIT|ISC|MPL.*|Apache.*|BSD.*)$/,
+      filename: `LICENSE_THIRDPARTY`,
+    }),
+  ],
+};

--- a/recipe-client-addon/webpack.config.js
+++ b/recipe-client-addon/webpack.config.js
@@ -1,0 +1,49 @@
+/* eslint-env node */
+var path = require("path");
+var ConcatSource = require("webpack-sources").ConcatSource;
+
+/**
+ * Create a webpack config object for a library. The compiled library will be
+ * output to the vendor directory.
+ *
+ * @param {String} name
+ *   Library name. This generally should match the name used on npm.
+ * @param {String} entryPoint
+ *   Path to the entry point of the library. Webpack can handle directories with
+ *   a package.json file, so normally this is "./node_modules/libname".
+ */
+function libraryConfig(name, entryPoint) {
+  return {
+    context: __dirname,
+    entry: {
+      [name]: entryPoint,
+    },
+    output: {
+      path: path.resolve(__dirname, "vendor/"),
+      filename: "[name].js",
+      library: name,
+      libraryTarget: "this",
+    },
+    plugins: [
+      /**
+       * Plugin that appends "this.EXPORTED_SYMBOLS = ["libname"]" to assets
+       * output by webpack. This allows built assets to be imported using
+       * Cu.import.
+       */
+      function ExportedSymbols() {
+        this.plugin("emit", function(compilation, callback) {
+          const assetName = `${name}.js`;
+          compilation.assets[assetName] = new ConcatSource(
+            compilation.assets[assetName],
+            `this.EXPORTED_SYMBOLS = ["${name}"];`
+          );
+          callback();
+        });
+      },
+    ],
+  };
+}
+
+module.exports = [
+  libraryConfig("mozjexl", "./node_modules/mozjexl"),
+];

--- a/recipe-client-addon/webpack.config.js
+++ b/recipe-client-addon/webpack.config.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 var path = require("path");
 var ConcatSource = require("webpack-sources").ConcatSource;
+var LicenseWebpackPlugin = require("license-webpack-plugin");
 
 /**
  * Create a webpack config object for a library. The compiled library will be
@@ -40,6 +41,10 @@ function libraryConfig(name, entryPoint) {
           callback();
         });
       },
+      new LicenseWebpackPlugin({
+        pattern: /^(MIT|ISC|MPL.*|Apache.*|BSD.*)$/,
+        filename: `${name}_LICENSE`,
+      }),
     ],
   };
 }


### PR DESCRIPTION
In working on #749, I needed a way to load up [ajv](https://github.com/epoberezkin/ajv), but didn't want to manually import it like we did with mozjexl. Webpack to the rescue!

What this does is add a webpack config to the add-on that includes one configuration per-library that we want to include. Each config builds the library into a single file and outputs it to a `vendor` subdirectory. It also includes a plugin that appends `this.EXPORTED_SYMBOLS = ["libname"];` to the end of the output file so that it can be imported via `Cu.import`.

The rest is plumbing for automatically including these files within the add-on.

I think this is more preferable to running webpack on the entire add-on for a few reasons:
- We can continue to use imports that look familiar to Firefox devs.
- The code that we land in mozilla-central is still amenable to large refactors that happen from time-to-time.
- No need to mess around with source maps for the entire add-on.

This _should_ work with most browser-compatible libraries that we care about, although some browser globals might cause issues, like `URL` or `fetch`. If we run into that, I'd consider just adding an `importGlobalProperties` call to the top of the output file as necessary. Could be an optional argument to `libraryConfig`.

This is a WIP because I still need to write docs and also have a question:

How should the workflow for triggering builds go? Should we keep using the scripts in `bin` and modify them to run webpack every time? Should we switch to `npm` script commands and call the scripts within those instead? Should we just expect devs to run webpack when necessary (since you only need a rebuild when dependencies change)?

I'd appreciate feedback from anyone, but want it particularly from @mythmon. :D