### PR TITLE
#873: New Clone Recipe page

### DIFF
--- a/recipe-server/client/control_new/components/common/FormActions.js
+++ b/recipe-server/client/control_new/components/common/FormActions.js
@@ -1,3 +1,4 @@
+import { Spin } from 'antd';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -16,18 +17,23 @@ import React from 'react';
  *   </FormActions.Secondary>
  * </FormActions>
  */
-export default function FormActions({ children }) {
+export default function FormActions({ children, isLoading }) {
+  const Wrapper = isLoading ? Spin : 'span';
   return (
     <div className="form-actions">
-      {children}
+      <Wrapper>
+        {children}
+      </Wrapper>
     </div>
   );
 }
 FormActions.propTypes = {
   children: PropTypes.node,
+  isLoading: PropTypes.bool,
 };
 FormActions.defaultProps = {
   children: null,
+  isLoading: false,
 };
 
 /**

--- a/recipe-server/client/control_new/components/common/LoadingOverlay.js
+++ b/recipe-server/client/control_new/components/common/LoadingOverlay.js
@@ -9,21 +9,21 @@ import { areAnyRequestsInProgress } from 'control_new/state/requests/selectors';
 export class SimpleLoadingOverlay extends React.Component {
   static propTypes = {
     children: PropTypes.any,
-    condition: PropTypes.bool,
+    visible: PropTypes.bool,
   };
 
   static defaultProps = {
     children: null,
-    condition: false,
+    visible: false,
   };
 
   render() {
     const {
       children,
-      condition,
+      visible,
     } = this.props;
 
-    const Wrapper = condition ? Spin : 'div';
+    const Wrapper = visible ? Spin : 'div';
 
     return (
       <Wrapper>
@@ -46,7 +46,7 @@ export default class LoadingOverlay extends React.Component {
 
   render() {
     return (
-      <SimpleLoadingOverlay condition={this.props.loading} {...this.props} />
+      <SimpleLoadingOverlay visible={this.props.loading} {...this.props} />
     );
   }
 }

--- a/recipe-server/client/control_new/components/common/LoadingOverlay.js
+++ b/recipe-server/client/control_new/components/common/LoadingOverlay.js
@@ -9,21 +9,21 @@ import { areAnyRequestsInProgress } from 'control_new/state/requests/selectors';
 export class SimpleLoadingOverlay extends React.Component {
   static propTypes = {
     children: PropTypes.any,
-    visible: PropTypes.bool,
+    isVisible: PropTypes.bool,
   };
 
   static defaultProps = {
     children: null,
-    visible: false,
+    isVisible: false,
   };
 
   render() {
     const {
       children,
-      visible,
+      isVisible,
     } = this.props;
 
-    const Wrapper = visible ? Spin : 'div';
+    const Wrapper = isVisible ? Spin : 'div';
 
     return (
       <Wrapper>
@@ -36,17 +36,17 @@ export class SimpleLoadingOverlay extends React.Component {
 
 @connect(
   state => ({
-    loading: areAnyRequestsInProgress(state),
+    isLoading: areAnyRequestsInProgress(state),
   }),
 )
 export default class LoadingOverlay extends React.Component {
   static propTypes = {
-    loading: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
   };
 
   render() {
     return (
-      <SimpleLoadingOverlay visible={this.props.loading} {...this.props} />
+      <SimpleLoadingOverlay isVisible={this.props.isLoading} {...this.props} />
     );
   }
 }

--- a/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
@@ -6,7 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link, push as pushAction } from 'redux-little-router';
 
-import LoadingOverlay from 'control_new/components/common/LoadingOverlay';
+import { SimpleLoadingOverlay } from 'control_new/components/common/LoadingOverlay';
 import RecipeForm from 'control_new/components/recipes/RecipeForm';
 import QueryRecipe from 'control_new/components/data/QueryRecipe';
 
@@ -64,11 +64,9 @@ export default class CloneRecipePage extends React.Component {
         'Recipe cannot be saved. Please correct any errors listed in the form below.',
       );
 
-      if (error) {
-        this.setState({
-          formErrors: error.data || error,
-        });
-      }
+      this.setState({
+        formErrors: error.data || error,
+      });
     }
   }
 
@@ -83,7 +81,7 @@ export default class CloneRecipePage extends React.Component {
     return (
       <div className="clone-page">
         <QueryRecipe pk={recipeId} />
-        <LoadingOverlay useCondition condition={!recipeName}>
+        <SimpleLoadingOverlay isVisible={!recipeName}>
           <h2>New Recipe</h2>
           { recipeName &&
             <h3>
@@ -96,7 +94,7 @@ export default class CloneRecipePage extends React.Component {
             onSubmit={this.handleSubmit}
             errors={this.state.formErrors}
           />
-        </LoadingOverlay>
+        </SimpleLoadingOverlay>
       </div>
     );
   }

--- a/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
@@ -1,18 +1,18 @@
-import { message, Button, Icon, Dropdown, Menu } from 'antd';
+import { message } from 'antd';
 import autobind from 'autobind-decorator';
 import { Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import { Link, push as pushAction } from 'redux-little-router';
 
-import { SimpleLoadingOverlay } from 'control_new/components/common/LoadingOverlay';
+import LoadingOverlay from 'control_new/components/common/LoadingOverlay';
 import RecipeForm from 'control_new/components/recipes/RecipeForm';
 import QueryRecipe from 'control_new/components/data/QueryRecipe';
 
-import { updateRecipe } from 'control_new/state/recipes/actions';
+import { createRecipe as createAction } from 'control_new/state/recipes/actions';
 import { getRecipe } from 'control_new/state/recipes/selectors';
 import { getRouterParamAsInt } from 'control_new/state/router/selectors';
-
 
 @connect(
   state => {
@@ -24,13 +24,14 @@ import { getRouterParamAsInt } from 'control_new/state/router/selectors';
     };
   },
   {
-    updateRecipe,
+    push: pushAction,
+    createRecipe: createAction,
   },
 )
 @autobind
-export default class EditRecipePage extends React.Component {
+export default class CloneRecipePage extends React.Component {
   static propTypes = {
-    updateRecipe: PropTypes.func.isRequired,
+    createRecipe: PropTypes.func.isRequired,
     recipeId: PropTypes.number.isRequired,
     recipe: PropTypes.instanceOf(Map),
   };
@@ -38,14 +39,6 @@ export default class EditRecipePage extends React.Component {
   static defaultProps = {
     recipe: null,
   };
-
-  static ActionMenu = (
-    <Menu>
-      <Menu.Item>
-        <a href="clone">Clone Recipe</a>
-      </Menu.Item>
-    </Menu>
-  );
 
   state = {
     formErrors: undefined,
@@ -55,14 +48,17 @@ export default class EditRecipePage extends React.Component {
    * Update the existing recipe and display a message.
    */
   async handleSubmit(values) {
-    const { recipeId } = this.props;
+    const { push } = this.props;
 
     try {
-      await this.props.updateRecipe(recipeId, values);
+      const newId = await this.props.createRecipe(values);
+
       message.success('Recipe saved');
       this.setState({
         formErrors: undefined,
       });
+
+      push(`/recipe/${newId}`);
     } catch (error) {
       message.error(
         'Recipe cannot be saved. Please correct any errors listed in the form below.',
@@ -78,27 +74,29 @@ export default class EditRecipePage extends React.Component {
 
   render() {
     const { recipe, recipeId } = this.props;
+
     const recipeName = recipe.get('name');
 
-    return (
-      <div className="edit-page">
-        <QueryRecipe pk={recipeId} />
-        <SimpleLoadingOverlay condition={!recipeName}>
-          <h2>Edit Recipe</h2>
+    // Remove the 'name' field value.
+    const displayedRecipe = recipe.set('name');
 
-          {
-            recipeName &&
-            <Dropdown overlay={EditRecipePage.ActionMenu} placement="bottomRight" trigger={['click']}>
-              <Button className="action-button"><Icon type="setting" /></Button>
-            </Dropdown>
+    return (
+      <div className="clone-page">
+        <QueryRecipe pk={recipeId} />
+        <LoadingOverlay useCondition condition={!recipeName}>
+          <h2>New Recipe</h2>
+          { recipeName &&
+            <h3>
+              Cloning recipe values from <Link href={`/recipe/${recipeId}`}>&quot;{ recipeName }&quot;</Link>
+            </h3>
           }
 
           <RecipeForm
-            recipe={recipe}
+            recipe={displayedRecipe}
             onSubmit={this.handleSubmit}
             errors={this.state.formErrors}
           />
-        </SimpleLoadingOverlay>
+        </LoadingOverlay>
       </div>
     );
   }

--- a/recipe-server/client/control_new/components/recipes/EditRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/EditRecipePage.js
@@ -83,7 +83,7 @@ export default class EditRecipePage extends React.Component {
     return (
       <div className="edit-page">
         <QueryRecipe pk={recipeId} />
-        <SimpleLoadingOverlay visible={!recipeName}>
+        <SimpleLoadingOverlay isVisible={!recipeName}>
           <h2>Edit Recipe</h2>
 
           {

--- a/recipe-server/client/control_new/components/recipes/EditRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/EditRecipePage.js
@@ -83,7 +83,7 @@ export default class EditRecipePage extends React.Component {
     return (
       <div className="edit-page">
         <QueryRecipe pk={recipeId} />
-        <SimpleLoadingOverlay condition={!recipeName}>
+        <SimpleLoadingOverlay visible={!recipeName}>
           <h2>Edit Recipe</h2>
 
           {

--- a/recipe-server/client/control_new/less/main.less
+++ b/recipe-server/client/control_new/less/main.less
@@ -143,3 +143,17 @@ fieldset {
     font-weight: bold;
   }
 }
+
+
+.ant-dropdown-menu-item.error {
+  background: @error-color;
+
+  & > a {
+    color: @white;
+  }
+
+  &:hover,
+  &:focus {
+    background: @red-7;
+  }
+}

--- a/recipe-server/client/control_new/less/pages/recipe_form.less
+++ b/recipe-server/client/control_new/less/pages/recipe_form.less
@@ -39,3 +39,27 @@
     }
   }
 }
+
+.edit-page {
+  h2 {
+    display: inline-block;
+  }
+
+  .action-button {
+    animation: opacityFadeIn 0.5s;
+    float: right;
+  }
+}
+
+@keyframes opacityFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.clone-page {
+  h3 {
+    font-size: 0.7em;
+    font-weight: 400;
+    margin-bottom: 1em;
+  }
+}

--- a/recipe-server/client/control_new/routes.js
+++ b/recipe-server/client/control_new/routes.js
@@ -7,6 +7,7 @@ import App from 'control_new/components/App';
 import CreateExtensionPage from 'control_new/components/extensions/CreateExtensionPage';
 import EditExtensionPage from 'control_new/components/extensions/EditExtensionPage';
 import CreateRecipePage from 'control_new/components/recipes/CreateRecipePage';
+import CloneRecipePage from 'control_new/components/recipes/CloneRecipePage';
 import EditRecipePage from 'control_new/components/recipes/EditRecipePage';
 import ExtensionListing from 'control_new/components/extensions/Listing';
 import Dummy from 'control_new/components/pages/Dummy';
@@ -32,6 +33,10 @@ const routes = {
         '/edit': {
           component: EditRecipePage,
           crumb: 'Edit Recipe',
+        },
+        '/clone': {
+          component: CloneRecipePage,
+          crumb: 'Clone Recipe',
         },
       },
     },


### PR DESCRIPTION
Fixes #873 
~Depends on PR #872~

- Adds `/clone` route to recipes
- Adds `CloneRecipePage` component
- Adds gear dropdown menu on `EditRecipePage` with link to clone page

This is probably going to require a rebase and some work from #858 , since the ticket requires the `revision` routes.