### PR TITLE
#749: Add StudyStorage.jsm for storing data about studies

### DIFF
--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -6,6 +6,7 @@
 
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Preferences.jsm");
 Cu.import("resource:///modules/ShellService.jsm");
@@ -18,6 +19,9 @@ Cu.import("resource://shield-recipe-client/lib/FilterExpressions.jsm");
 Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm");
 Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm");
 Cu.import("resource://shield-recipe-client/lib/Sampling.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(
+  this, "StudyStorage", "resource://shield-recipe-client/lib/StudyStorage.jsm");
 
 const {generateUUID} = Cc["@mozilla.org/uuid-generator;1"].getService(Ci.nsIUUIDGenerator);
 
@@ -225,6 +229,14 @@ this.NormandyDriver = function(sandboxManager) {
       get: sandboxManager.wrapAsync(PreferenceExperiments.get, {cloneInto: true}),
       getAllActive: sandboxManager.wrapAsync(PreferenceExperiments.getAllActive, {cloneInto: true}),
       has: sandboxManager.wrapAsync(PreferenceExperiments.has),
+    },
+
+    // Study storage API
+    studies: {
+      create: sandboxManager.wrapAsync(StudyStorage.create, {cloneArguments: true}),
+      update: sandboxManager.wrapAsync(StudyStorage.update, {cloneArguments: true}),
+      get: sandboxManager.wrapAsync(StudyStorage.get, {cloneInto: true}),
+      has: sandboxManager.wrapAsync(StudyStorage.has),
     },
   };
 };

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -29,6 +29,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "CleanupManager",
                                   "resource://shield-recipe-client/lib/CleanupManager.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "ActionSandboxManager",
                                   "resource://shield-recipe-client/lib/ActionSandboxManager.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "StudyStorage",
+                                  "resource://shield-recipe-client/lib/StudyStorage.jsm");
 
 Cu.importGlobalProperties(["fetch"]);
 
@@ -181,6 +183,9 @@ this.RecipeRunner = {
 
     // Nuke sandboxes
     Object.values(actionSandboxManagers).forEach(manager => manager.removeHold("recipeRunner"));
+
+    // Close storage connections
+    await StudyStorage.close();
   },
 
   async loadActionSandboxManagers() {

--- a/recipe-client-addon/lib/StudyStorage.jsm
+++ b/recipe-client-addon/lib/StudyStorage.jsm
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const {utils: Cu} = Components;
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "IndexedDB", "resource://gre/modules/IndexedDB.jsm");
+
+this.EXPORTED_SYMBOLS = ["StudyStorage"];
+
+const DB_OPTIONS = {
+  namespace: "shield-study-addons",
+  version: 1,
+  storage: "persistent",
+  schema: {
+    name: { autoIncrement: false, unique: false },
+    version: { autoIncrement: false, unique: false },
+    description: { autoIncrement: false, unique: false },
+    installDate: { autoIncrement: false, unique: false },
+    studyEndDate: { autoIncrement: false, unique: false },
+    addonId: { autoIncrement: false, unique: true },
+    active: { autoIncrement: false, unique: false },
+  },
+};
+
+this.StudyStorage = {
+  dbName: "shield-studies",
+
+  async reset(clearData) {
+    if (this.database) {
+      if (clearData) {
+        await this.database.objectStore(this.dbName, "readwrite").clear();
+      }
+
+      await this.database.close();
+      this.database = null;
+    }
+  },
+
+  async getDatabase() {
+    if (!this.database) {
+      this.database = await IndexedDB.open(this.dbName, DB_OPTIONS, db => {
+        db.createObjectStore(this.dbName, { keyPath: "addonId" });
+      });
+    }
+
+    return this.database;
+  },
+
+  async getStudyData(studyId) {
+    const db = await this.getDatabase();
+
+    return await db.objectStore(this.dbName, "readwrite").get(studyId);
+  },
+
+  async saveStudyData(study) {
+    const {
+      name, // The unique name for the experiment
+      version, // The add-on version
+      description, // The add-on description
+      installDate = Date.now(), // The install date
+      studyEndDate = null, // The study end date (starts off null)
+      addonId = study.id, // The add-on ID
+      active = true, // The active status of the study (starts off true)
+    } = study;
+
+
+    const db = await this.getDatabase();
+
+    return await db.objectStore(this.dbName, "readwrite")
+      .put({
+        name,
+        version,
+        description,
+        installDate,
+        studyEndDate,
+        addonId,
+        active,
+      });
+  },
+};

--- a/recipe-client-addon/lib/StudyStorage.jsm
+++ b/recipe-client-addon/lib/StudyStorage.jsm
@@ -126,9 +126,10 @@ this.StudyStorage = {
 
   async close() {
     if (databasePromise) {
-      const db = await databasePromise;
-      await db.close();
+      const promise = databasePromise;
       databasePromise = null;
+      const db = await promise;
+      await db.close();
     }
   },
 
@@ -156,7 +157,7 @@ this.StudyStorage = {
     }
 
     const db = await getDatabase();
-    if (getStore(db).get(study.name)) {
+    if (await getStore(db).get(study.name)) {
       throw new Error(
         `Cannot create study with name ${study.name}: a study exists with that name already.`,
       );

--- a/recipe-client-addon/lib/StudyStorage.jsm
+++ b/recipe-client-addon/lib/StudyStorage.jsm
@@ -41,22 +41,28 @@ const DB_SCHEMA = {
   properties: {
     name: {
       type: "string",
+      minLength: 1,
     },
     addonId: {
       type: "string",
+      minLength: 1,
     },
     addonVersion: {
       type: "string",
+      minLength: 1,
     },
     description: {
       type: "string",
+      minLength: 1,
     },
     studyStartDate: {
       type: "string",
+      minLength: 1,
       format: "date-time",
     },
     studyEndDate: {
       type: ["string", "null"],
+      minLength: 1,
       format: "date-time",
       default: null,
     },
@@ -150,6 +156,12 @@ this.StudyStorage = {
     }
 
     const db = await getDatabase();
+    if (getStore(db).get(study.name)) {
+      throw new Error(
+        `Cannot create study with name ${study.name}: a study exists with that name already.`,
+      );
+    }
+
     return getStore(db).add(study);
   },
 
@@ -158,7 +170,9 @@ this.StudyStorage = {
     const savedStudy = await getStore(db).get(studyName);
     if (!savedStudy) {
       throw new Error(`Cannot update study ${studyName}: could not find study.`);
-    } else if (!validateUpdate(data)) {
+    }
+
+    if (!validateUpdate(data)) {
       throw new Error(`
         Cannot update study ${studyName}: validation failed:
         ${ajvInstance.errorsText(validateUpdate.errors)}

--- a/recipe-client-addon/lib/StudyStorage.jsm
+++ b/recipe-client-addon/lib/StudyStorage.jsm
@@ -2,6 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/**
+ * @typedef {Object} Study
+ * @property {string} name
+ *   Unique name of the study
+ * @property {number} version
+ *   Study add-on version number
+ * @property {string} description
+ *   Description of the study and its intent.
+ * @property {string} studyStartDate
+ *   ISO-formatted date string of when the study was started.
+ * @property {string} studyEndDate
+ *   ISO-formatted date string of when the study was ended.
+ * @property {string} addonId
+ *   Add-on ID for this particular study.
+ * @property {boolean} active
+ *   Is the study still running?
+ */
+
 "use strict";
 
 const {utils: Cu} = Components;
@@ -15,69 +33,76 @@ const DB_OPTIONS = {
   version: 1,
   storage: "persistent",
   schema: {
-    name: { autoIncrement: false, unique: false },
+    name: { autoIncrement: false, unique: true },
     version: { autoIncrement: false, unique: false },
     description: { autoIncrement: false, unique: false },
-    installDate: { autoIncrement: false, unique: false },
+    studyStartDate: { autoIncrement: false, unique: false },
     studyEndDate: { autoIncrement: false, unique: false },
-    addonId: { autoIncrement: false, unique: true },
+    addonId: { autoIncrement: false, unique: false },
     active: { autoIncrement: false, unique: false },
   },
 };
 
+const dbName = "shield-studies";
+let database;
+
+async function getDatabase() {
+  if (!database) {
+    database = await IndexedDB.open(dbName, DB_OPTIONS, db => {
+      db.createObjectStore(dbName, { keyPath: "name" });
+    });
+  }
+  return database;
+}
+
 this.StudyStorage = {
-  dbName: "shield-studies",
-
-  async reset(clearData) {
-    if (this.database) {
-      if (clearData) {
-        await this.database.objectStore(this.dbName, "readwrite").clear();
-      }
-
-      await this.database.close();
-      this.database = null;
+  async clearAllData() {
+    if (database) {
+      await database.objectStore(dbName, "readwrite").clear();
     }
   },
 
-  async getDatabase() {
-    if (!this.database) {
-      this.database = await IndexedDB.open(this.dbName, DB_OPTIONS, db => {
-        db.createObjectStore(this.dbName, { keyPath: "addonId" });
-      });
+  async closeConnection() {
+    if (database) {
+      await database.close();
+      database = null;
     }
-
-    return this.database;
   },
 
-  async getStudyData(studyId) {
-    const db = await this.getDatabase();
+  async getStudy(studyName) {
+    const db = await getDatabase();
 
-    return await db.objectStore(this.dbName, "readwrite").get(studyId);
+    return db.objectStore(dbName, "readonly").get(studyName);
   },
 
-  async saveStudyData(study) {
+  async saveStudy(study) {
     const {
-      name, // The unique name for the experiment
+      name, // The unique name for the study
       version, // The add-on version
       description, // The add-on description
-      installDate = Date.now(), // The install date
+      studyStartDate = Date.now(), // The study start date
       studyEndDate = null, // The study end date (starts off null)
       addonId = study.id, // The add-on ID
       active = true, // The active status of the study (starts off true)
     } = study;
 
+    const db = await getDatabase();
 
-    const db = await this.getDatabase();
-
-    return await db.objectStore(this.dbName, "readwrite")
-      .put({
+    return db.objectStore(dbName, "readwrite")
+      .add({
         name,
         version,
         description,
-        installDate,
+        studyStartDate,
         studyEndDate,
         addonId,
         active,
       });
+  },
+
+  async updateStudy(study) {
+    const db = await getDatabase();
+
+    return db.objectStore(dbName, "readwrite").put(study);
   },
 };

--- a/recipe-client-addon/lib/StudyStorage.jsm
+++ b/recipe-client-addon/lib/StudyStorage.jsm
@@ -24,187 +24,147 @@
 
 const {utils: Cu} = Components;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
 XPCOMUtils.defineLazyModuleGetter(this, "IndexedDB", "resource://gre/modules/IndexedDB.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "ajv", "resource://shield-recipe-client/vendor/ajv.js");
 
 this.EXPORTED_SYMBOLS = ["StudyStorage"];
 
 const DB_NAME = "shield-studies";
-let gDatabase;
-
 const DB_OPTIONS = {
-  namespace: "shield-study-addons",
   version: 1,
   storage: "persistent",
-  schema: {
-    name: { type: "string", unique: true },
-    version: { type: "string" },
-    description: { type: "string" },
-    studyStartDate: { type: "number" },
-    studyEndDate: { type: "number" },
-    addonId: { type: "string", },
-    active: { type: "boolean" },
+};
+const DB_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    name: {
+      type: "string",
+    },
+    addonId: {
+      type: "string",
+    },
+    addonVersion: {
+      type: "string",
+    },
+    description: {
+      type: "string",
+    },
+    studyStartDate: {
+      type: "string",
+      format: "date-time",
+    },
+    studyEndDate: {
+      type: ["string", "null"],
+      format: "date-time",
+      default: null,
+    },
+    active: {
+      type: "boolean",
+      default: true,
+    },
   },
 };
+const CREATE_SCHEMA = Object.assign({}, DB_SCHEMA, {
+  required: [
+    "name",
+    "addonId",
+    "addonVersion",
+    "description",
+    "studyStartDate",
+  ],
+});
+const UPDATE_SCHEMA = DB_SCHEMA;
 
-// Compares a given `data` object against the DB_OPTIONS.schema. Throws if a key
-// that is not in the schema appears, or if the schema `type` does not match the
-// given value type.
-function validateSchema(data) {
-  const {schema} = DB_OPTIONS;
+const ajvInstance = new ajv({
+  allErrors: true,
+  useDefaults: true,
+});
+const validateCreate = ajvInstance.compile(CREATE_SCHEMA);
+const validateUpdate = ajvInstance.compile(UPDATE_SCHEMA);
 
-  Object.keys(data).forEach((dataKey) => {
-    const incomingData = data[dataKey];
-    const requiredType = schema[dataKey] && schema[dataKey].type;
-
-    if (!requiredType) {
-      throw new Error(`Key "${dataKey}" does not exist in Study schema.`);
-    }
-
-    // In some cases, the value will be empty, at which point we just want to
-    // skip the rest of validation.
-    if (typeof incomingData === "undefined" || incomingData === null) {
-      return;
-    }
-
-    // If the `type` is a function, it's going to be a class (like Map or Set),
-    // otherwise we can assume it is a primitive type (like "boolean" or "number").
-    const validates = typeof requiredType === "function" ?
-      incomingData instanceof requiredType : typeof incomingData === requiredType;
-
-    if (!validates) {
-      throw new Error(`Key "${dataKey}" must be of type "${requiredType.name || requiredType}"`);
-    }
-  });
-}
-
-
-// Creates new object store and populates that store's indexes.
-function setupDatabase(db) {
-  const {schema} = DB_OPTIONS;
-  const store = db.createObjectStore(DB_NAME, { keyPath: "name" });
-
-  Object.keys(schema).forEach((schemaKey) => {
-    store.createIndex(schemaKey, schemaKey, schema[schemaKey]);
-  });
-}
-
-// Determines if a DB connection/request already exists.
-function hasDatabaseRequest() {
-  return !!gDatabase;
-}
-
-// Returns the currently active IDB connection, and creates one if not
-// already present.
+/**
+ * Cache the database connection so that it is shared among multiple operations.
+ */
+let databasePromise;
 async function getDatabase() {
-  if (!hasDatabaseRequest()) {
-    // gDB is a Promise to prevent multiple calls to `IDB.open` - subsequent calls
-    // will refer to this same promise, requiring only one `open` call internally.
-    gDatabase = new Promise(async (resolve) => {
-      const db = await IndexedDB.open(DB_NAME, DB_OPTIONS, setupDatabase);
-      resolve(db);
+  if (!databasePromise) {
+    databasePromise = IndexedDB.open(DB_NAME, DB_OPTIONS, db => {
+      db.createObjectStore(DB_NAME, {
+        keyPath: "name",
+      });
     });
   }
-
-  return gDatabase;
+  return databasePromise;
 }
 
+/**
+ * Get a transaction for interacting with the study store.
+ *
+ * NOTE: Methods on the store returned by this function MUST be called
+ * synchronously, otherwise the transaction with the store will expire.
+ * This is why the helper takes a database as an argument; if we fetched the
+ * database in the helper directly, the helper would be async and the
+ * transaction would expire before methods on the store were called.
+ */
+function getStore(db) {
+  return db.objectStore(DB_NAME, "readwrite");
+}
 
 this.StudyStorage = {
-  /**
-   * Clears all data from the connected IndexedDB.
-   * @async
-   */
-  async clearAllData() {
+  async clear() {
     const db = await getDatabase();
-    await db.objectStore(DB_NAME, "readwrite").clear();
+    await getStore(db).clear();
   },
 
-  /**
-   * If a database exists and is connected, disconnect and remove the reference
-   * to that database.
-   *
-   * @async
-   */
-  async closeConnection() {
-    if (hasDatabaseRequest()) {
-      const db = await getDatabase();
+  async close() {
+    if (databasePromise) {
+      const db = await databasePromise;
       await db.close();
-      gDatabase = null;
+      databasePromise = null;
     }
   },
 
-  /**
-   * Look up a Study based on the given unique name. Returns `null` if no study
-   * is found in the DB.
-   *
-   * @async
-   * @param  {string} studyName Unique name of study to retrieve.
-   * @return {Promise<Study>}
-   */
-  async getStudy(studyName) {
+  async has(studyName) {
     const db = await getDatabase();
-
-    const foundStudy = await db.objectStore(DB_NAME, "readonly").get(studyName);
-
-    return foundStudy || null;
+    const study = await getStore(db).get(studyName);
+    return !!study;
   },
 
-  /**
-   * Given a Study, validates its schema and saves the data into the DB's
-   * objectStore instance.
-   *
-   * @async
-   * @param  {Study}  study [description]
-   * @return {Promise}
-   */
-  async saveStudy(study) {
-    const {
-      addonId, // The add-on ID
-      name, // The unique name for the study
-      version, // The add-on version
-      description, // The add-on description
-      studyStartDate = Date.now(), // The study start date
-      studyEndDate = null, // The study end date (starts off null)
-      active = true, // The active status of the study (starts off true)
-    } = study;
-
+  async get(studyName) {
     const db = await getDatabase();
-    const newStudy = {
-      name,
-      version,
-      description,
-      studyStartDate,
-      studyEndDate,
-      addonId,
-      active,
-    };
-
-    validateSchema(newStudy);
-
-    return db.objectStore(DB_NAME, "readwrite").add(newStudy);
-  },
-
-  /**
-   * Given a study name and an object of partial Study data, updates that
-   * study's values in-place and saves the changes back to the DB.
-   *
-   * @async
-   * @param  {string} studyName Unique name of the study to update.
-   * @param  {Study}  data      Object of data to update the study with.
-   */
-  async updateStudy(studyName, data) {
-    if (!studyName) {
-      throw new Error("StudyStorage - name is required to update study.");
+    const study = await getStore(db).get(studyName);
+    if (!study) {
+      throw new Error(`Could not find a study named ${studyName}.`);
     }
 
-    const savedStudy = await this.getStudy(studyName);
+    return study;
+  },
+
+  async create(study) {
+    if (!validateCreate(study)) {
+      throw new Error(
+        `Cannot create study: validation failed: ${ajvInstance.errorsText(validateCreate.errors)}`,
+      );
+    }
+
+    const db = await getDatabase();
+    return getStore(db).add(study);
+  },
+
+  async update(studyName, data) {
+    const db = await getDatabase();
+    const savedStudy = await getStore(db).get(studyName);
     if (!savedStudy) {
-      throw new Error(`StudyStorage - no study named "${studyName}" exists yet.`);
+      throw new Error(`Cannot update study ${studyName}: could not find study.`);
+    } else if (!validateUpdate(data)) {
+      throw new Error(`
+        Cannot update study ${studyName}: validation failed:
+        ${ajvInstance.errorsText(validateUpdate.errors)}
+      `);
     }
 
-    validateSchema(data);
-
-    const db = await getDatabase();
-    return db.objectStore(DB_NAME, "readwrite").put(Object.assign({}, savedStudy, data));
+    return getStore(db).put(Object.assign({}, savedStudy, data));
   },
 };

--- a/recipe-client-addon/lib/StudyStorage.jsm
+++ b/recipe-client-addon/lib/StudyStorage.jsm
@@ -6,7 +6,7 @@
  * @typedef {Object} Study
  * @property {string} name
  *   Unique name of the study
- * @property {number} version
+ * @property {string} version
  *   Study add-on version number
  * @property {string} description
  *   Description of the study and its intent.
@@ -28,81 +28,183 @@ XPCOMUtils.defineLazyModuleGetter(this, "IndexedDB", "resource://gre/modules/Ind
 
 this.EXPORTED_SYMBOLS = ["StudyStorage"];
 
+const DB_NAME = "shield-studies";
+let gDatabase;
+
 const DB_OPTIONS = {
   namespace: "shield-study-addons",
   version: 1,
   storage: "persistent",
   schema: {
-    name: { autoIncrement: false, unique: true },
-    version: { autoIncrement: false, unique: false },
-    description: { autoIncrement: false, unique: false },
-    studyStartDate: { autoIncrement: false, unique: false },
-    studyEndDate: { autoIncrement: false, unique: false },
-    addonId: { autoIncrement: false, unique: false },
-    active: { autoIncrement: false, unique: false },
+    name: { type: "string", unique: true },
+    version: { type: "string" },
+    description: { type: "string" },
+    studyStartDate: { type: "number" },
+    studyEndDate: { type: "number" },
+    addonId: { type: "string", },
+    active: { type: "boolean" },
   },
 };
 
-const dbName = "shield-studies";
-let database;
+// Compares a given `data` object against the DB_OPTIONS.schema. Throws if a key
+// that is not in the schema appears, or if the schema `type` does not match the
+// given value type.
+function validateSchema(data) {
+  const {schema} = DB_OPTIONS;
 
-async function getDatabase() {
-  if (!database) {
-    database = await IndexedDB.open(dbName, DB_OPTIONS, db => {
-      db.createObjectStore(dbName, { keyPath: "name" });
-    });
-  }
-  return database;
+  Object.keys(data).forEach((dataKey) => {
+    const incomingData = data[dataKey];
+    const requiredType = schema[dataKey] && schema[dataKey].type;
+
+    if (!requiredType) {
+      throw new Error(`Key "${dataKey}" does not exist in Study schema.`);
+    }
+
+    // In some cases, the value will be empty, at which point we just want to
+    // skip the rest of validation.
+    if (typeof incomingData === "undefined" || incomingData === null) {
+      return;
+    }
+
+    // If the `type` is a function, it's going to be a class (like Map or Set),
+    // otherwise we can assume it is a primitive type (like "boolean" or "number").
+    const validates = typeof requiredType === "function" ?
+      incomingData instanceof requiredType : typeof incomingData === requiredType;
+
+    if (!validates) {
+      throw new Error(`Key "${dataKey}" must be of type "${requiredType.name || requiredType}"`);
+    }
+  });
 }
 
+
+// Creates new object store and populates that store's indexes.
+function setupDatabase(db) {
+  const {schema} = DB_OPTIONS;
+  const store = db.createObjectStore(DB_NAME, { keyPath: "name" });
+
+  Object.keys(schema).forEach((schemaKey) => {
+    store.createIndex(schemaKey, schemaKey, schema[schemaKey]);
+  });
+}
+
+// Determines if a DB connection/request already exists.
+function hasDatabaseRequest() {
+  return !!gDatabase;
+}
+
+// Returns the currently active IDB connection, and creates one if not
+// already present.
+async function getDatabase() {
+  if (!hasDatabaseRequest()) {
+    // gDB is a Promise to prevent multiple calls to `IDB.open` - subsequent calls
+    // will refer to this same promise, requiring only one `open` call internally.
+    gDatabase = new Promise(async (resolve) => {
+      const db = await IndexedDB.open(DB_NAME, DB_OPTIONS, setupDatabase);
+      resolve(db);
+    });
+  }
+
+  return gDatabase;
+}
+
+
 this.StudyStorage = {
+  /**
+   * Clears all data from the connected IndexedDB.
+   * @async
+   */
   async clearAllData() {
-    if (database) {
-      await database.objectStore(dbName, "readwrite").clear();
-    }
+    const db = await getDatabase();
+    await db.objectStore(DB_NAME, "readwrite").clear();
   },
 
+  /**
+   * If a database exists and is connected, disconnect and remove the reference
+   * to that database.
+   *
+   * @async
+   */
   async closeConnection() {
-    if (database) {
-      await database.close();
-      database = null;
+    if (hasDatabaseRequest()) {
+      const db = await getDatabase();
+      await db.close();
+      gDatabase = null;
     }
   },
 
+  /**
+   * Look up a Study based on the given unique name. Returns `null` if no study
+   * is found in the DB.
+   *
+   * @async
+   * @param  {string} studyName Unique name of study to retrieve.
+   * @return {Promise<Study>}
+   */
   async getStudy(studyName) {
     const db = await getDatabase();
 
-    return db.objectStore(dbName, "readonly").get(studyName);
+    const foundStudy = await db.objectStore(DB_NAME, "readonly").get(studyName);
+
+    return foundStudy || null;
   },
 
+  /**
+   * Given a Study, validates its schema and saves the data into the DB's
+   * objectStore instance.
+   *
+   * @async
+   * @param  {Study}  study [description]
+   * @return {Promise}
+   */
   async saveStudy(study) {
     const {
+      addonId, // The add-on ID
       name, // The unique name for the study
       version, // The add-on version
       description, // The add-on description
       studyStartDate = Date.now(), // The study start date
       studyEndDate = null, // The study end date (starts off null)
-      addonId = study.id, // The add-on ID
       active = true, // The active status of the study (starts off true)
     } = study;
 
     const db = await getDatabase();
+    const newStudy = {
+      name,
+      version,
+      description,
+      studyStartDate,
+      studyEndDate,
+      addonId,
+      active,
+    };
 
-    return db.objectStore(dbName, "readwrite")
-      .add({
-        name,
-        version,
-        description,
-        studyStartDate,
-        studyEndDate,
-        addonId,
-        active,
-      });
+    validateSchema(newStudy);
+
+    return db.objectStore(DB_NAME, "readwrite").add(newStudy);
   },
 
-  async updateStudy(study) {
-    const db = await getDatabase();
+  /**
+   * Given a study name and an object of partial Study data, updates that
+   * study's values in-place and saves the changes back to the DB.
+   *
+   * @async
+   * @param  {string} studyName Unique name of the study to update.
+   * @param  {Study}  data      Object of data to update the study with.
+   */
+  async updateStudy(studyName, data) {
+    if (!studyName) {
+      throw new Error("StudyStorage - name is required to update study.");
+    }
 
-    return db.objectStore(dbName, "readwrite").put(study);
+    const savedStudy = await this.getStudy(studyName);
+    if (!savedStudy) {
+      throw new Error(`StudyStorage - no study named "${studyName}" exists yet.`);
+    }
+
+    validateSchema(data);
+
+    const db = await getDatabase();
+    return db.objectStore(DB_NAME, "readwrite").put(Object.assign({}, savedStudy, data));
   },
 };

--- a/recipe-client-addon/package.json
+++ b/recipe-client-addon/package.json
@@ -20,6 +20,7 @@
     "webpack": "3.1.0"
   },
   "dependencies": {
+    "ajv": "^5.2.1",
     "mozjexl": "1.1.5"
   }
 }

--- a/recipe-client-addon/test/browser/browser.ini
+++ b/recipe-client-addon/test/browser/browser.ini
@@ -7,6 +7,7 @@ head = head.js
 [browser_FilterExpressions.js]
 [browser_EventEmitter.js]
 [browser_Storage.js]
+[browser_StudyStorage.js]
 [browser_Heartbeat.js]
 [browser_RecipeRunner.js]
 [browser_LogManager.js]

--- a/recipe-client-addon/test/browser/browser_StudyStorage.js
+++ b/recipe-client-addon/test/browser/browser_StudyStorage.js
@@ -4,35 +4,31 @@ Cu.import("resource://shield-recipe-client/lib/StudyStorage.jsm", this);
 
 function withStudyStorage(testFn) {
   return async () => {
-    await testFn(StudyStorage);
-
-    await StudyStorage.clearAllData();
-    await StudyStorage.closeConnection();
+    try {
+      await testFn(StudyStorage);
+    } finally {
+      await StudyStorage.clearAllData();
+      await StudyStorage.closeConnection();
+    }
   };
 }
 
-// -------
-
 add_task(withStudyStorage(async function checkSaveStudy(storage) {
-  try {
-    await storage.saveStudy({
-      name: "hi",
-      version: 2,
-      description: "fake",
-      id: 12345
-    });
-  } catch (err) {
-    throw err;
-  }
+  await storage.saveStudy({
+    name: "Test study",
+    version: "2.0.0",
+    description: "fake",
+    addonId: "12345"
+  });
 }));
 
 // Test looking up study data
 add_task(withStudyStorage(async function checkGetStudy(storage) {
   const mockStudy = {
     name: "Test",
-    version: 2,
+    version: "2.0.0",
     description: "fake",
-    id: "12345"
+    addonId: "12345"
   };
 
   await storage.saveStudy(mockStudy);
@@ -44,27 +40,76 @@ add_task(withStudyStorage(async function checkGetStudy(storage) {
     "StudyStorage loaded version successfully using `getStudyData`.");
 }));
 
+// Test looking up nonexistant data
+add_task(withStudyStorage(async function checkGetMissingStudy(storage) {
+  const study = await storage.getStudy("Test");
+
+  is(study, null, "StudyStorage correctly returned `null` for a missing study.");
+}));
+
 
 // Test saving different data with the same `id`
 add_task(withStudyStorage(async function checkUpdateStudy(storage) {
 
   await storage.saveStudy({
-    name: "hey",
-    version: 1,
+    name: "Test Study",
+    version: "1.0.0",
     description: "fake",
-    id: "12345"
+    addonId: "12345"
   });
 
-  await storage.updateStudy({
-    name: "hey",
-    version: 123,
+  await storage.updateStudy("Test Study", {
+    version: "123.0.0",
     description: "test",
-    id: "12345"
+    addonId: "456"
   });
 
-  const savedStudy = await storage.getStudy("hey");
+  const savedStudy = await storage.getStudy("Test Study");
 
   ok(savedStudy, "saveStudyData correctly saved the study.");
-  is(savedStudy.name, "hey", "saveStudyData correctly updated the study name.");
-  is(savedStudy.version, 123, "saveStudyData correctly updated the study version");
+  is(savedStudy.name, "Test Study", "saveStudyData correctly updated the study name.");
+  is(savedStudy.version, "123.0.0", "saveStudyData correctly updated the study version");
+  is(savedStudy.addonId, "456", "saveStudyData correctly updated the study addon ID");
+}));
+
+// Test updating with incomplete data
+add_task(withStudyStorage(async function checkUpdateIncompleteStudy(storage) {
+  const mockStudy = {
+    name: "Test Study",
+    version: "500.0.0",
+    description: "fake",
+    addonId: "12345"
+  };
+
+  await storage.saveStudy(mockStudy);
+
+  await storage.updateStudy("Test Study", { description: "test" });
+
+  const savedStudy = await storage.getStudy("Test Study");
+
+  ok(savedStudy, "saveStudyData correctly saved the study.");
+  is(savedStudy.name, mockStudy.name, "saveStudyData correctly updated the study name.");
+  is(savedStudy.version, mockStudy.version, "saveStudyData correctly updated the study version.");
+  is(savedStudy.addonId, mockStudy.addonId, "saveStudyData correctly updated the study addonId.");
+  is(savedStudy.description, "test", "saveStudyData correctly updated the study description.");
+}));
+
+
+// Test creating with incorrect schema
+add_task(withStudyStorage(async function checkCreateInvalidSchema(storage) {
+  const mockStudy = {
+    name: 12345,
+    version: 500,
+    description: true,
+    addonId: new Map()
+  };
+
+  let didThrow = false;
+  try {
+    await storage.saveStudy(mockStudy);
+  } catch (e) {
+    didThrow = true;
+  }
+
+  ok(didThrow, "Invalid schema correctly threw errors.");
 }));

--- a/recipe-client-addon/test/browser/browser_StudyStorage.js
+++ b/recipe-client-addon/test/browser/browser_StudyStorage.js
@@ -2,53 +2,32 @@
 
 Cu.import("resource://shield-recipe-client/lib/StudyStorage.jsm", this);
 
+function withStudyStorage(testFn) {
+  return async () => {
+    await testFn(StudyStorage);
+
+    await StudyStorage.clearAllData();
+    await StudyStorage.closeConnection();
+  };
+}
+
 // -------
 
-add_task(async function checkReset() {
-  ok(!StudyStorage.database, "StudyStorage starts without an IDB instance.");
-
-  await StudyStorage.getDatabase();
-  ok(StudyStorage.database, "StudyStorage creates an IDB instance.");
-
-  await StudyStorage.reset();
-  ok(!StudyStorage.database, "StudyStorage correctly removes its IDB instance.");
-});
-
-add_task(async function checkGetDatabase() {
-  await StudyStorage.reset(true);
-  ok(!StudyStorage.database, "StudyStorage starts without an IDB instance.");
-
-  const db1 = await StudyStorage.getDatabase();
-  ok(db1, "StudyStorage creates an IDB instance.");
-
-  const db2 = await StudyStorage.getDatabase();
-  is(db1, db2, "StudyStorage creates only one IDB instance at a time.");
-});
-
-
-add_task(async function checkSaveStudy() {
-  await StudyStorage.reset(true);
-  let success = true;
-
+add_task(withStudyStorage(async function checkSaveStudy(storage) {
   try {
-    await StudyStorage.saveStudyData({
+    await storage.saveStudy({
       name: "hi",
       version: 2,
       description: "fake",
       id: 12345
     });
   } catch (err) {
-    success = false;
     throw err;
   }
-
-  ok(success, "StudyStorage saved data successfully using `saveStudyData`.");
-});
+}));
 
 // Test looking up study data
-add_task(async function checkGetStudyData() {
-  await StudyStorage.reset(true);
-
+add_task(withStudyStorage(async function checkGetStudy(storage) {
   const mockStudy = {
     name: "Test",
     version: 2,
@@ -56,37 +35,36 @@ add_task(async function checkGetStudyData() {
     id: "12345"
   };
 
-  await StudyStorage.saveStudyData(mockStudy);
+  await storage.saveStudy(mockStudy);
 
-  const study = await StudyStorage.getStudyData("12345");
+  const study = await storage.getStudy("Test");
 
   is(study.name, mockStudy.name, "StudyStorage loaded name successfully using `getStudyData`.");
   is(study.version, mockStudy.version,
     "StudyStorage loaded version successfully using `getStudyData`.");
-});
+}));
 
 
 // Test saving different data with the same `id`
-add_task(async function checkOverwriteStudy() {
-  await StudyStorage.reset(true);
+add_task(withStudyStorage(async function checkUpdateStudy(storage) {
 
-  await StudyStorage.saveStudyData({
+  await storage.saveStudy({
     name: "hey",
     version: 1,
     description: "fake",
     id: "12345"
   });
 
-  await StudyStorage.saveStudyData({
-    name: "hello",
-    version: 2,
-    description: "fake",
+  await storage.updateStudy({
+    name: "hey",
+    version: 123,
+    description: "test",
     id: "12345"
   });
 
-  let savedStudy = await StudyStorage.getStudyData("12345");
+  const savedStudy = await storage.getStudy("hey");
 
   ok(savedStudy, "saveStudyData correctly saved the study.");
-  is(savedStudy.name, "hello", "saveStudyData correctly updated the study name.");
-  is(savedStudy.version, 2, "saveStudyData correctly updated the study version");
-});
+  is(savedStudy.name, "hey", "saveStudyData correctly updated the study name.");
+  is(savedStudy.version, 123, "saveStudyData correctly updated the study version");
+}));

--- a/recipe-client-addon/test/browser/browser_StudyStorage.js
+++ b/recipe-client-addon/test/browser/browser_StudyStorage.js
@@ -1,0 +1,92 @@
+"use strict";
+
+Cu.import("resource://shield-recipe-client/lib/StudyStorage.jsm", this);
+
+// -------
+
+add_task(async function checkReset() {
+  ok(!StudyStorage.database, "StudyStorage starts without an IDB instance.");
+
+  await StudyStorage.getDatabase();
+  ok(StudyStorage.database, "StudyStorage creates an IDB instance.");
+
+  await StudyStorage.reset();
+  ok(!StudyStorage.database, "StudyStorage correctly removes its IDB instance.");
+});
+
+add_task(async function checkGetDatabase() {
+  await StudyStorage.reset(true);
+  ok(!StudyStorage.database, "StudyStorage starts without an IDB instance.");
+
+  const db1 = await StudyStorage.getDatabase();
+  ok(db1, "StudyStorage creates an IDB instance.");
+
+  const db2 = await StudyStorage.getDatabase();
+  is(db1, db2, "StudyStorage creates only one IDB instance at a time.");
+});
+
+
+add_task(async function checkSaveStudy() {
+  await StudyStorage.reset(true);
+  let success = true;
+
+  try {
+    await StudyStorage.saveStudyData({
+      name: "hi",
+      version: 2,
+      description: "fake",
+      id: 12345
+    });
+  } catch (err) {
+    success = false;
+    throw err;
+  }
+
+  ok(success, "StudyStorage saved data successfully using `saveStudyData`.");
+});
+
+// Test looking up study data
+add_task(async function checkGetStudyData() {
+  await StudyStorage.reset(true);
+
+  const mockStudy = {
+    name: "Test",
+    version: 2,
+    description: "fake",
+    id: "12345"
+  };
+
+  await StudyStorage.saveStudyData(mockStudy);
+
+  const study = await StudyStorage.getStudyData("12345");
+
+  is(study.name, mockStudy.name, "StudyStorage loaded name successfully using `getStudyData`.");
+  is(study.version, mockStudy.version,
+    "StudyStorage loaded version successfully using `getStudyData`.");
+});
+
+
+// Test saving different data with the same `id`
+add_task(async function checkOverwriteStudy() {
+  await StudyStorage.reset(true);
+
+  await StudyStorage.saveStudyData({
+    name: "hey",
+    version: 1,
+    description: "fake",
+    id: "12345"
+  });
+
+  await StudyStorage.saveStudyData({
+    name: "hello",
+    version: 2,
+    description: "fake",
+    id: "12345"
+  });
+
+  let savedStudy = await StudyStorage.getStudyData("12345");
+
+  ok(savedStudy, "saveStudyData correctly saved the study.");
+  is(savedStudy.name, "hello", "saveStudyData correctly updated the study name.");
+  is(savedStudy.version, 2, "saveStudyData correctly updated the study version");
+});

--- a/recipe-client-addon/webpack.config.js
+++ b/recipe-client-addon/webpack.config.js
@@ -6,6 +6,7 @@ var LicenseWebpackPlugin = require("license-webpack-plugin");
 module.exports = {
   context: __dirname,
   entry: {
+    ajv: "./node_modules/ajv/",
     mozjexl: "./node_modules/mozjexl/",
   },
   output: {


### PR DESCRIPTION
This is a continuation of #860. It also relies on #877; commits from 03dc6f9 onward are the interesting ones.

The biggest change between the last PR and this is the use of ajv for schema validation of data. I chose it over other schema validation or rolling our own because we already use JSONSchema elsewhere within Normandy, and I'd rather be consistent in our schemas. One mild downside of this is that types that we could actually store natively in IndexedDB, like dates, are instead stored as strings.