### PR TITLE
#910: Fix broken approvals (new UI)

### DIFF
--- a/recipe-server/client/control_new/components/common/LoadingOverlay.js
+++ b/recipe-server/client/control_new/components/common/LoadingOverlay.js
@@ -9,24 +9,27 @@ import { areAnyRequestsInProgress } from 'control_new/state/app/requests/selecto
 export class SimpleLoadingOverlay extends React.Component {
   static propTypes = {
     children: PropTypes.any,
+    className: PropTypes.string,
     isVisible: PropTypes.bool,
   };
 
   static defaultProps = {
     children: null,
+    className: null,
     isVisible: false,
   };
 
   render() {
     const {
       children,
+      className,
       isVisible,
     } = this.props;
 
     const Wrapper = isVisible ? Spin : 'div';
 
     return (
-      <Wrapper>
+      <Wrapper className={className}>
         {children}
       </Wrapper>
     );

--- a/recipe-server/client/control_new/components/recipes/ApprovalDetails.js
+++ b/recipe-server/client/control_new/components/recipes/ApprovalDetails.js
@@ -1,0 +1,33 @@
+import { Map } from 'immutable';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default class ApprovalDetails extends React.PureComponent {
+  static propTypes = {
+    request: PropTypes.instanceOf(Map).isRequired,
+  };
+
+  render() {
+    const { request } = this.props;
+
+    return (
+      <dl className="details narrow">
+        <dt>
+          {request.get('approved') ? 'Approved' : 'Rejected'} by
+        </dt>
+        <dd>
+          {request.getIn(['approver', 'email'])}
+        </dd>
+
+        <dt>Responsed</dt>
+        <dd title={moment(request.get('created')).format('MMMM Do YYYY, h:mm a')}>
+          {moment(request.get('created')).fromNow()}
+        </dd>
+
+        <dt>Comment</dt>
+        <dd>{request.get('comment')}</dd>
+      </dl>
+    );
+  }
+}

--- a/recipe-server/client/control_new/components/recipes/ApprovalForm.js
+++ b/recipe-server/client/control_new/components/recipes/ApprovalForm.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import { SimpleLoadingOverlay } from 'control_new/components/common/LoadingOverlay';
 import FormActions from 'control_new/components/forms/FormActions';
 import FormItem from 'control_new/components/forms/FormItem';
 import {
@@ -26,7 +27,12 @@ export default class ApprovalForm extends React.Component {
     approvalRequest: PropTypes.instanceOf(Map).isRequired,
     closeApprovalRequest: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
-  }
+    isSubmitting: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    isSubmitting: false,
+  };
 
   handleApproveClick(event) {
     this.props.onSubmit(event, { approved: true });
@@ -47,26 +53,30 @@ export default class ApprovalForm extends React.Component {
   }
 
   render() {
+    const { isSubmitting } = this.props;
+
     return (
       <Form>
         <FormItem name="comment">
-          <Input placeholder="Comment" />
+          <Input placeholder="Comment" disabled={isSubmitting} />
         </FormItem>
-        <FormActions>
-          <FormActions.Primary>
-            <Button icon="dislike" onClick={this.handleRejectClick} type="danger">
-                Reject
+        <SimpleLoadingOverlay isVisible={isSubmitting}>
+          <FormActions>
+            <FormActions.Primary>
+              <Button icon="dislike" onClick={this.handleRejectClick} type="danger">
+                  Reject
+                </Button>
+              <Button icon="like" onClick={this.handleApproveClick} type="primary">
+                Approve
               </Button>
-            <Button icon="like" onClick={this.handleApproveClick} type="primary">
-              Approve
-            </Button>
-          </FormActions.Primary>
-          <FormActions.Secondary>
-            <Button icon="close-circle" onClick={this.handleCloseButtonClick}>
-              Close
-            </Button>
-          </FormActions.Secondary>
-        </FormActions>
+            </FormActions.Primary>
+            <FormActions.Secondary>
+              <Button icon="close-circle" onClick={this.handleCloseButtonClick}>
+                Close
+              </Button>
+            </FormActions.Secondary>
+          </FormActions>
+        </SimpleLoadingOverlay>
       </Form>
     );
   }

--- a/recipe-server/client/control_new/components/recipes/ApprovalRequest.js
+++ b/recipe-server/client/control_new/components/recipes/ApprovalRequest.js
@@ -7,6 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import ApprovalForm from 'control_new/components/recipes/ApprovalForm';
+import ApprovalDetails from 'control_new/components/recipes/ApprovalDetails';
 import RecipeDetails from 'control_new/components/recipes/RecipeDetails';
 import {
   approveApprovalRequest as approveApprovalRequestAction,
@@ -111,7 +112,7 @@ export default class ApprovalRequest extends React.Component {
         onSubmit={this.handleSubmit}
         errors={errors}
       />)
-      : <RequestDetails request={approvalRequest} />;
+      : <ApprovalDetails request={approvalRequest} />;
 
     return (
       <div className="approval-history-details">
@@ -140,35 +141,6 @@ export default class ApprovalRequest extends React.Component {
           </Col>
         </Row>
       </div>
-    );
-  }
-}
-
-class RequestDetails extends React.PureComponent {
-  static propTypes = {
-    request: PropTypes.instanceOf(Map).isRequired,
-  };
-
-  render() {
-    const { request } = this.props;
-
-    return (
-      <dl className="details narrow">
-        <dt>
-          {request.get('approved') ? 'Approved' : 'Rejected'} by
-        </dt>
-        <dd>
-          {request.getIn(['approver', 'email'])}
-        </dd>
-
-        <dt>Responsed</dt>
-        <dd title={moment(request.get('created')).format('MMMM Do YYYY, h:mm a')}>
-          {moment(request.get('created')).fromNow()}
-        </dd>
-
-        <dt>Comment</dt>
-        <dd>{request.get('comment')}</dd>
-      </dl>
     );
   }
 }


### PR DESCRIPTION
Fixes #910 

- Fixes `approvalApprovalRequest` typo (preventing approvals from working at all)
- Fixes `error.data.error` issues (error reported in #910)
- Changed the `LoadingOverlay`s in `ApprovalForm/Request` to not affect the approval form upon submission
  - Previously, any `comment` text would be wiped out due to the `LoadingOverlay` flipping the dom.

Ready for review. I've tagged @rehandalal and @mythmon , I reckon whoever gets to it first should be fine.