### PR TITLE
Fix #940: Mark studies as ended if their add-ons are uninstalled.

### DIFF
--- a/recipe-client-addon/lib/AddonStudies.jsm
+++ b/recipe-client-addon/lib/AddonStudies.jsm
@@ -137,8 +137,8 @@ this.AddonStudies = {
   },
 
   async init() {
-    // If the add-on an active study has been removed since we last ran, stop
-    // the study.
+    // If an active study's add-on has been removed since we last ran, stop the
+    // study.
     const activeStudies = (await this.getAll()).filter(study => study.active);
     const db = await getDatabase();
     for (const study of activeStudies) {

--- a/recipe-client-addon/lib/ShieldRecipeClient.jsm
+++ b/recipe-client-addon/lib/ShieldRecipeClient.jsm
@@ -19,6 +19,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "PreferenceExperiments",
   "resource://shield-recipe-client/lib/PreferenceExperiments.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "AboutPages",
   "resource://shield-recipe-client-content/AboutPages.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "AddonStudies",
+  "resource://shield-recipe-client/lib/AddonStudies.jsm");
 
 this.EXPORTED_SYMBOLS = ["ShieldRecipeClient"];
 
@@ -70,6 +72,12 @@ this.ShieldRecipeClient = {
       await AboutPages.init();
     } catch (err) {
       log.error("Failed to initialize about pages:", err);
+    }
+
+    try {
+      await AddonStudies.init();
+    } catch (err) {
+      log.error("Failed to initialize addon studies:", err);
     }
 
     // Initialize experiments first to avoid a race between initializing prefs

--- a/recipe-client-addon/test/browser/browser_AddonStudies.js
+++ b/recipe-client-addon/test/browser/browser_AddonStudies.js
@@ -9,7 +9,7 @@ Cu.import("resource://shield-recipe-client/lib/AddonStudies.jsm", this);
 // Initialize test utils
 AddonTestUtils.initMochitest(this);
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies(),
   async function testGetMissing() {
     is(
@@ -20,7 +20,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory({name: "test-study"}),
   ]),
@@ -30,7 +30,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory(),
     studyFactory(),
@@ -45,7 +45,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory({name: "test-study"}),
   ]),
@@ -58,7 +58,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies(),
   async function testCloseDatabase() {
     await AddonStudies.close();
@@ -82,7 +82,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory({name: "test-study1"}),
     studyFactory({name: "test-study2"}),
@@ -126,7 +126,7 @@ add_task(async function testStartRequiredArguments() {
   }
 });
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory(),
   ]),
@@ -139,7 +139,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withStub(Addons, "applyInstall"),
   withWebExtension(),
   async function testStartAddonCleanup(applyInstallStub, [addonId, addonFile]) {
@@ -158,7 +158,7 @@ compose_task(
 );
 
 const testOverwriteId = "testStartAddonNoOverwrite@example.com";
-compose_task(
+decorate_task(
   withInstalledWebExtension({version: "1.0", id: testOverwriteId}),
   withWebExtension({version: "2.0", id: testOverwriteId}),
   async function testStartAddonNoOverwrite([installedId, installedFile], [id, addonFile]) {
@@ -173,7 +173,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withWebExtension({version: "2.0"}),
   async function testStart([addonId, addonFile]) {
     const startupPromise = AddonTestUtils.promiseWebExtensionStartup(addonId);
@@ -214,7 +214,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies(),
   async function testStopNoStudy() {
     await Assert.rejects(
@@ -225,7 +225,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory({active: false}),
   ]),
@@ -239,7 +239,7 @@ compose_task(
 );
 
 const testStopId = "testStop@example.com";
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory({active: true, addonId: testStopId, studyEndDate: null}),
   ]),
@@ -255,7 +255,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory({active: true, addonId: "testStopWarn@example.com", studyEndDate: null}),
   ]),
@@ -273,7 +273,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory({active: true, addonId: "does.not.exist@example.com", studyEndDate: null}),
     studyFactory({active: true, addonId: "installed@example.com"}),
@@ -306,7 +306,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     studyFactory({active: true, addonId: "installed@example.com", studyEndDate: null}),
   ]),

--- a/recipe-client-addon/test/browser/browser_Addons.js
+++ b/recipe-client-addon/test/browser/browser_Addons.js
@@ -8,7 +8,7 @@ Cu.import("resource://shield-recipe-client/lib/Addons.jsm", this);
 AddonTestUtils.initMochitest(this);
 
 const testInstallId = "testInstallUpdate@example.com";
-compose_task(
+decorate_task(
   withInstalledWebExtension({version: "1.0", id: testInstallId}),
   withWebExtension({version: "2.0", id: testInstallId}),
   async function testInstallUpdate([id1, addonFile1], [id2, addonFile2]) {

--- a/recipe-client-addon/test/browser/browser_Addons.js
+++ b/recipe-client-addon/test/browser/browser_Addons.js
@@ -9,15 +9,9 @@ AddonTestUtils.initMochitest(this);
 
 const testInstallId = "testInstallUpdate@example.com";
 compose_task(
-  withWebExtension({version: "1.0", id: testInstallId}),
+  withInstalledWebExtension({version: "1.0", id: testInstallId}),
   withWebExtension({version: "2.0", id: testInstallId}),
   async function testInstallUpdate([id1, addonFile1], [id2, addonFile2]) {
-    // Install 1.0 add-on
-    let startupPromise = AddonTestUtils.promiseWebExtensionStartup(testInstallId);
-    const installedAddonUrl = Services.io.newFileURI(addonFile1).spec;
-    await Addons.install(installedAddonUrl);
-    await startupPromise;
-
     // Fail to install the 2.0 add-on without updating enabled
     const newAddonUrl = Services.io.newFileURI(addonFile2).spec;
     await Assert.rejects(
@@ -27,7 +21,7 @@ compose_task(
     );
 
     // Install the new add-on with updating enabled
-    startupPromise = AddonTestUtils.promiseWebExtensionStartup(testInstallId);
+    const startupPromise = AddonTestUtils.promiseWebExtensionStartup(testInstallId);
     await Addons.install(newAddonUrl, {update: true});
 
     const addon = await startupPromise;
@@ -36,7 +30,5 @@ compose_task(
       "2.0",
       "install can successfully update an already-installed addon when updating is enabled."
     );
-
-    await Addons.uninstall(testInstallId);
   }
 );

--- a/recipe-client-addon/test/browser/browser_EventEmitter.js
+++ b/recipe-client-addon/test/browser/browser_EventEmitter.js
@@ -26,7 +26,7 @@ function listenerC(x = 1) {
   evidence.log += "c";
 }
 
-compose_task(
+decorate_task(
   withSandboxManager(Assert),
   async function(sandboxManager) {
     const eventEmitter = new EventEmitter(sandboxManager);
@@ -100,7 +100,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withSandboxManager(Assert),
   async function sandboxedEmitter(sandboxManager) {
     const eventEmitter = new EventEmitter(sandboxManager);

--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -84,7 +84,7 @@ add_task(withDriver(Assert, async function distribution(driver) {
   is(client.distribution, "funnelcake", "distribution is read from preferences");
 }));
 
-compose_task(
+decorate_task(
   withSandboxManager(Assert),
   async function testCreateStorage(sandboxManager) {
     const driver = new NormandyDriver(sandboxManager);
@@ -149,7 +149,7 @@ add_task(withDriver(Assert, async function getAddon(driver, sandboxManager) {
   Assert.equal(addon, null, "Add-on has been uninstalled");
 }));
 
-compose_task(
+decorate_task(
   withSandboxManager(Assert),
   async function testAddonsGetWorksInSandbox(sandboxManager) {
     const driver = new NormandyDriver(sandboxManager);
@@ -182,7 +182,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withSandboxManager(Assert),
   AddonStudies.withStudies([
     studyFactory({name: "test-study", addonVersion: "5.0"}),

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -324,7 +324,7 @@ add_task(withMockNormandyApi(async function testLoadActionSandboxManagers(mockAp
   );
 }));
 
-compose_task(
+decorate_task(
   withPrefEnv({
     set: [
       ["extensions.shield-recipe-client.dev_mode", true],
@@ -342,7 +342,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withPrefEnv({
     set: [
       ["extensions.shield-recipe-client.dev_mode", false],
@@ -360,7 +360,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withPrefEnv({
     set: [
       ["extensions.shield-recipe-client.dev_mode", false],

--- a/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
+++ b/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
@@ -4,50 +4,64 @@ Cu.import("resource://shield-recipe-client/lib/ShieldRecipeClient.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/RecipeRunner.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm", this);
 Cu.import("resource://shield-recipe-client-content/AboutPages.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/AddonStudies.jsm", this);
 
-add_task(async function testStartup() {
-  sinon.stub(RecipeRunner, "init");
-  sinon.stub(PreferenceExperiments, "init");
-  sinon.stub(AboutPages, "init");
+function withStubInits(testFunction) {
+  return compose(
+    withStub(AboutPages, "init"),
+    withStub(AddonStudies, "init"),
+    withStub(PreferenceExperiments, "init"),
+    withStub(RecipeRunner, "init"),
+    testFunction
+  );
+}
 
-  await ShieldRecipeClient.startup();
-  ok(AboutPages.init.called, "startup calls AboutPages.init");
-  ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
-  ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+compose_task(
+  withStubInits,
+  async function testStartup() {
+    await ShieldRecipeClient.startup();
+    ok(AboutPages.init.called, "startup calls AboutPages.init");
+    ok(AddonStudies.init.called, "startup calls AddonStudies.init");
+    ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
+    ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+  }
+);
 
-  PreferenceExperiments.init.restore();
-  RecipeRunner.init.restore();
-  AboutPages.init.restore();
-});
+compose_task(
+  withStubInits,
+  async function testStartupPrefInitFail() {
+    PreferenceExperiments.init.returns(Promise.reject(new Error("oh no")));
 
-add_task(async function testStartupPrefInitFail() {
-  sinon.stub(RecipeRunner, "init");
-  sinon.stub(PreferenceExperiments, "init").returns(Promise.reject(new Error("oh no")));
-  sinon.stub(AboutPages, "init");
+    await ShieldRecipeClient.startup();
+    ok(AboutPages.init.called, "startup calls AboutPages.init");
+    ok(AddonStudies.init.called, "startup calls AddonStudies.init");
+    ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
+    ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+  }
+);
 
-  await ShieldRecipeClient.startup();
-  ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
-  // Even if PreferenceExperiments.init fails, other init functions should be called.
-  ok(AboutPages.init.called, "startup calls AboutPages.init");
-  ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+compose_task(
+  withStubInits,
+  async function testStartupAboutPagesInitFail() {
+    AboutPages.init.returns(Promise.reject(new Error("oh no")));
 
-  PreferenceExperiments.init.restore();
-  RecipeRunner.init.restore();
-  AboutPages.init.restore();
-});
+    await ShieldRecipeClient.startup();
+    ok(AboutPages.init.called, "startup calls AboutPages.init");
+    ok(AddonStudies.init.called, "startup calls AddonStudies.init");
+    ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
+    ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+  }
+);
 
-add_task(async function testStartupAboutPagesInitFail() {
-  sinon.stub(RecipeRunner, "init");
-  sinon.stub(PreferenceExperiments, "init");
-  sinon.stub(AboutPages, "init").returns(Promise.reject(new Error("oh no")));
+compose_task(
+  withStubInits,
+  async function testStartupAddonStudiesInitFail() {
+    AddonStudies.init.returns(Promise.reject(new Error("oh no")));
 
-  await ShieldRecipeClient.startup();
-  ok(AboutPages.init.called, "startup calls AboutPages.init");
-  // Even if PreferenceExperiments.init fails, other init functions should be called.
-  ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
-  ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
-
-  PreferenceExperiments.init.restore();
-  RecipeRunner.init.restore();
-  AboutPages.init.restore();
-});
+    await ShieldRecipeClient.startup();
+    ok(AboutPages.init.called, "startup calls AboutPages.init");
+    ok(AddonStudies.init.called, "startup calls AddonStudies.init");
+    ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
+    ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+  }
+);

--- a/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
+++ b/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
@@ -7,7 +7,7 @@ Cu.import("resource://shield-recipe-client-content/AboutPages.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/AddonStudies.jsm", this);
 
 function withStubInits(testFunction) {
-  return compose(
+  return decorate(
     withStub(AboutPages, "init"),
     withStub(AddonStudies, "init"),
     withStub(PreferenceExperiments, "init"),
@@ -16,7 +16,7 @@ function withStubInits(testFunction) {
   );
 }
 
-compose_task(
+decorate_task(
   withStubInits,
   async function testStartup() {
     await ShieldRecipeClient.startup();
@@ -27,7 +27,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withStubInits,
   async function testStartupPrefInitFail() {
     PreferenceExperiments.init.returns(Promise.reject(new Error("oh no")));
@@ -40,7 +40,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withStubInits,
   async function testStartupAboutPagesInitFail() {
     AboutPages.init.returns(Promise.reject(new Error("oh no")));
@@ -53,7 +53,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withStubInits,
   async function testStartupAddonStudiesInitFail() {
     AddonStudies.init.returns(Promise.reject(new Error("oh no")));

--- a/recipe-client-addon/test/browser/browser_about_studies.js
+++ b/recipe-client-addon/test/browser/browser_about_studies.js
@@ -11,14 +11,14 @@ function withAboutStudies(testFunc) {
   );
 }
 
-compose_task(
+decorate_task(
   withAboutStudies,
   async function testAboutStudiesWorks(browser) {
     ok(browser.contentDocument.getElementById("app"), "App element was found");
   }
 );
 
-compose_task(
+decorate_task(
   withPrefEnv({
     set: [["extensions.shield-recipe-client.shieldLearnMoreUrl", "http://test/%OS%/"]],
   }),
@@ -39,7 +39,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withPrefEnv({
     set: [["browser.preferences.useOldOrganization", false]],
   }),
@@ -58,7 +58,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   withPrefEnv({
     set: [["browser.preferences.useOldOrganization", true]],
   }),
@@ -93,7 +93,7 @@ compose_task(
   }
 );
 
-compose_task(
+decorate_task(
   AddonStudies.withStudies([
     // Sort order should be study3, study1, study2 (order by enabled, then most recent).
     studyFactory({

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -73,7 +73,7 @@ this.withWebExtension = function(manifestOverrides = {}) {
 
 this.withInstalledWebExtension = function(manifestOverrides = {}) {
   return function wrapper(testFunction) {
-    return compose(
+    return decorate(
       withWebExtension(manifestOverrides),
       async function wrappedTestFunction(...args) {
         const [id, file] = args[args.length - 1];
@@ -207,14 +207,25 @@ this.withPrefEnv = function(inPrefs) {
   };
 };
 
-this.compose = function(...args) {
+/**
+ * Combine a list of functions right to left. The rightmost function is passed
+ * to the preceeding function as the argument; the result of this is passed to
+ * the next function until all are exhausted. For example, this:
+ *
+ * decorate(func1, func2, func3);
+ *
+ * is equivalent to this:
+ *
+ * func1(func2(func3));
+ */
+this.decorate = function(...args) {
   const funcs = Array.from(args);
-  let composed = funcs.pop();
+  let decorated = funcs.pop();
   funcs.reverse();
   for (const func of funcs) {
-    composed = func(composed);
+    decorated = func(decorated);
   }
-  return composed;
+  return decorated;
 };
 
 /**
@@ -222,12 +233,12 @@ this.compose = function(...args) {
  * wrappers. The last argument should be your test function; all other arguments
  * should be functions that accept a single test function argument.
  *
- * The arguments are composed together and passed to add_task as a single test
- * function.
+ * The arguments are combined using decorate and passed to add_task as a single
+ * test function.
  *
  * @param {[Function]} args
  * @example
- *   compose_task(
+ *   decorate_task(
  *     withMockPreferences,
  *     withMockNormandyApi,
  *     async function myTest(mockPreferences, mockApi) {
@@ -235,8 +246,8 @@ this.compose = function(...args) {
  *     }
  *   );
  */
-this.compose_task = function(...args) {
-  return add_task(compose(...args));
+this.decorate_task = function(...args) {
+  return add_task(decorate(...args));
 };
 
 let _studyFactoryId = 0;


### PR DESCRIPTION
This is based off #919; 3b45b72 is the new commit to review.

@rhelmer The tests pass on this PR, but when I test it out manually with an XPI, my uninstall listener in `AddonStudies.jsm` is not called when I uninstall a study add-on via `about:addons`. Is there a reason why a listener for add-on uninstalls would not be called?

The TC run for this PR should have a task for building the XPI; check the artifacts there for a copy of the XPI if you want to test it out for yourself. You can use the following line in the browser console to create a new study entry in `about:studies`:

```js
// recipeId must be unique for each new study. 
Cu.import("resource://shield-recipe-client/lib/AddonStudies.jsm", {}).AddonStudies.start({recipeId: 9000, name: "My Study", description: "Don't worry about it", addonUrl: "https://github.com/Osmose/jsonfile-example/releases/download/v1/jsonfile-example.xpi"})
```