### PR TITLE
Cachebust addon taskcluster base image to pick up Rust 1.19.

### DIFF
--- a/addon-builder/Dockerfile
+++ b/addon-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:zesty
 WORKDIR /root
-ENV CACHEBUST=2017-06-12
+ENV CACHEBUST=2017-07-26
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-transport-https \
         curl \

--- a/addon-builder/dot.hgrc
+++ b/addon-builder/dot.hgrc
@@ -1,0 +1,5 @@
+[share]
+pool = /root/hgshare
+
+[extensions]
+robustcheckout = /root/version-control-tools/hgext/robustcheckout

--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -70,7 +70,7 @@ def main():
                 'deadline': fromNow('1 day'),
                 'expires': fromNow('365 days'),
                 'payload': {
-                    'image': 'mozilla/normandy-taskcluster:2017-06-12',
+                    'image': 'mozilla/normandy-taskcluster:2017-07-26',
                     'command': [
                         '/bin/bash',
                         '-c',


### PR DESCRIPTION
This fixes some Taskcluster breakage we saw.