### PR TITLE
Minify webpack dependencies and run React in prod mode

### DIFF
--- a/recipe-client-addon/package.json
+++ b/recipe-client-addon/package.json
@@ -12,16 +12,16 @@
   },
   "devDependencies": {
     "babel-eslint": "7.2.3",
-    "babili-webpack-plugin": "^0.1.2",
+    "babili-webpack-plugin": "0.1.2",
     "eslint": "3.19.0",
     "eslint-config-normandy": "1.0.0",
     "eslint-plugin-babel": "4.1.1",
     "eslint-plugin-mozilla": "0.3.2",
-    "license-webpack-plugin": "^0.5.1",
+    "license-webpack-plugin": "0.5.1",
     "webpack": "3.1.0"
   },
   "dependencies": {
-    "ajv": "^5.2.1",
+    "ajv": "5.2.1",
     "mozjexl": "1.1.5"
   }
 }

--- a/recipe-client-addon/package.json
+++ b/recipe-client-addon/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "babel-eslint": "7.2.3",
+    "babili-webpack-plugin": "^0.1.2",
     "eslint": "3.19.0",
     "eslint-config-normandy": "1.0.0",
     "eslint-plugin-babel": "4.1.1",

--- a/recipe-client-addon/webpack.config.js
+++ b/recipe-client-addon/webpack.config.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 var path = require("path");
+var webpack = require("webpack");
 var ConcatSource = require("webpack-sources").ConcatSource;
 var LicenseWebpackPlugin = require("license-webpack-plugin");
 
@@ -16,6 +17,11 @@ module.exports = {
     libraryTarget: "this",
   },
   plugins: [
+    new webpack.DefinePlugin({
+      "process.env": {
+        NODE_ENV: JSON.stringify("production"),
+      },
+    }),
     /**
      * Plugin that appends "this.EXPORTED_SYMBOLS = ["libname"]" to assets
      * output by webpack. This allows built assets to be imported using

--- a/recipe-client-addon/webpack.config.js
+++ b/recipe-client-addon/webpack.config.js
@@ -3,6 +3,7 @@ var path = require("path");
 var webpack = require("webpack");
 var ConcatSource = require("webpack-sources").ConcatSource;
 var LicenseWebpackPlugin = require("license-webpack-plugin");
+var BabiliPlugin = require("babili-webpack-plugin");
 
 module.exports = {
   context: __dirname,
@@ -22,6 +23,7 @@ module.exports = {
         NODE_ENV: JSON.stringify("production"),
       },
     }),
+    new BabiliPlugin(),
     /**
      * Plugin that appends "this.EXPORTED_SYMBOLS = ["libname"]" to assets
      * output by webpack. This allows built assets to be imported using


### PR DESCRIPTION
- Adds Babili to minify the add-on dependencies. This saves almost a megabyte in the XPI with the dependencies added in #902.
- Sets NODE_ENV to production so that React (added in #902) runs in production mode, which skips some unnecessary checks. Long-term it'd be nice to disable this when the `dev_mode` pref is set, but I don't have the time to investigate that right now.

I'm only flagging mythmon since this only touches the webpack config for the add-on and not the actual code. I informally ran the idea of minifying by @Mossop to make sure this won't be a problem for the mozilla-central check-in.