### PR TITLE
Bind AddonStudies.jsm methods in the driver

### DIFF
--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -182,11 +182,14 @@ this.NormandyDriver = function(sandboxManager) {
 
     // Study storage API
     studies: {
-      start: sandboxManager.wrapAsync(AddonStudies.start, {cloneArguments: true, cloneInto: true}),
-      stop: sandboxManager.wrapAsync(AddonStudies.stop),
-      get: sandboxManager.wrapAsync(AddonStudies.get, {cloneInto: true}),
-      getAll: sandboxManager.wrapAsync(AddonStudies.getAll, {cloneInto: true}),
-      has: sandboxManager.wrapAsync(AddonStudies.has),
+      start: sandboxManager.wrapAsync(
+        AddonStudies.start.bind(AddonStudies),
+        {cloneArguments: true, cloneInto: true}
+      ),
+      stop: sandboxManager.wrapAsync(AddonStudies.stop.bind(AddonStudies)),
+      get: sandboxManager.wrapAsync(AddonStudies.get.bind(AddonStudies), {cloneInto: true}),
+      getAll: sandboxManager.wrapAsync(AddonStudies.getAll.bind(AddonStudies), {cloneInto: true}),
+      has: sandboxManager.wrapAsync(AddonStudies.has.bind(AddonStudies)),
     },
   };
 };


### PR DESCRIPTION
I noticed an issue during manual testing of add-on studies; `driver.studies.start` fails when called in a sandbox because `this` is unbound when it's called.

This fleshes out the study API tests a bit and fixes the binding issue. I expect this to fail on TC with the errors fixed by #936, but if you run this locally, you can see the test added in the first commit fail, and then be fixed by the second commit.

This is small enough to not need two reviewers. 