### PR TITLE
Add postinstall vendor build

### DIFF
--- a/recipe-server/package.json
+++ b/recipe-server/package.json
@@ -14,7 +14,8 @@
     "test": "NODE_ENV=production karma start",
     "lint:js": "eslint normandy client karma.conf.js webpack.config.js *.webpack.config.js",
     "lint:css": "stylelint 'client/**/*.less' --config .stylelintrc",
-    "lint:js-security": "nsp check ."
+    "lint:js-security": "nsp check .",
+    "postinstall": "npm run build:vendor"
   },
   "license": "MPL-2.0",
   "dependencies": {


### PR DESCRIPTION
After pulling the merged `master` branch, I ran into an issue where the site wouldn't load due to the missing vendor bundle.

This commit sets the npm `postinstall` script to build the vendor file. When a dev runs `npm install`, the vendor file is built automatically. I think this is a decent approach, considering that we only should need to rebuild the vendor file when `package.json` updates anyway.

Ready for review.