### PR TITLE
JEXL: explore AST traversal for JEXL

### DIFF
--- a/mozjexl/lib/Jexl.js
+++ b/mozjexl/lib/Jexl.js
@@ -18,6 +18,9 @@ function Jexl() {
 	this._customGrammar = null;
 	this._lexer = null;
 	this._transforms = {};
+	this.Lexer = Lexer;
+	this.Parser = Parser;
+	this.defaultGrammar = defaultGrammar;
 }
 
 /**

--- a/mozjexl/lib/idsintree.js
+++ b/mozjexl/lib/idsintree.js
@@ -1,0 +1,37 @@
+
+expression = process.argv[2] || 'normandy.clientId=="abced" && channel=="nightly"';
+console.log(`
+
+  EXPRESSION TO PARSE
+
+  ${expression}
+
+`)
+
+var Evaluator = require('./evaluator/Evaluator'),
+  Lexer = require('./Lexer'),
+  Parser = require('./parser/Parser'),
+  defaultGrammar = require('./grammar').elements;
+
+P = new Parser(defaultGrammar);
+P.addTokens(new Lexer(defaultGrammar).tokenize(expression))
+
+function findIdsInTree (jexlParseTree) {
+  const out = [];
+  const tree = jexlParseTree;
+  function recurse (tree) {
+    if (!tree) {
+      return
+    }
+    console.log(tree);
+    if (tree.type === "Identifier") {
+      out.push(tree.value);
+    }
+    recurse(tree.left);
+    recurse(tree.right);
+  };
+  recurse(tree);
+  return out;
+}
+out = findIdsInTree(P._tree);
+console.log(`\nidentifiers: ${JSON.stringify(out)}`)

--- a/mozjexl/lib/parser/Parser.js
+++ b/mozjexl/lib/parser/Parser.js
@@ -87,6 +87,7 @@ Parser.prototype.addToken = function(token) {
  */
 Parser.prototype.addTokens = function(tokens) {
 	tokens.forEach(this.addToken, this);
+	return this;
 };
 
 /**


### PR DESCRIPTION
Claim:
1.  we can do it.
2.  nested (dot) ids are a pain

usage:
cd lib
node idsintree.js [jexl]

Next:
1.  do we WANT to do this?
2.  expose what exactly?