### PR TITLE
#927: Selenium ID's

### DIFF
--- a/recipe-server/client/control_new/components/pages/Gateway.js
+++ b/recipe-server/client/control_new/components/pages/Gateway.js
@@ -9,17 +9,17 @@ export default class Gateway extends React.Component {
     return (
       <Row className="page-gateway" type="flex" justify="space-around" align="top">
         <Col className="gw-col" xs={24} sm={10} md={8}>
-          <Card title="Recipes">
+          <Card title="Recipes" id="gw-recipes-card">
             <Icon type="book" />
             <p>Basic SHIELD recipes</p>
-            <Link href="/recipe">Go to Recipes</Link>
+            <Link href="/recipe" id="gw-recipes-link">Go to Recipes</Link>
           </Card>
         </Col>
         <Col className="gw-col" xs={24} sm={10} md={8}>
-          <Card title="Extensions">
+          <Card title="Extensions" id="gw-extensions-card">
             <Icon type="code" />
             <p>SHIELD WebExtensions</p>
-            <Link href="/extension">Go to Extensions</Link>
+            <Link href="/extension" id="gw-extensions-card">Go to Extensions</Link>
           </Card>
         </Col>
       </Row>

--- a/recipe-server/client/control_new/components/recipes/DetailsActionBar.js
+++ b/recipe-server/client/control_new/components/recipes/DetailsActionBar.js
@@ -108,20 +108,25 @@ export default class DetailsActionBar extends React.Component {
 
     return (
       <div className="details-action-bar clearfix">
-        <Link href={`${routerPath}/clone`}>
-          <Button icon="swap" type="primary">Clone</Button>
+        <Link href={`${routerPath}/clone`} id="dab-clone-link">
+          <Button icon="swap" type="primary" id="dab-clone-button">Clone</Button>
         </Link>
 
         {
           isLatest &&
-            <Link href={`/recipe/${recipeId}/edit`}>
-              <Button icon="edit" type="primary">Edit</Button>
+            <Link href={`/recipe/${recipeId}/edit`} id="dab-edit-link">
+              <Button icon="edit" type="primary" id="dab-edit-button">Edit</Button>
             </Link>
         }
 
         {
           isApprovable &&
-            <Button icon="question-circle" type="primary" onClick={this.handleRequestClick}>
+            <Button
+              icon="question-circle"
+              type="primary"
+              onClick={this.handleRequestClick}
+              id="dab-request-approval"
+            >
               Request Approval
             </Button>
         }
@@ -129,7 +134,7 @@ export default class DetailsActionBar extends React.Component {
         {
           isPendingApproval &&
             <Link href={`/recipe/${recipeId}/approval_history`}>
-              <Button icon="message" type="primary">Approval Request</Button>
+              <Button icon="message" type="primary" id="dab-approval-status">Approval Request</Button>
             </Link>
         }
 

--- a/recipe-server/client/control_new/components/recipes/ListingActionBar.js
+++ b/recipe-server/client/control_new/components/recipes/ListingActionBar.js
@@ -75,8 +75,8 @@ export default class ListingActionBar extends React.Component {
           />
         </Col>
         <Col span={8} className="righted">
-          <Link href="/recipe/new">
-            <Button type="primary" icon="plus">New Recipe</Button>
+          <Link href="/recipe/new" id="lab-recipe-link">
+            <Button type="primary" icon="plus" id="lab-recipe-button">New Recipe</Button>
           </Link>
         </Col>
       </Row>

--- a/recipe-server/client/control_new/components/recipes/PreferenceExperimentFields.js
+++ b/recipe-server/client/control_new/components/recipes/PreferenceExperimentFields.js
@@ -339,7 +339,12 @@ export class ExperimentBranchFields extends React.Component {
           name={`${fieldName}.slug`}
           connectToForm={false}
         >
-          <Input disabled={disabled} value={branch.get('slug', '')} onChange={this.handleChangeSlug} />
+          <Input
+            disabled={disabled}
+            value={branch.get('slug', '')}
+            onChange={this.handleChangeSlug}
+            id="pef-branch-name"
+          />
         </FormItem>
         <FormItem
           label="Preference Value"

--- a/recipe-server/client/control_new/components/recipes/RecipeForm.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeForm.js
@@ -102,7 +102,14 @@ export default class RecipeForm extends React.Component {
         )}
         <FormActions>
           <FormActions.Primary>
-            <Button type="primary" htmlType="submit" disabled={isLoading}>Save</Button>
+            <Button
+              type="primary"
+              htmlType="submit"
+              disabled={isLoading}
+              id="rf-save-button"
+            >
+              Save
+            </Button>
           </FormActions.Primary>
         </FormActions>
       </Form>
@@ -132,13 +139,19 @@ class ActionSelect extends React.Component {
     const stringValue = value ? value.toString(10) : undefined;
 
     return (
-      <Select placeholder="Select an action..." value={stringValue} {...props}>
-        {actions.toList().map(action => (
-          <Select.Option key={action.get('id')} value={action.get('id').toString(10)}>
-            {action.get('name')}
-          </Select.Option>
-        ))}
-      </Select>
+      <div id="rf-action-select">
+        <Select placeholder="Select an action..." value={stringValue} {...props}>
+          {actions.toList().map(action => (
+            <Select.Option
+              key={action.get('id')}
+              value={action.get('id').toString(10)}
+              id={`rf-${action.get('name')}`}
+            >
+              {action.get('name')}
+            </Select.Option>
+          ))}
+        </Select>
+      </div>
     );
   }
 }


### PR DESCRIPTION
Fixes #927 

- Adds ID's to select elements for use with Selenium tests

---

Regarding ID changes (this is for Emily):

- add a unique id for the recipes card on the home page
  - #gw-recipes-card
- add a unique id for the 'recipes' button on the recipes card
  - #gw-recipes-link
- add a unique id for the new recipe button
  - #lab-recipe-button
  - (also #lab-recipe-link for the a tag)
- add a unique id for the recipe action dropdown
  - Unfortunately, the react component we're using doesnt allow us to add an ID to it.
  - In fact, I don't think it uses a `select` element at all.
  - I've added an ID to a container div, hopefully this suffices: #rf-action-select
- add a unique id for the save button
  - #rf-save-button

- add a unique id or value for the console-log,  show_heartbeat, preference_experiment actions
  - The react component we're using doesn't allow us to add ID to the action options
  - However, you _should_ be able to select them like so: `.ant-select-selection-selected-value[title="console-log"]`

- add a unique id or value for the branch name
  - #pef-branch-name
- add a unique id for the request approval button
  - #dab-request-approval
  - Not to be confused with the `approval request` button (shown when a request is already open)
    - #dab-approval-status
- add a unique id or value for the edit button
  - #dab-edit-button
- add a unique id or value for the clone button
  - #dab-clone-button
- add a unique id the action name on the edit recipe page
  - I think this is a duplicate of the action-related ID's up above
