### PR TITLE
Add -b/--build-vendor flag to add-on build scripts, disable auto-build.

### DIFF
--- a/docs/dev/recipe-client-addon/workflow.rst
+++ b/docs/dev/recipe-client-addon/workflow.rst
@@ -71,6 +71,9 @@ files:
    cd recipe-client-addon
    ./bin/make-xpi.sh # Creates /recipe-client-addon/shield-recipe-client.xpi
 
+Pass the ``-b``/``--build-vendor`` flag to auto-build vendor dependencies before
+creating the XPI.
+
 .. _recipe-client-sync:
 
 Sync changes to mozilla-central
@@ -83,6 +86,9 @@ checkout of mozilla-central. The files that are copied over are determined by
 
    cd recipe-client-addon
    ./bin/update-mozilla-central.sh /path/to/mozilla-central
+
+Pass the ``-b``/``--build-vendor`` flag to auto-build vendor dependencies before
+copying the files to the checkout.
 
 .. _recipe-client-tests:
 

--- a/docs/dev/recipe-client-addon/workflow.rst
+++ b/docs/dev/recipe-client-addon/workflow.rst
@@ -71,8 +71,9 @@ files:
    cd recipe-client-addon
    ./bin/make-xpi.sh # Creates /recipe-client-addon/shield-recipe-client.xpi
 
-Pass the ``-b``/``--build-vendor`` flag to auto-build vendor dependencies before
-creating the XPI.
+If the vendor directory hasn't been built, ``make-xpi.sh`` auto-builds it. Or,
+pass the ``-b``/``--build-vendor`` flag to force-build vendor dependencies
+before creating the XPI.
 
 .. _recipe-client-sync:
 
@@ -87,8 +88,9 @@ checkout of mozilla-central. The files that are copied over are determined by
    cd recipe-client-addon
    ./bin/update-mozilla-central.sh /path/to/mozilla-central
 
-Pass the ``-b``/``--build-vendor`` flag to auto-build vendor dependencies before
-copying the files to the checkout.
+If the vendor directory hasn't been built, ``update-mozilla-central.sh``
+auto-builds it. Or, pass the ``-b``/``--build-vendor`` flag to force-build
+vendor dependencies before copying files to the checkout.
 
 .. _recipe-client-tests:
 

--- a/recipe-client-addon/bin/make-xpi.sh
+++ b/recipe-client-addon/bin/make-xpi.sh
@@ -5,6 +5,22 @@ set -eu
 BASE_DIR="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")"
 TMP_DIR=$(mktemp -d)
 DEST="${TMP_DIR}/shield-recipe-client"
+BUILD_VENDOR=false
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+  -b|--build-vendor)
+  BUILD_VENDOR=true
+  ;;
+  *)
+  # unknown option
+  ;;
+esac
+shift # past argument
+done
 
 mkdir -p $DEST
 
@@ -15,9 +31,11 @@ function cleanup {
 trap cleanup EXIT
 
 # Build vendor files
-pushd $BASE_DIR
-npm run build
-popd
+if [[ "$BUILD_VENDOR" = true ]]; then
+  pushd $BASE_DIR
+  npm run build
+  popd
+fi
 
 while read -r LINE || [[ -n "${LINE}" ]]; do
   mkdir -p "$(dirname "${DEST}/${LINE}")"

--- a/recipe-client-addon/bin/make-xpi.sh
+++ b/recipe-client-addon/bin/make-xpi.sh
@@ -5,6 +5,7 @@ set -eu
 BASE_DIR="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")"
 TMP_DIR=$(mktemp -d)
 DEST="${TMP_DIR}/shield-recipe-client"
+VENDOR_DIR="${BASE_DIR}/vendor"
 BUILD_VENDOR=false
 
 while [[ $# -gt 0 ]]
@@ -31,7 +32,7 @@ function cleanup {
 trap cleanup EXIT
 
 # Build vendor files
-if [[ "$BUILD_VENDOR" = true ]]; then
+if [[ "$BUILD_VENDOR" = true || !(-d "$VENDOR_DIR") ]]; then
   pushd $BASE_DIR
   npm run build
   popd

--- a/recipe-client-addon/bin/tc/build_test.sh
+++ b/recipe-client-addon/bin/tc/build_test.sh
@@ -17,7 +17,7 @@ popd
 echo 'Syncing recipe-client-addon to mozilla-central...'
 pushd normandy/recipe-client-addon
 npm install
-./bin/update-mozilla-central.sh ../../mozilla-central/
+./bin/update-mozilla-central.sh --build-vendor ../../mozilla-central/
 popd
 
 echo 'Setting up environment'

--- a/recipe-client-addon/bin/tc/lint.sh
+++ b/recipe-client-addon/bin/tc/lint.sh
@@ -17,7 +17,7 @@ popd
 echo 'Syncing recipe-client-addon to mozilla-central...'
 pushd normandy/recipe-client-addon
 npm install
-./bin/update-mozilla-central.sh ../../mozilla-central/
+./bin/update-mozilla-central.sh --build-vendor ../../mozilla-central/
 popd
 
 echo 'Setting up environment'

--- a/recipe-client-addon/bin/tc/make-xpi.sh
+++ b/recipe-client-addon/bin/tc/make-xpi.sh
@@ -6,6 +6,6 @@ echo 'NPM install'
 npm install
 
 echo 'Making XPI'
-./bin/make-xpi.sh
+./bin/make-xpi.sh --build-vendor
 cp shield-recipe-client.xpi /artifacts/
 popd

--- a/recipe-client-addon/bin/update-mozilla-central.sh
+++ b/recipe-client-addon/bin/update-mozilla-central.sh
@@ -2,26 +2,46 @@
 
 set -eu
 
-if [[ $# -lt 1 ]]; then
-  echo "usage: $(basename $0) MOZ-CENTRAL" >&2
+baseDir="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
+mozCentral=""
+buildVendor=false
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+  -b|--build-vendor)
+  buildVendor=true
+  ;;
+  *)
+  # Assumed to be the path to mozilla-central
+  mozCentral=$key
+  ;;
+esac
+shift # past argument
+done
+
+if [[ -z "$mozCentral" ]]; then
+  echo "usage: $(basename $0) [-b|--build-vendor] MOZ-CENTRAL" >&2
   exit 1
 fi
 
-baseDir="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
-mozCentral="$1"
 dest="${mozCentral}/browser/extensions/shield-recipe-client"
 
 if [[ ! -d "$dest" ]]; then
-    echo "Sync destination $dest does not exist" >&2
-    exit 1
+  echo "Sync destination $dest does not exist" >&2
+  exit 1
 fi
 
 rm -rf "${dest}"/*
 
 # Build vendor files
-pushd $baseDir
-npm run build
-popd
+if [[ "$buildVendor" = true ]]; then
+  pushd $baseDir
+  npm run build
+  popd
+fi
 
 while read -r line || [[ -n "${line}" ]]; do
   mkdir -p "$(dirname "${dest}/${line}")"

--- a/recipe-client-addon/bin/update-mozilla-central.sh
+++ b/recipe-client-addon/bin/update-mozilla-central.sh
@@ -4,6 +4,7 @@ set -eu
 
 baseDir="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
 mozCentral=""
+vendorDir="${baseDir}/vendor"
 buildVendor=false
 
 while [[ $# -gt 0 ]]
@@ -36,8 +37,8 @@ fi
 
 rm -rf "${dest}"/*
 
-# Build vendor files
-if [[ "$buildVendor" = true ]]; then
+# Build vendor files if enabled or if vendor doesn't exist yet
+if [[ "$buildVendor" = true || !(-d "$vendorDir") ]]; then
   pushd $baseDir
   npm run build
   popd


### PR DESCRIPTION
I got tired of waiting for NPM to build when 99% of the time I don't need it to auto-build.

I, of course, am the one who made the scripts auto-build in the first place.