### PR TITLE
Fix mis-named test function.

### DIFF
--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -225,7 +225,7 @@ decorate_task(
   }
 );
 
-compose_task(
+decorate_task(
   withPrefEnv({
     set: [
       ["test.char", "a string"],


### PR DESCRIPTION
This slipped through the cracks when two PRs merged around the same time,
but their test runs were offset by several days.