### PR TITLE
Fix #746: Add driver functions for reading preferences.

### DIFF
--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -188,5 +188,39 @@ this.NormandyDriver = function(sandboxManager) {
       getAll: sandboxManager.wrapAsync(AddonStudies.getAll, {cloneInto: true}),
       has: sandboxManager.wrapAsync(AddonStudies.has),
     },
+
+    // Preference read-only API
+    preferences: {
+      getBool: wrapPrefGetter(Services.prefs.getBoolPref),
+      getInt: wrapPrefGetter(Services.prefs.getIntPref),
+      getChar: wrapPrefGetter(Services.prefs.getCharPref),
+      has(name) {
+        return Services.prefs.getPrefType(name) !== Services.prefs.PREF_INVALID;
+      },
+    },
   };
 };
+
+/**
+ * Wrap a getter form nsIPrefBranch for use in the sandbox.
+ *
+ * We don't want to export the getters directly in case they add parameters that
+ * aren't safe for the sandbox without us noticing; wrapping helps prevent
+ * passing unknown parameters.
+ *
+ * @param {Function} getter
+ *   Function on an nsIPrefBranch that fetches a preference value.
+ * @return {Function}
+ */
+function wrapPrefGetter(getter) {
+  return (value, defaultValue = undefined) => {
+    // Passing undefined as the defaultValue disables throwing exceptions when
+    // the pref is missing or the type doesn't match, so we need to specifically
+    // exclude it if we don't want default value behavior.
+    const args = [value];
+    if (defaultValue !== undefined) {
+      args.push(defaultValue);
+    }
+    return getter.apply(null, args);
+  };
+}

--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -206,3 +206,87 @@ compose_task(
     `);
   }
 );
+
+compose_task(
+  withPrefEnv({
+    set: [
+      ["test.char", "a string"],
+      ["test.int", 5],
+      ["test.bool", true],
+    ],
+  }),
+  withSandboxManager(Assert, async function testPreferences(sandboxManager) {
+    const driver = new NormandyDriver(sandboxManager);
+    sandboxManager.cloneIntoGlobal("driver", driver, {cloneFunctions: true});
+
+    // Assertion helpers
+    sandboxManager.addGlobal("is", is);
+    sandboxManager.addGlobal("ok", ok);
+    sandboxManager.addGlobal("assertThrows", Assert.throws.bind(Assert));
+
+    await sandboxManager.evalInSandbox(`
+      (async function sandboxTest() {
+        ok(
+          driver.preferences.getBool("test.bool"),
+          "preferences.getBool can retrieve boolean preferences."
+        );
+        is(
+          driver.preferences.getInt("test.int"),
+          5,
+          "preferences.getInt can retrieve integer preferences."
+        );
+        is(
+          driver.preferences.getChar("test.char"),
+          "a string",
+          "preferences.getChar can retrieve string preferences."
+        );
+        assertThrows(
+          () => driver.preferences.getChar("test.int"),
+          "preferences.getChar throws when retreiving a non-string preference."
+        );
+        assertThrows(
+          () => driver.preferences.getInt("test.bool"),
+          "preferences.getInt throws when retreiving a non-integer preference."
+        );
+        assertThrows(
+          () => driver.preferences.getBool("test.char"),
+          "preferences.getBool throws when retreiving a non-boolean preference."
+        );
+        assertThrows(
+          () => driver.preferences.getChar("test.does.not.exist"),
+          "preferences.getChar throws when retreiving a non-existant preference."
+        );
+        assertThrows(
+          () => driver.preferences.getInt("test.does.not.exist"),
+          "preferences.getInt throws when retreiving a non-existant preference."
+        );
+        assertThrows(
+          () => driver.preferences.getBool("test.does.not.exist"),
+          "preferences.getBool throws when retreiving a non-existant preference."
+        );
+        ok(
+          driver.preferences.getBool("test.does.not.exist", true),
+          "preferences.getBool returns a default value if the preference doesn't exist."
+        );
+        is(
+          driver.preferences.getInt("test.does.not.exist", 7),
+          7,
+          "preferences.getInt returns a default value if the preference doesn't exist."
+        );
+        is(
+          driver.preferences.getChar("test.does.not.exist", "default"),
+          "default",
+          "preferences.getChar returns a default value if the preference doesn't exist."
+        );
+        ok(
+          driver.preferences.has("test.char"),
+          "preferences.has returns true if the given preference exists."
+        );
+        ok(
+          !driver.preferences.has("test.does.not.exist"),
+          "preferences.has returns false if the given preference does not exist."
+        );
+      })();
+    `);
+  })
+);


### PR DESCRIPTION
I opted to leave out checked whether a preference has a user-set value because I couldn't think of a reason we'd need that in an action.

I also opted to use a type-specific API similar to `nsIPrefBranch` to enforce type expectations (especially given recent issues around mis-typed preference values).