### PR TITLE
Disable Django system check for HTTPOnly CSRF cookies.

### DIFF
--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -340,6 +340,12 @@ class Base(Core):
     AWS_SECRET_ACCESS_KEY = values.Value()
     AWS_STORAGE_BUCKET_NAME = values.Value()
 
+    SILENCED_SYSTEM_CHECKS = values.ListValue([
+        # Check CSRF cookie http only. disabled because we read the
+        # CSRF cookie in JS for forms in React.
+        'security.W017',
+    ])
+
 
 class Development(Base):
     """Settings for local development."""


### PR DESCRIPTION
We are purposely disabling HTTPOnly on the CSRF cookies because we are reading this cookie in JS for the new React forms.

We found while trying to deploy this branch to dev.