### PR TITLE
New UI: Split recipe loading overlays

### DIFF
--- a/recipe-server/client/control_new/components/common/LoadingOverlay.js
+++ b/recipe-server/client/control_new/components/common/LoadingOverlay.js
@@ -41,15 +41,15 @@ export class SimpleLoadingOverlay extends React.PureComponent {
 
 
 @connect(
-  (state, { requests }) => {
+  (state, { requestIds }) => {
     let isLoading;
 
     // If we're given one or more request IDs, check if at least one is in progress.
     // If nothing is given, simply check if _any_ request is in progress.
-    if (requests) {
-      let requestArray = requests;
+    if (requestIds) {
+      let requestArray = requestIds;
       if (!(requestArray instanceof Array)) {
-        requestArray = [requests];
+        requestArray = [requestIds];
       }
 
       isLoading = !!requestArray.find(reqId => isRequestInProgress(state, reqId));
@@ -65,11 +65,11 @@ export class SimpleLoadingOverlay extends React.PureComponent {
 export default class LoadingOverlay extends React.PureComponent {
   static propTypes = {
     isLoading: PropTypes.bool.isRequired,
-    requests: PropTypes.oneOf([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
+    requestIds: PropTypes.oneOf([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
   };
 
   static defaultProps = {
-    requests: null,
+    requestIds: null,
   };
 
   render() {

--- a/recipe-server/client/control_new/components/common/LoadingOverlay.js
+++ b/recipe-server/client/control_new/components/common/LoadingOverlay.js
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { areAnyRequestsInProgress } from 'control_new/state/app/requests/selectors';
+import {
+  areAnyRequestsInProgress,
+  isRequestInProgress,
+} from 'control_new/state/app/requests/selectors';
 
 
-export class SimpleLoadingOverlay extends React.Component {
+export class SimpleLoadingOverlay extends React.PureComponent {
   static propTypes = {
     children: PropTypes.any,
     className: PropTypes.string,
@@ -38,13 +41,35 @@ export class SimpleLoadingOverlay extends React.Component {
 
 
 @connect(
-  state => ({
-    isLoading: areAnyRequestsInProgress(state),
-  }),
+  (state, { requests }) => {
+    let isLoading;
+
+    // If we're given one or more request IDs, check if at least one is in progress.
+    // If nothing is given, simply check if _any_ request is in progress.
+    if (requests) {
+      let requestArray = requests;
+      if (!(requestArray instanceof Array)) {
+        requestArray = [requests];
+      }
+
+      isLoading = !!requestArray.find(reqId => isRequestInProgress(state, reqId));
+    } else {
+      isLoading = areAnyRequestsInProgress(state);
+    }
+
+    return {
+      isLoading,
+    };
+  },
 )
-export default class LoadingOverlay extends React.Component {
+export default class LoadingOverlay extends React.PureComponent {
   static propTypes = {
     isLoading: PropTypes.bool.isRequired,
+    requests: PropTypes.oneOf([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
+  };
+
+  static defaultProps = {
+    requests: null,
   };
 
   render() {

--- a/recipe-server/client/control_new/components/extensions/ExtensionListing.js
+++ b/recipe-server/client/control_new/components/extensions/ExtensionListing.js
@@ -120,7 +120,7 @@ export default class ExtensionListing extends React.Component {
 
         <ListingActionBar />
 
-        <LoadingOverlay requests={`fetch-extensions-page-${pageNumber}`}>
+        <LoadingOverlay requestIds={`fetch-extensions-page-${pageNumber}`}>
           <DataList
             columns={columns}
             columnRenderers={ExtensionListing.columnRenderers}

--- a/recipe-server/client/control_new/components/extensions/ExtensionListing.js
+++ b/recipe-server/client/control_new/components/extensions/ExtensionListing.js
@@ -120,7 +120,7 @@ export default class ExtensionListing extends React.Component {
 
         <ListingActionBar />
 
-        <LoadingOverlay>
+        <LoadingOverlay requests={`fetch-extensions-page-${pageNumber}`}>
           <DataList
             columns={columns}
             columnRenderers={ExtensionListing.columnRenderers}

--- a/recipe-server/client/control_new/components/recipes/ApprovalHistoryPage.js
+++ b/recipe-server/client/control_new/components/recipes/ApprovalHistoryPage.js
@@ -37,7 +37,7 @@ export default class ApprovalHistoryPage extends React.Component {
         <QueryRecipe pk={recipeId} />
         <QueryRecipeHistory pk={recipeId} />
 
-        <LoadingOverlay>
+        <LoadingOverlay requests={`fetch-recipe-history-${recipeId}`}>
           {
             history.map(revision => (
               <ApprovalRequest key={revision.get('id')} revision={revision} />

--- a/recipe-server/client/control_new/components/recipes/ApprovalHistoryPage.js
+++ b/recipe-server/client/control_new/components/recipes/ApprovalHistoryPage.js
@@ -37,7 +37,7 @@ export default class ApprovalHistoryPage extends React.Component {
         <QueryRecipe pk={recipeId} />
         <QueryRecipeHistory pk={recipeId} />
 
-        <LoadingOverlay requests={`fetch-recipe-history-${recipeId}`}>
+        <LoadingOverlay requestIds={`fetch-recipe-history-${recipeId}`}>
           {
             history.map(revision => (
               <ApprovalRequest key={revision.get('id')} revision={revision} />

--- a/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
@@ -96,7 +96,7 @@ export default class CloneRecipePage extends React.Component {
         <QueryRecipe pk={recipeId} />
         <QueryRevision pk={revisionId} />
 
-        <LoadingOverlay requests={[`fetch-recipe-${recipeId}`, `fetch-revision-${revisionId}`]}>
+        <LoadingOverlay requestIds={[`fetch-recipe-${recipeId}`, `fetch-revision-${revisionId}`]}>
           <h2>Clone Recipe</h2>
           { recipeName &&
             <Link href={recipeDetailsURL}>

--- a/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
@@ -6,7 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link, push as pushAction } from 'redux-little-router';
 
-import { SimpleLoadingOverlay } from 'control_new/components/common/LoadingOverlay';
+import LoadingOverlay from 'control_new/components/common/LoadingOverlay';
 import RecipeForm from 'control_new/components/recipes/RecipeForm';
 import QueryRecipe from 'control_new/components/data/QueryRecipe';
 import QueryRevision from 'control_new/components/data/QueryRevision';
@@ -96,7 +96,7 @@ export default class CloneRecipePage extends React.Component {
         <QueryRecipe pk={recipeId} />
         <QueryRevision pk={revisionId} />
 
-        <SimpleLoadingOverlay isVisible={!recipeName}>
+        <LoadingOverlay requests={[`fetch-recipe-${recipeId}`, `fetch-revision-${revisionId}`]}>
           <h2>Clone Recipe</h2>
           { recipeName &&
             <Link href={recipeDetailsURL}>
@@ -109,7 +109,7 @@ export default class CloneRecipePage extends React.Component {
             onSubmit={this.handleSubmit}
             errors={this.state.formErrors}
           />
-        </SimpleLoadingOverlay>
+        </LoadingOverlay>
       </div>
     );
   }

--- a/recipe-server/client/control_new/components/recipes/EditRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/EditRecipePage.js
@@ -76,7 +76,7 @@ export default class EditRecipePage extends React.Component {
     return (
       <div className="edit-page">
         <QueryRecipe pk={recipeId} />
-        <LoadingOverlay requests={`fetch-recipe-${recipeId}`}>
+        <LoadingOverlay requestIds={`fetch-recipe-${recipeId}`}>
           <h2>Edit Recipe</h2>
 
           <RecipeForm

--- a/recipe-server/client/control_new/components/recipes/EditRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/EditRecipePage.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { SimpleLoadingOverlay } from 'control_new/components/common/LoadingOverlay';
+import LoadingOverlay from 'control_new/components/common/LoadingOverlay';
 import RecipeForm from 'control_new/components/recipes/RecipeForm';
 import QueryRecipe from 'control_new/components/data/QueryRecipe';
 
@@ -72,12 +72,11 @@ export default class EditRecipePage extends React.Component {
 
   render() {
     const { recipe, recipeId } = this.props;
-    const recipeName = recipe.get('name');
 
     return (
       <div className="edit-page">
         <QueryRecipe pk={recipeId} />
-        <SimpleLoadingOverlay isVisible={!recipeName}>
+        <LoadingOverlay requests={`fetch-recipe-${recipeId}`}>
           <h2>Edit Recipe</h2>
 
           <RecipeForm
@@ -85,7 +84,7 @@ export default class EditRecipePage extends React.Component {
             onSubmit={this.handleSubmit}
             errors={this.state.formErrors}
           />
-        </SimpleLoadingOverlay>
+        </LoadingOverlay>
       </div>
     );
   }

--- a/recipe-server/client/control_new/components/recipes/HistoryTimeline.js
+++ b/recipe-server/client/control_new/components/recipes/HistoryTimeline.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'redux-little-router';
 
-import { SimpleLoadingOverlay } from 'control_new/components/common/LoadingOverlay';
+import LoadingOverlay from 'control_new/components/common/LoadingOverlay';
 import QueryRecipeHistory from 'control_new/components/data/QueryRecipeHistory';
 import RevisionApprovalTag from 'control_new/components/recipes/RevisionApprovalTag';
 import {
@@ -39,7 +39,7 @@ export default class HistoryTimeline extends React.Component {
     return (
       <div>
         <QueryRecipeHistory pk={recipeId} />
-        <SimpleLoadingOverlay isVisible={history.size === 0}>
+        <LoadingOverlay requests={`fetch-recipe-history-${recipeId}`}>
           <Timeline>
             {
               history.map((revision, index) => {
@@ -68,7 +68,7 @@ export default class HistoryTimeline extends React.Component {
               }).toArray()
             }
           </Timeline>
-        </SimpleLoadingOverlay>
+        </LoadingOverlay>
       </div>
     );
   }

--- a/recipe-server/client/control_new/components/recipes/HistoryTimeline.js
+++ b/recipe-server/client/control_new/components/recipes/HistoryTimeline.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'redux-little-router';
 
-import LoadingOverlay from 'control_new/components/common/LoadingOverlay';
+import { SimpleLoadingOverlay } from 'control_new/components/common/LoadingOverlay';
 import QueryRecipeHistory from 'control_new/components/data/QueryRecipeHistory';
 import RevisionApprovalTag from 'control_new/components/recipes/RevisionApprovalTag';
 import {
@@ -39,7 +39,7 @@ export default class HistoryTimeline extends React.Component {
     return (
       <div>
         <QueryRecipeHistory pk={recipeId} />
-        <LoadingOverlay>
+        <SimpleLoadingOverlay isVisible={history.size === 0}>
           <Timeline>
             {
               history.map((revision, index) => {
@@ -68,7 +68,7 @@ export default class HistoryTimeline extends React.Component {
               }).toArray()
             }
           </Timeline>
-        </LoadingOverlay>
+        </SimpleLoadingOverlay>
       </div>
     );
   }

--- a/recipe-server/client/control_new/components/recipes/HistoryTimeline.js
+++ b/recipe-server/client/control_new/components/recipes/HistoryTimeline.js
@@ -39,7 +39,7 @@ export default class HistoryTimeline extends React.Component {
     return (
       <div>
         <QueryRecipeHistory pk={recipeId} />
-        <LoadingOverlay requests={`fetch-recipe-history-${recipeId}`}>
+        <LoadingOverlay requestIds={`fetch-recipe-history-${recipeId}`}>
           <Timeline>
             {
               history.map((revision, index) => {

--- a/recipe-server/client/control_new/components/recipes/RecipeDetailPage.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeDetailPage.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import LoadingOverlay from 'control_new/components/common/LoadingOverlay';
+import { SimpleLoadingOverlay } from 'control_new/components/common/LoadingOverlay';
 import QueryRecipe from 'control_new/components/data/QueryRecipe';
 import DetailsActionBar from 'control_new/components/recipes/DetailsActionBar';
 import RecipeDetails from 'control_new/components/recipes/RecipeDetails';
@@ -50,12 +50,12 @@ export default class RecipeDetailPage extends React.Component {
           <Col span={16}>
             <DetailsActionBar />
             <RevisionNotice revision={revision} />
-            <LoadingOverlay>
+            <SimpleLoadingOverlay isVisible={!revision.get('recipe')}>
               <RecipeDetails recipe={revision.get('recipe', new Map())} />
-            </LoadingOverlay>
+            </SimpleLoadingOverlay>
           </Col>
           <Col span={8} className="recipe-history">
-            <Card title="History">
+            <Card className="card-no-hover" title="History">
               <HistoryTimeline
                 history={history}
                 recipeId={recipeId}

--- a/recipe-server/client/control_new/components/recipes/RecipeDetailPage.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeDetailPage.js
@@ -50,12 +50,12 @@ export default class RecipeDetailPage extends React.Component {
           <Col span={16}>
             <DetailsActionBar />
             <RevisionNotice revision={revision} />
-            <LoadingOverlay requests={[`fetch-recipe-${recipeId}`, `fetch-revision-${revisionId}`]}>
+            <LoadingOverlay requestIds={[`fetch-recipe-${recipeId}`, `fetch-revision-${revisionId}`]}>
               <RecipeDetails recipe={revision.get('recipe', new Map())} />
             </LoadingOverlay>
           </Col>
           <Col span={8} className="recipe-history">
-            <Card className="card-no-hover" title="History">
+            <Card className="noHovering" title="History">
               <HistoryTimeline
                 history={history}
                 recipeId={recipeId}

--- a/recipe-server/client/control_new/components/recipes/RecipeDetailPage.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeDetailPage.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { SimpleLoadingOverlay } from 'control_new/components/common/LoadingOverlay';
+import LoadingOverlay from 'control_new/components/common/LoadingOverlay';
 import QueryRecipe from 'control_new/components/data/QueryRecipe';
 import DetailsActionBar from 'control_new/components/recipes/DetailsActionBar';
 import RecipeDetails from 'control_new/components/recipes/RecipeDetails';
@@ -50,9 +50,9 @@ export default class RecipeDetailPage extends React.Component {
           <Col span={16}>
             <DetailsActionBar />
             <RevisionNotice revision={revision} />
-            <SimpleLoadingOverlay isVisible={!revision.get('recipe')}>
+            <LoadingOverlay requests={[`fetch-recipe-${recipeId}`, `fetch-revision-${revisionId}`]}>
               <RecipeDetails recipe={revision.get('recipe', new Map())} />
-            </SimpleLoadingOverlay>
+            </LoadingOverlay>
           </Col>
           <Col span={8} className="recipe-history">
             <Card className="card-no-hover" title="History">

--- a/recipe-server/client/control_new/components/recipes/RecipeDetails.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeDetails.js
@@ -14,7 +14,7 @@ export default class RecipeDetails extends React.Component {
 
     return (
       <div className="recipe-details">
-        <Card className="card-no-hover" key="recipe-details" title="Recipe">
+        <Card className="noHovering" key="recipe-details" title="Recipe">
           <dl className="details">
             <dt>Name</dt>
             <dd>{recipe.get('name')}</dd>
@@ -26,7 +26,7 @@ export default class RecipeDetails extends React.Component {
           </dl>
         </Card>
 
-        <Card className="card-no-hover" key="action-details" title="Action">
+        <Card className="noHovering" key="action-details" title="Action">
           <dl className="details">
             <dt>Name</dt>
             <dd>{recipe.getIn(['action', 'name'])}</dd>

--- a/recipe-server/client/control_new/components/recipes/RecipeDetails.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeDetails.js
@@ -14,7 +14,7 @@ export default class RecipeDetails extends React.Component {
 
     return (
       <div className="recipe-details">
-        <Card key="recipe-details" title="Recipe">
+        <Card className="card-no-hover" key="recipe-details" title="Recipe">
           <dl className="details">
             <dt>Name</dt>
             <dd>{recipe.get('name')}</dd>
@@ -26,7 +26,7 @@ export default class RecipeDetails extends React.Component {
           </dl>
         </Card>
 
-        <Card key="action-details" title="Action">
+        <Card className="card-no-hover" key="action-details" title="Action">
           <dl className="details">
             <dt>Name</dt>
             <dd>{recipe.getIn(['action', 'name'])}</dd>

--- a/recipe-server/client/control_new/components/recipes/RecipeListing.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeListing.js
@@ -179,7 +179,7 @@ export default class RecipeListing extends React.Component {
 
         <ListingActionBar />
 
-        <LoadingOverlay requests={requestId}>
+        <LoadingOverlay requestIds={requestId}>
           <DataList
             columns={columns}
             columnRenderers={RecipeListing.columnRenderers}

--- a/recipe-server/client/control_new/components/recipes/RecipeListing.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeListing.js
@@ -164,17 +164,22 @@ export default class RecipeListing extends React.Component {
   render() {
     const { columns, count, ordering, pageNumber, recipes, status } = this.props;
 
+    const filters = this.getFilters();
+
+    const filterIds = Object.keys(filters).map(key => `${key}-${filters[key]}`);
+    const requestId = `fetch-filtered-recipes-page-${pageNumber}-${filterIds.join('-')}`;
+
     return (
       <div>
         <QueryRecipeListingColumns />
         <QueryFilteredRecipes
           pageNumber={pageNumber}
-          filters={this.getFilters()}
+          filters={filters}
         />
 
         <ListingActionBar />
 
-        <LoadingOverlay>
+        <LoadingOverlay requests={requestId}>
           <DataList
             columns={columns}
             columnRenderers={RecipeListing.columnRenderers}

--- a/recipe-server/client/control_new/less/ant-override.less
+++ b/recipe-server/client/control_new/less/ant-override.less
@@ -20,3 +20,10 @@
 .ant-menu-submenu-title {
   background: rgba(0, 0, 0, 0.025);
 }
+
+// ant Card's `noHovering` doesn't seem to do anything, so this class makes up for it.
+.card-no-hover:hover,
+.card-no-hover:focus {
+  border-color: @border-color-split;
+  box-shadow: none;
+}

--- a/recipe-server/client/control_new/less/ant-override.less
+++ b/recipe-server/client/control_new/less/ant-override.less
@@ -22,8 +22,8 @@
 }
 
 // ant Card's `noHovering` doesn't seem to do anything, so this class makes up for it.
-.card-no-hover:hover,
-.card-no-hover:focus {
+.noHovering:hover,
+.noHovering:focus {
   border-color: @border-color-split;
   box-shadow: none;
 }

--- a/recipe-server/client/control_new/state/app/requests/selectors.js
+++ b/recipe-server/client/control_new/state/app/requests/selectors.js
@@ -8,7 +8,7 @@ export function getRequest(state, id, defaultsTo = DEFAULT_REQUEST) {
 
 export function isRequestInProgress(state, id) {
   const request = getRequest(state, id);
-  return request.get('inProgress');
+  return request.get('inProgress', false);
 }
 
 


### PR DESCRIPTION
- Swaps out `LoadingOverlay`s from `recipes/DetailPage` and `HistoryTimeline`
  - Previously, one request would lock up both sections of the Recipe Details page (the actual details, and the revision history)
  - With this approach, if the recipe loads before the history, it unlocks accordingly
- Adds `card-no-hover` CSS class to make up for the `noHovering` prop of `Card`s not working