### PR TITLE
Fix CODEOWNERS glob for recipe-client-addon

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 * @mozilla/normandy-owners
 
 # add-on work needs to be reviewed by both a Firefox Peer and a comitter
-recipe-client-addon/* @mozilla/normandy-owners @mozilla/normandy-firefox-peers
+recipe-client-addon/** @mozilla/normandy-owners @mozilla/normandy-firefox-peers


### PR DESCRIPTION
Docs for the pattern format used here are here: https://git-scm.com/docs/gitignore

> Otherwise, Git treats the pattern as a shell glob suitable for consumption by fnmatch(3) with the FNM_PATHNAME flag: wildcards in the pattern will not match a / in the pathname. For example, `Documentation/*.html` matches `Documentation/git.html` but not `Documentation/ppc/ppc.html` or `tools/perf/Documentation/perf.html`.
>
> ...
>
> A trailing `/**` matches everything inside. For example, `abc/**` matches all files inside directory `abc`, relative to the location of the .gitignore file, with infinite depth.

