### PR TITLE
fetch and run recipes early in startup

### DIFF
--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -203,6 +203,10 @@ this.ClientEnvironment = {
       return Utils.keyBy(addons, "id");
     });
 
+    XPCOMUtils.defineLazyGetter(environment, "isFirstRun", () => {
+      return Preferences.get("extensions.shield-recipe-client.first_run");
+    });
+
     return environment;
   },
 };

--- a/recipe-client-addon/lib/RecipeRunner.jsm
+++ b/recipe-client-addon/lib/RecipeRunner.jsm
@@ -42,6 +42,9 @@ const log = LogManager.getLogger("recipe-runner");
 const prefs = Services.prefs.getBranch("extensions.shield-recipe-client.");
 const TIMER_NAME = "recipe-client-addon-run";
 const RUN_INTERVAL_PREF = "run_interval_seconds";
+const FIRST_RUN_PREF = "first_run";
+const UI_AVAILABLE_NOTIFICATION = "sessionstore-windows-restored";
+const SHIELD_INIT_NOTIFICATION = "shield-init-complete";
 
 this.RecipeRunner = {
   init() {
@@ -54,6 +57,28 @@ this.RecipeRunner = {
       this.run();
     }
 
+    if (prefs.getBoolPref(FIRST_RUN_PREF)) {
+      // Run once immediately after the UI is available. Do this before adding the
+      // timer so we can't end up racing it.
+      const observer = {
+        observe: (subject, topic, data) => {
+          Services.obs.removeObserver(observer, UI_AVAILABLE_NOTIFICATION);
+
+          this.run();
+          this.registerTimer();
+          prefs.setBoolPref(FIRST_RUN_PREF, false);
+
+          Services.obs.notifyObservers(null, SHIELD_INIT_NOTIFICATION);
+        },
+      };
+      Services.obs.addObserver(observer, UI_AVAILABLE_NOTIFICATION);
+      CleanupManager.addCleanupHandler(() => Services.obs.removeObserver(observer, UI_AVAILABLE_NOTIFICATION));
+    } else {
+      this.registerTimer();
+    }
+  },
+
+  registerTimer() {
     this.updateRunInterval();
     CleanupManager.addCleanupHandler(() => timerManager.unregisterTimer(TIMER_NAME));
 

--- a/recipe-client-addon/lib/ShieldRecipeClient.jsm
+++ b/recipe-client-addon/lib/ShieldRecipeClient.jsm
@@ -39,6 +39,7 @@ const DEFAULT_PREFS = {
   "logging.level": Log.Level.Warn,
   user_id: "",
   run_interval_seconds: 86400, // 24 hours
+  first_run: true,
 };
 const PREF_DEV_MODE = "extensions.shield-recipe-client.dev_mode";
 const PREF_LOGGING_LEVEL = PREF_BRANCH + "logging.level";

--- a/recipe-client-addon/test/browser/browser_ClientEnvironment.js
+++ b/recipe-client-addon/test/browser/browser_ClientEnvironment.js
@@ -134,3 +134,16 @@ add_task(withDriver(Assert, async function testAddonsInContext(driver) {
 
   await driver.addons.uninstall(addonId);
 }));
+
+add_task(async function isFirstRun() {
+  let environment = ClientEnvironment.getEnvironment();
+
+  // isFirstRun is set to false after the recipe client runs
+  ok(!environment.isFirstRun, "isFirstRun has a default value");
+
+  // isFirstRun is read from a preference
+  await SpecialPowers.pushPrefEnv({set: [["extensions.shield-recipe-client.first_run", true]]});
+  environment = ClientEnvironment.getEnvironment();
+  ok(environment.isFirstRun, "isFirstRun is read from preferences");
+});
+

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -330,7 +330,13 @@ add_task(async function testStartup() {
   const updateRunIntervalStub = sinon.stub(RecipeRunner, "updateRunInterval");
 
   // in dev mode
-  await SpecialPowers.pushPrefEnv({set: [["extensions.shield-recipe-client.dev_mode", true]]});
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["extensions.shield-recipe-client.dev_mode", true],
+      ["extensions.shield-recipe-client.first_run", false],
+    ],
+  });
+
   RecipeRunner.init();
   ok(runStub.called, "RecipeRunner.run is called immediately when in dev mode");
   ok(addCleanupHandlerStub.called, "A cleanup function is registered when in dev mode");
@@ -341,7 +347,13 @@ add_task(async function testStartup() {
   updateRunIntervalStub.reset();
 
   // not in dev mode
-  await SpecialPowers.pushPrefEnv({set: [["extensions.shield-recipe-client.dev_mode", false]]});
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["extensions.shield-recipe-client.dev_mode", false],
+      ["extensions.shield-recipe-client.first_run", false],
+    ],
+  });
+
   RecipeRunner.init();
   ok(!runStub.called, "RecipeRunner.run is not called immediately when not in dev mode");
   ok(addCleanupHandlerStub.called, "A cleanup function is registered when not in dev mode");


### PR DESCRIPTION
This is just the first bit for issue #889 - do a first fetch+run of recipes and then creates the update timer after `"sessionstore-windows-restored"` has been observed.

