### PR TITLE
#533: Validate URLs on show-heartbeat

### DIFF
--- a/recipe-server/client/control_new/components/forms/DocumentUrlInput.js
+++ b/recipe-server/client/control_new/components/forms/DocumentUrlInput.js
@@ -1,0 +1,43 @@
+import { Icon, Input } from 'antd';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * URL input that displays a clickable link to its value.
+ */
+export default class DocumentUrlInput extends React.Component {
+  static propTypes = {
+    disabled: PropTypes.bool,
+    // rc-form warns if the component already has a value prop, but doesn't
+    // initially provide it. So we can't have a default, and also can't require
+    // it.
+    // eslint-disable-next-line react/require-default-props
+    value: PropTypes.string,
+  };
+
+  static defaultProps = {
+    disabled: false,
+  };
+
+  render() {
+    const { disabled, value, ...props } = this.props;
+    let addonAfter = <span><Icon type="link" /> View</span>;
+    if (value) {
+      addonAfter = (
+        <a href={this.props.value} target="_blank" rel="noopener noreferrer">
+          {addonAfter}
+        </a>
+      );
+    }
+
+    return (
+      <Input
+        disabled={disabled}
+        type="url"
+        addonAfter={addonAfter}
+        value={value}
+        {...props}
+      />
+    );
+  }
+}

--- a/recipe-server/client/control_new/components/recipes/PreferenceExperimentFields.js
+++ b/recipe-server/client/control_new/components/recipes/PreferenceExperimentFields.js
@@ -5,6 +5,7 @@ import { List, Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import DocumentUrlInput from 'control_new/components/forms/DocumentUrlInput';
 import FormItem from 'control_new/components/forms/FormItem';
 import { connectFormProps } from 'control_new/utils/forms';
 
@@ -83,46 +84,6 @@ export default class PreferenceExperimentFields extends React.Component {
           <ExperimentBranches disabled={disabled} />
         </FormItem>
       </div>
-    );
-  }
-}
-
-/**
- * URL input that displays a clickable link to its value.
- */
-export class DocumentUrlInput extends React.Component {
-  static propTypes = {
-    disabled: PropTypes.bool,
-    // rc-form warns if the component already has a value prop, but doesn't
-    // initially provide it. So we can't have a default, and also can't require
-    // it.
-    // eslint-disable-next-line react/require-default-props
-    value: PropTypes.string,
-  };
-
-  static defaultProps = {
-    disabled: false,
-  };
-
-  render() {
-    const { disabled, value, ...props } = this.props;
-    let addonBefore = <span><Icon type="link" /> View</span>;
-    if (value) {
-      addonBefore = (
-        <a href={this.props.value} target="_blank" rel="noopener noreferrer">
-          {addonBefore}
-        </a>
-      );
-    }
-
-    return (
-      <Input
-        disabled={disabled}
-        type="url"
-        addonBefore={addonBefore}
-        value={value}
-        {...props}
-      />
     );
   }
 }

--- a/recipe-server/client/control_new/components/recipes/ShowHeartbeatFields.js
+++ b/recipe-server/client/control_new/components/recipes/ShowHeartbeatFields.js
@@ -3,6 +3,7 @@ import { Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import DocumentUrlInput from 'control_new/components/forms/DocumentUrlInput';
 import FormItem from 'control_new/components/forms/FormItem';
 import { connectFormProps } from 'control_new/utils/forms';
 
@@ -62,7 +63,7 @@ export default class ShowHeartbeatFields extends React.Component {
           name="arguments.postAnswerUrl"
           initialValue={recipeArguments.get('postAnswerUrl', '')}
         >
-          <Input disabled={disabled} />
+          <DocumentUrlInput disabled={disabled} />
         </FormItem>
         <FormItem
           label="Learn More Message"


### PR DESCRIPTION
Fixes #533 

- Separates `DocumentUrlInput` into its own file
- Replaces old n busted `Input` with new hotness `DocumentUrlInput` on the show-heartbeat arguments form
  - Under the hood, the field is now validated on the front end, fulfilling #533 's needs