### PR TITLE
#695: Add EnvAlert component

### DIFF
--- a/recipe-server/client/control_new/components/App.js
+++ b/recipe-server/client/control_new/components/App.js
@@ -7,6 +7,7 @@ import { Link } from 'redux-little-router';
 import CurrentUserDetails from 'control_new/components/common/CurrentUserDetails';
 import NavigationCrumbs from 'control_new/components/common/NavigationCrumbs';
 import NavigationMenu from 'control_new/components/common/NavigationMenu';
+import EnvAlert from 'control_new/components/common/EnvAlert';
 import QueryActions from 'control_new/components/data/QueryActions';
 import QueryServiceInfo from 'control_new/components/data/QueryServiceInfo';
 
@@ -28,6 +29,8 @@ export default class App extends React.Component {
     return (
       <LocaleProvider locale={enUS}>
         <Layout>
+          <EnvAlert />
+
           {/*
            Global query components; add any queries for data needed across the
            entire app that we only need to fetch once.

--- a/recipe-server/client/control_new/components/common/EnvAlert.js
+++ b/recipe-server/client/control_new/components/common/EnvAlert.js
@@ -1,11 +1,20 @@
 import { Alert } from 'antd';
+import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Simple component which tells the user whether they are viewing a dev or staging
  * environment. On production, nothing is shown.
  */
+@connect(() => ({
+  currentUrl: window.location.href,
+}))
 export default class EnvAlert extends React.PureComponent {
+  static propTypes = {
+    currentUrl: PropTypes.string.isRequired,
+  };
+
   static productionFragments = ['normandy-admin.prod.'];
   static stageFragments = ['normandy-admin.stage.'];
 
@@ -39,7 +48,7 @@ export default class EnvAlert extends React.PureComponent {
   }
 
   render() {
-    const currentUrl = window.location.href;
+    const { currentUrl } = this.props;
 
     // Never show this component when on production.
     if (EnvAlert.checkProduction(currentUrl)) {

--- a/recipe-server/client/control_new/components/common/EnvAlert.js
+++ b/recipe-server/client/control_new/components/common/EnvAlert.js
@@ -6,8 +6,8 @@ import React from 'react';
  * environment. On production, nothing is shown.
  */
 export default class EnvAlert extends React.PureComponent {
-  static productionUrls = ['normandy-admin.prod.'];
-  static stageUrls = ['normandy-admin.stage.'];
+  static productionFragments = ['normandy-admin.prod.'];
+  static stageFragments = ['normandy-admin.stage.'];
 
   static learnMoreLink = (
     <a
@@ -19,22 +19,23 @@ export default class EnvAlert extends React.PureComponent {
     </a>);
 
   /**
-   * Find a string fragment in an array of strings.
+   * Given a URL and an array of strings, determines if that URL contains at least
+   * one of the strings.
    *
-   * @param  {String}        needle   String fragment to find.
-   * @param  {Array<String>} haystack String collection to search.
-   * @return {Boolean}                Was the fragment found?
+   * @param  {String}        url       URL to search over.
+   * @param  {Array<String>} fragments Collection of strings to find in the URL.
+   * @return {Boolean}                 True if URL contains at least one fragment.
    */
-  static findPartialString(needle, haystack) {
-    return !!haystack.find(straw => straw.indexOf(needle) > -1);
+  static findFragmentsInURL(url, fragments) {
+    return !!fragments.find(piece => url.indexOf(piece) > -1);
   }
 
   static checkProduction(url) {
-    return EnvAlert.findPartialString(url, EnvAlert.productionUrls);
+    return EnvAlert.findFragmentsInURL(url, EnvAlert.productionFragments);
   }
 
   static checkStaging(url) {
-    return EnvAlert.findPartialString(url, EnvAlert.stageUrls);
+    return EnvAlert.findFragmentsInURL(url, EnvAlert.stageFragments);
   }
 
   render() {

--- a/recipe-server/client/control_new/components/common/EnvAlert.js
+++ b/recipe-server/client/control_new/components/common/EnvAlert.js
@@ -1,0 +1,66 @@
+import { Alert } from 'antd';
+import React from 'react';
+
+/**
+ * Simple component which tells the user whether they are viewing a dev or staging
+ * environment. On production, nothing is shown.
+ */
+export default class EnvAlert extends React.PureComponent {
+  static productionUrls = ['normandy-admin.prod.'];
+  static stageUrls = ['normandy-admin.stage.'];
+
+  static learnMoreLink = (
+    <a
+      href="http://normandy.readthedocs.io/en/latest/qa/environments.html"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Learn more about Normandy environments.
+    </a>);
+
+  /**
+   * Find a string fragment in an array of strings.
+   *
+   * @param  {String}        needle   String fragment to find.
+   * @param  {Array<String>} haystack String collection to search.
+   * @return {Boolean}                Was the fragment found?
+   */
+  static findPartialString(needle, haystack) {
+    return !!haystack.find(straw => straw.indexOf(needle) > -1);
+  }
+
+  static checkProduction(url) {
+    return EnvAlert.findPartialString(url, EnvAlert.productionUrls);
+  }
+
+  static checkStaging(url) {
+    return EnvAlert.findPartialString(url, EnvAlert.stageUrls);
+  }
+
+  render() {
+    const currentUrl = window.location.href;
+
+    // Never show this component when on production.
+    if (EnvAlert.checkProduction(currentUrl)) {
+      return null;
+    }
+
+    const isStaging = EnvAlert.checkStaging(currentUrl);
+
+    // If we're here and not on staging, we must be on a development env.
+    const currEnv = isStaging ? 'staging' : 'development';
+
+    const message = `You are viewing a ${currEnv} environment.`;
+
+    return (
+      <Alert
+        banner
+        closable
+        description={EnvAlert.learnMoreLink}
+        message={message}
+        type="warning"
+        showIcon
+      />
+    );
+  }
+}

--- a/recipe-server/client/control_new/tests/components/common/test_EnvAlert.js
+++ b/recipe-server/client/control_new/tests/components/common/test_EnvAlert.js
@@ -1,34 +1,72 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
-import EnvAlert from 'control_new/components/common/EnvAlert';
+import TestComponent from 'control_new/components/common/EnvAlert';
+
+const { WrappedComponent: EnvAlert } = TestComponent;
 
 describe('<EnvAlert>', () => {
+  const props = {
+    currentUrl: 'http://localhost:8000/',
+  };
+
   it('should work', () => {
-    const wrapper = () => shallow(<EnvAlert />);
+    const wrapper = () => shallow(<EnvAlert {...props} />);
 
     expect(wrapper).not.toThrow();
   });
 
   describe('findFragmentsInURL', () => {
-    const testStrings = ['normandy-admin', 'fake-url.com', '/control/'];
+    const testStrings = ['normandy-admin', 'stage', '/control/'];
 
     it('should find a piece of a string amongst an array of strings', () => {
       let result = EnvAlert.findFragmentsInURL('https://www.normandy-admin.stage.com/control/',
         testStrings);
       expect(result).toBe(true);
 
-      result = EnvAlert.findFragmentsInURL('https://www.fake-url.com/', testStrings);
-      expect(result).toBe(true);
-
-      result = EnvAlert.findFragmentsInURL('http://mozilla.org/', testStrings);
-      expect(result).toBe(false);
-
-      result = EnvAlert.findFragmentsInURL('https://youtu.be/dQw4w9WgXcQ', testStrings);
-      expect(result).toBe(false);
-
       result = EnvAlert.findFragmentsInURL('http://firefox.com/normandy-admin/', testStrings);
       expect(result).toBe(true);
+
+      result = EnvAlert.findFragmentsInURL('http://mozilla.org/control', testStrings);
+      expect(result).toBe(false);
+    });
+  });
+
+
+  describe('production env', () => {
+    const url = 'https://www.normandy-admin.prod.com/control/';
+
+    it('should not render on production', () => {
+      const wrapper = mount(<EnvAlert currentUrl={url} />);
+      expect(wrapper.children().length).toBe(0);
+    });
+  });
+
+  describe('staging env', () => {
+    const url = 'https://www.normandy-admin.stage.com/control/';
+
+    it('should render on staging', () => {
+      const wrapper = mount(<EnvAlert currentUrl={url} />);
+      expect(wrapper.children().length).not.toBe(0);
+    });
+
+    it('should say it is a staging environment', () => {
+      const wrapper = mount(<EnvAlert currentUrl={url} />);
+      expect(wrapper.text()).toContain('staging environment');
+    });
+  });
+
+  describe('dev env', () => {
+    const url = 'http://localhost:8000/control/';
+
+    it('should render on dev', () => {
+      const wrapper = mount(<EnvAlert currentUrl={url} />);
+      expect(wrapper.children().length).not.toBe(0);
+    });
+
+    it('should say it is a dev environment', () => {
+      const wrapper = mount(<EnvAlert currentUrl={url} />);
+      expect(wrapper.text()).toContain('development environment');
     });
   });
 });

--- a/recipe-server/client/control_new/tests/components/common/test_EnvAlert.js
+++ b/recipe-server/client/control_new/tests/components/common/test_EnvAlert.js
@@ -10,33 +10,25 @@ describe('<EnvAlert>', () => {
     expect(wrapper).not.toThrow();
   });
 
-  describe('findPartialString', () => {
-    const testStrings = ['abc', 'def'];
+  describe('findFragmentsInURL', () => {
+    const testStrings = ['normandy-admin', 'fake-url.com', '/control/'];
 
     it('should find a piece of a string amongst an array of strings', () => {
-      // abc is present in 'abc'
-      let result = EnvAlert.findPartialString('abc', testStrings);
+      let result = EnvAlert.findFragmentsInURL('https://www.normandy-admin.stage.com/control/',
+        testStrings);
       expect(result).toBe(true);
 
-      // ef is present in 'def'
-      result = EnvAlert.findPartialString('ef', testStrings);
+      result = EnvAlert.findFragmentsInURL('https://www.fake-url.com/', testStrings);
       expect(result).toBe(true);
 
-      // xyz is not present
-      result = EnvAlert.findPartialString('xyz', testStrings);
+      result = EnvAlert.findFragmentsInURL('http://mozilla.org/', testStrings);
       expect(result).toBe(false);
 
-      // abcdef is not present
-      result = EnvAlert.findPartialString('abcdef', testStrings);
+      result = EnvAlert.findFragmentsInURL('https://youtu.be/dQw4w9WgXcQ', testStrings);
       expect(result).toBe(false);
+
+      result = EnvAlert.findFragmentsInURL('http://firefox.com/normandy-admin/', testStrings);
+      expect(result).toBe(true);
     });
-  });
-
-  it('should have accurate production URLs', () => {
-    expect(EnvAlert.productionUrls).toEqual(['normandy-admin.prod.']);
-  });
-
-  it('should have accurate staging URLs', () => {
-    expect(EnvAlert.stageUrls).toEqual(['normandy-admin.stage.']);
   });
 });

--- a/recipe-server/client/control_new/tests/components/common/test_EnvAlert.js
+++ b/recipe-server/client/control_new/tests/components/common/test_EnvAlert.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import EnvAlert from 'control_new/components/common/EnvAlert';
+
+describe('<EnvAlert>', () => {
+  it('should work', () => {
+    const wrapper = () => shallow(<EnvAlert />);
+
+    expect(wrapper).not.toThrow();
+  });
+
+  describe('findPartialString', () => {
+    const testStrings = ['abc', 'def'];
+
+    it('should find a piece of a string amongst an array of strings', () => {
+      // abc is present in 'abc'
+      let result = EnvAlert.findPartialString('abc', testStrings);
+      expect(result).toBe(true);
+
+      // ef is present in 'def'
+      result = EnvAlert.findPartialString('ef', testStrings);
+      expect(result).toBe(true);
+
+      // xyz is not present
+      result = EnvAlert.findPartialString('xyz', testStrings);
+      expect(result).toBe(false);
+
+      // abcdef is not present
+      result = EnvAlert.findPartialString('abcdef', testStrings);
+      expect(result).toBe(false);
+    });
+  });
+
+  it('should have accurate production URLs', () => {
+    expect(EnvAlert.productionUrls).toEqual(['normandy-admin.prod.']);
+  });
+
+  it('should have accurate staging URLs', () => {
+    expect(EnvAlert.stageUrls).toEqual(['normandy-admin.stage.']);
+  });
+});


### PR DESCRIPTION
Fixes #695 

- Adds component to top of page indicating whether the user is viewing a development or staging environment
- Adds link to the docs
- Adds appropriate tests

<img width="490" alt="screen shot 2017-08-07 at 2 48 12 pm" src="https://user-images.githubusercontent.com/2767162/29041065-7c175fd8-7b7f-11e7-93b6-d03337de16f0.png">
