### PR TITLE
Fix #937: Honor the opt-out study preference.

### DIFF
--- a/recipe-server/client/actions/opt-out-study/index.js
+++ b/recipe-server/client/actions/opt-out-study/index.js
@@ -1,5 +1,7 @@
 import { Action, registerAction, registerAsyncCallback } from '../utils';
 
+const SHIELD_OPT_OUT_PREF = 'app.shield.optoutstudies.enabled';
+
 let seenRecipeIds = [];
 
 /**
@@ -22,6 +24,13 @@ export default class OptOutStudyAction extends Action {
     // Exit early if we're on an incompatible client.
     if (studies === undefined) {
       this.normandy.log('Client does not support studies, aborting.', 'info');
+      return;
+    }
+
+    // Check opt-out preference
+    const preferences = this.normandy.preferences;
+    if (preferences && !preferences.getBool(SHIELD_OPT_OUT_PREF, false)) {
+      this.normandy.log('User has opted-out of opt-out experiments, aborting.', 'info');
       return;
     }
 

--- a/recipe-server/client/actions/tests/test_opt-out-study.js
+++ b/recipe-server/client/actions/tests/test_opt-out-study.js
@@ -63,6 +63,9 @@ describe('OptOutStudyAction', () => {
     normandy = {
       log: jasmine.createSpy('log'),
       studies: new MockStudies(),
+      preferences: {
+        getBool: jasmine.createSpy('getBool').and.returnValue(true),
+      },
     };
     resetAction();
   });
@@ -81,6 +84,19 @@ describe('OptOutStudyAction', () => {
       await action.execute();
       await postExecutionHook(normandy);
 
+      expect(normandy.log).toHaveBeenCalledWith(jasmine.any(String), 'info');
+    });
+
+    it('should log and exit if the user has opted out of opt-out studies', async () => {
+      normandy.preferences.getBool.and.returnValue(false);
+      const action = new OptOutStudyAction(normandy, optOutStudyFactory());
+
+      await action.execute();
+      await postExecutionHook(normandy);
+
+      expect(normandy.preferences.getBool).toHaveBeenCalledWith(
+        'app.shield.optoutstudies.enabled', false
+      );
       expect(normandy.log).toHaveBeenCalledWith(jasmine.any(String), 'info');
     });
 

--- a/recipe-server/client/actions/tests/test_preference-experiment.js
+++ b/recipe-server/client/actions/tests/test_preference-experiment.js
@@ -123,6 +123,9 @@ describe('PreferenceExperimentAction', () => {
       userId: 'fake-userid',
       log: jasmine.createSpy('log'),
       preferenceExperiments: new MockPreferenceExperiments(),
+      preferences: {
+        getBool: jasmine.createSpy('getBool').and.returnValue(true),
+      },
     };
     resetAction();
   });
@@ -141,6 +144,19 @@ describe('PreferenceExperimentAction', () => {
       await action.execute();
       await postExecutionHook(normandy);
 
+      expect(normandy.log).toHaveBeenCalledWith(jasmine.any(String), 'info');
+    });
+
+    it('should log and exit if the user has opted out of experiments', async () => {
+      normandy.preferences.getBool.and.returnValue(false);
+      const action = new PreferenceExperimentAction(normandy, preferenceExperimentFactory());
+
+      await action.execute();
+      await postExecutionHook(normandy);
+
+      expect(normandy.preferences.getBool).toHaveBeenCalledWith(
+        'app.shield.optoutstudies.enabled', false
+      );
       expect(normandy.log).toHaveBeenCalledWith(jasmine.any(String), 'info');
     });
 


### PR DESCRIPTION
Both preference experiments and opt-out studies make changes without prompting the user, and thus should both honor the opt-out pref.

This depends on #919, #938, _and_ #939. Luckily, the actual change is tiny: 1e4cdff. The rest is just a mediocre merge of the the three other branches and can be ignored.

@MattGrimes Can you confirm whether the opt-out pref we're adding to about:preferences should affect preference experiments in addition to opt-out studies? Or only opt-out studies?