### PR TITLE
Fix #820: Add option for pausing enrollment in an opt-out study. 

### DIFF
--- a/recipe-server/client/actions/opt-out-study/index.js
+++ b/recipe-server/client/actions/opt-out-study/index.js
@@ -16,7 +16,7 @@ export function resetAction() {
 export default class OptOutStudyAction extends Action {
   async execute() {
     const recipeId = this.recipe.id;
-    const { name, description, addonUrl } = this.recipe.arguments;
+    const { name, description, addonUrl, isEnrollmentPaused } = this.recipe.arguments;
     const studies = this.normandy.studies;
 
     // Exit early if we're on an incompatible client.
@@ -27,9 +27,12 @@ export default class OptOutStudyAction extends Action {
 
     seenRecipeIds.push(recipeId);
 
-    // If the study doesn't exist yet, enroll!
     const hasStudy = await studies.has(recipeId);
-    if (!hasStudy) {
+    if (isEnrollmentPaused) {
+      this.normandy.log(`Enrollment is paused for recipe ${recipeId}`, 'debug');
+    } else if (hasStudy) {
+      this.normandy.log(`Study for recipe ${recipeId} already exists`, 'debug');
+    } else {
       this.normandy.log(`Starting study for recipe ${recipeId}`, 'debug');
       await studies.start({
         recipeId,
@@ -37,8 +40,6 @@ export default class OptOutStudyAction extends Action {
         description,
         addonUrl,
       });
-    } else {
-      this.normandy.log(`Study for recipe ${recipeId} already exists`, 'debug');
     }
   }
 }

--- a/recipe-server/client/actions/opt-out-study/package.json
+++ b/recipe-server/client/actions/opt-out-study/package.json
@@ -30,6 +30,11 @@
                     "type": "string",
                     "format": "uri",
                     "minLength": 1
+                },
+                "isEnrollmentPaused": {
+                    "description": "Whether the study is currently enrolling new users",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         }

--- a/recipe-server/client/actions/opt-out-study/package.json
+++ b/recipe-server/client/actions/opt-out-study/package.json
@@ -32,7 +32,7 @@
                     "minLength": 1
                 },
                 "isEnrollmentPaused": {
-                    "description": "Whether the study is currently enrolling new users",
+                    "description": "If true, new users will not be enrolled in the study.",
                     "type": "boolean",
                     "default": false
                 }

--- a/recipe-server/client/actions/tests/test_opt-out-study.js
+++ b/recipe-server/client/actions/tests/test_opt-out-study.js
@@ -9,6 +9,7 @@ function argumentsFactory(args) {
     name: 'Fake Study',
     description: 'not real',
     addonUrl: 'http://example.com/addon.xpi',
+    isEnrollmentPaused: false,
     ...args,
   };
 }
@@ -113,6 +114,17 @@ describe('OptOutStudyAction', () => {
         addonUrl: recipe.arguments.addonUrl,
       });
 
+      const action = new OptOutStudyAction(normandy, recipe);
+      spyOn(normandy.studies, 'start').and.callThrough();
+
+      await action.execute();
+      await postExecutionHook(normandy);
+
+      expect(normandy.studies.start).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if enrollment is paused', async () => {
+      const recipe = optOutStudyFactory({ isEnrollmentPaused: true });
       const action = new OptOutStudyAction(normandy, recipe);
       spyOn(normandy.studies, 'start').and.callThrough();
 

--- a/recipe-server/client/control/components/action_fields/OptOutStudyFields.js
+++ b/recipe-server/client/control/components/action_fields/OptOutStudyFields.js
@@ -51,6 +51,15 @@ class OptOutStudyFields extends ActionFields {
             </option>
           ))}
         </ControlField>
+
+        <ControlField
+          label="Pause Enrollment (If checked, no new study participants will be enrolled)"
+          name="arguments.isEnrollmentPaused"
+          component="input"
+          type="checkbox"
+          className="checkbox-field"
+          disabled={disabled}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Adds a checkbox to the opt-out study form fields that allows users to pause enrollment without stopping the study completely. Long-term I think we need a better design around handling the specifics of enroll-unenroll-style studies, but this will do for the short term, I think.