### PR TITLE
Fix lint checks in migration recipes/0045.

### DIFF
--- a/recipe-server/normandy/recipes/migrations/0045_update_action_hashes.py
+++ b/recipe-server/normandy/recipes/migrations/0045_update_action_hashes.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import hashlib
-from base64 import b64encode, urlsafe_b64encode
+from base64 import urlsafe_b64encode
 
 from django.db import migrations
 


### PR DESCRIPTION
This fixes a lint error introduced in #974, which was merged before CI finished.