### PR TITLE
Migrate signing format to autograph 2

### DIFF
--- a/recipe-server/normandy/recipes/signing.py
+++ b/recipe-server/normandy/recipes/signing.py
@@ -64,7 +64,6 @@ class Autographer(object):
             # Convert to bytes, and then back.
             encoded_implementation = base64.b64encode(item).decode('utf8')
             signing_request.append({
-                'template': 'content-signature',
                 'input': encoded_implementation,
             })
 


### PR DESCRIPTION
We're moving to a new version of autograph that has a slightly different API request/response format. Thankfully, I think the changes for normandy are, pretty much, non-existent.

Note that merging this PR means we need to move the staging/prod stacks over to the new autograph 2 service, so ops needs to update configuration. 