### PR TITLE
#785: Remove approval comment from popover

### DIFF
--- a/recipe-server/client/control_new/components/recipes/RevisionApprovalTag.js
+++ b/recipe-server/client/control_new/components/recipes/RevisionApprovalTag.js
@@ -73,9 +73,9 @@ export default class RevisionApprovalTag extends React.Component {
 
     if ([REVISION_LIVE, REVISION_DISABLED, REVISION_APPROVED, REVISION_REJECTED].includes(status)) {
       popoverContent = (
-        <div className="timeline-popover">
-          <div><strong>&quot;{revision.getIn(['approval_request', 'comment'])}&quot;</strong></div>
-          <div><em>~ {revision.getIn(['approval_request', 'approver', 'email'])}</em></div>
+        <div>
+          <div><strong>“{revision.getIn(['approval_request', 'comment'])}”</strong></div>
+          <label>— {revision.getIn(['approval_request', 'approver', 'email'])}</label>
         </div>
       );
     } else {
@@ -83,7 +83,7 @@ export default class RevisionApprovalTag extends React.Component {
     }
 
     return (
-      <Popover content={popoverContent} placement="right">
+      <Popover overlayClassName="timeline-popover" content={popoverContent} placement="right">
         <Link href={`/recipe/${revision.getIn(['recipe', 'id'])}/approval_history`}>
           <Tag color={color}>
             {label}

--- a/recipe-server/client/control_new/components/recipes/RevisionApprovalTag.js
+++ b/recipe-server/client/control_new/components/recipes/RevisionApprovalTag.js
@@ -73,7 +73,7 @@ export default class RevisionApprovalTag extends React.Component {
 
     if ([REVISION_LIVE, REVISION_DISABLED, REVISION_APPROVED, REVISION_REJECTED].includes(status)) {
       popoverContent = (
-        <div>
+        <div className="timeline-popover">
           <div><strong>&quot;{revision.getIn(['approval_request', 'comment'])}&quot;</strong></div>
           <div><em>~ {revision.getIn(['approval_request', 'approver', 'email'])}</em></div>
         </div>
@@ -83,7 +83,7 @@ export default class RevisionApprovalTag extends React.Component {
     }
 
     return (
-      <Popover content={popoverContent}>
+      <Popover content={popoverContent} placement="right">
         <Link href={`/recipe/${revision.getIn(['recipe', 'id'])}/approval_history`}>
           <Tag color={color}>
             {label}

--- a/recipe-server/client/control_new/less/main.less
+++ b/recipe-server/client/control_new/less/main.less
@@ -172,3 +172,7 @@ fieldset {
     padding-left: 1em;
   }
 }
+
+.timeline-popover {
+  max-width: 300px;
+}

--- a/recipe-server/client/control_new/less/main.less
+++ b/recipe-server/client/control_new/less/main.less
@@ -174,5 +174,17 @@ fieldset {
 }
 
 .timeline-popover {
-  max-width: 300px;
+  font-weight: 400;
+
+  label {
+    display: block;
+    margin-top: 0.5em;
+    text-align: right;
+  }
+
+  .ant-popover-inner-content {
+    background: @white;
+    border-radius: 2px;
+    max-width: 300px;
+  }
 }


### PR DESCRIPTION
Fixes #785 (more accurately, finishes #785)

- #785 called for fixing a UI element that no longer exists in the new UI
- While checking to confirm #785 had been met, I found that using the approval comments as tooltips in the HistoryTimeline lead to a real wide string across the page:
<img alt="screen shot 2017-08-07 at 1 13 08 pm" src="https://user-images.githubusercontent.com/2767162/29037583-3cfa27c0-7b72-11e7-8cfc-94fd0be1690d.png">

- This PR removes the comment from the tooltip, since the full text comment is available on the approval history page: 
<img width="346" alt="screen shot 2017-08-07 at 12 47 28 pm" src="https://user-images.githubusercontent.com/2767162/29037649-77633960-7b72-11e7-9927-050e337fd91e.png">

- Also noticed that the `Responsed` field on approval requests did not reflect useful information, so it was removed.

R?
