### PR TITLE
#984: Add Opt-Out action UI

### DIFF
--- a/recipe-server/client/control_new/components/forms/SwitchBox.js
+++ b/recipe-server/client/control_new/components/forms/SwitchBox.js
@@ -1,0 +1,58 @@
+// eslint flags our `onClick` as an accessibility issue, but the Switch already
+// handles user focus etc.
+/* eslint-disable jsx-a11y/interactive-supports-focus */
+
+import { Switch } from 'antd';
+import autobind from 'autobind-decorator';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+@autobind
+export default class SwitchBox extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    onChange: PropTypes.func.isRequired,
+    value: PropTypes.any,
+  };
+
+  static defaultProps = {
+    children: null,
+    value: null,
+  };
+
+  handleClick() {
+    const newValue = !this.props.value;
+
+    this.props.onChange(newValue);
+  }
+
+  render() {
+    const {
+      value,
+      children,
+      ...rest
+    } = this.props;
+
+
+    return (
+      <label className="switchbox">
+        <Switch
+          {...rest}
+          checked={value}
+        />
+
+        {
+          children &&
+            <span
+              className="label"
+              onClick={this.handleClick}
+              role="checkbox"
+              aria-checked={value}
+            >
+              { children }
+            </span>
+        }
+      </label>
+    );
+  }
+}

--- a/recipe-server/client/control_new/components/recipes/OptOutStudyFields.js
+++ b/recipe-server/client/control_new/components/recipes/OptOutStudyFields.js
@@ -1,0 +1,88 @@
+import { Col, Row, Input, Select } from 'antd';
+import { Map, List } from 'immutable';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import SwitchBox from 'control_new/components/forms/SwitchBox';
+import FormItem from 'control_new/components/forms/FormItem';
+import { connectFormProps } from 'control_new/utils/forms';
+
+import { getExtensionListing } from 'control_new/state/app/extensions/selectors';
+
+@connectFormProps
+@connect(
+  state => ({
+    extensions: getExtensionListing(state),
+  }),
+)
+export default class OptOutStudyFields extends React.Component {
+  static propTypes = {
+    disabled: PropTypes.bool,
+    extensions: PropTypes.instanceOf(List).isRequired,
+    recipeArguments: PropTypes.instanceOf(Map).isRequired,
+  };
+
+  static defaultProps = {
+    disabled: false,
+    extensions: new List(),
+    recipeArguments: new Map(),
+  };
+
+  render() {
+    const {
+      recipeArguments,
+      disabled,
+    } = this.props;
+    return (
+      <Row>
+        <p className="action-info">Enroll the user in a study which they can remove themselves from.</p>
+        <Row gutter={24}>
+          <Col xs={24} md={12}>
+            <FormItem
+              label="Study Name"
+              name="arguments.name"
+              initialValue={recipeArguments.get('name', '')}
+            >
+              <Input disabled={disabled} />
+            </FormItem>
+            <FormItem
+              label="Study Description"
+              name="arguments.description"
+              initialValue={recipeArguments.get('description', '')}
+            >
+              <Input type="textarea" rows="3" disabled={disabled} />
+            </FormItem>
+          </Col>
+
+          <Col xs={24} md={12}>
+            <FormItem
+              label="Add-on Extension"
+              name="arguments.addonUrl"
+              initialValue={recipeArguments.get('addonUrl', '')}
+            >
+              <Select disabled={disabled}>
+                {this.props.extensions.map(extension =>
+                  (<Select.Option key={extension.get('id')} value={extension.get('xpi')}>
+                    {extension.get('name')}
+                  </Select.Option>),
+                )}
+              </Select>
+            </FormItem>
+
+            <FormItem
+              label="Prevent New Enrollment"
+              name="arguments.isEnrollmentPaused"
+              initialValue={recipeArguments.get('isEnrollmentPaused', false)}
+            >
+              <SwitchBox>
+                Prevents new users from joining this study&nbsp;cohort. <br /> Existing
+                users will remain in&nbsp;the&nbsp;study.
+              </SwitchBox>
+            </FormItem>
+          </Col>
+        </Row>
+      </Row>
+    );
+  }
+}

--- a/recipe-server/client/control_new/components/recipes/OptOutStudyFields.js
+++ b/recipe-server/client/control_new/components/recipes/OptOutStudyFields.js
@@ -75,7 +75,7 @@ export default class OptOutStudyFields extends React.Component {
               name="arguments.isEnrollmentPaused"
               initialValue={recipeArguments.get('isEnrollmentPaused', false)}
             >
-              <SwitchBox>
+              <SwitchBox disabled={disabled}>
                 Prevents new users from joining this study&nbsp;cohort. <br /> Existing
                 users will remain in&nbsp;the&nbsp;study.
               </SwitchBox>

--- a/recipe-server/client/control_new/components/recipes/RecipeForm.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeForm.js
@@ -10,6 +10,7 @@ import FormActions from 'control_new/components/forms/FormActions';
 import ConsoleLogFields from 'control_new/components/recipes/ConsoleLogFields';
 import PreferenceExperimentFields from 'control_new/components/recipes/PreferenceExperimentFields';
 import ShowHeartbeatFields from 'control_new/components/recipes/ShowHeartbeatFields';
+import OptOutStudyFields from 'control_new/components/recipes/OptOutStudyFields';
 import { getAction, getAllActions } from 'control_new/state/app/actions/selectors';
 import { areAnyRequestsInProgress } from 'control_new/state/app/requests/selectors';
 import { getGithubUrl } from 'control_new/state/app/serviceInfo/selectors';
@@ -50,6 +51,7 @@ export default class RecipeForm extends React.Component {
     'console-log': ConsoleLogFields,
     'show-heartbeat': ShowHeartbeatFields,
     'preference-experiment': PreferenceExperimentFields,
+    'opt-out-study': OptOutStudyFields,
   };
 
   componentWillReceiveProps(newProps) {

--- a/recipe-server/client/control_new/components/recipes/ShowHeartbeatFields.js
+++ b/recipe-server/client/control_new/components/recipes/ShowHeartbeatFields.js
@@ -1,11 +1,11 @@
-import { Col, Input, InputNumber, Row, Select, Switch, Tooltip } from 'antd';
+import { Col, Input, InputNumber, Row, Select, Tooltip } from 'antd';
 import autobind from 'autobind-decorator';
 import { Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import DocumentUrlInput from 'control_new/components/forms/DocumentUrlInput';
-
+import SwitchBox from 'control_new/components/forms/SwitchBox';
 import FormItem from 'control_new/components/forms/FormItem';
 import { connectFormProps } from 'control_new/utils/forms';
 
@@ -93,10 +93,10 @@ export default class ShowHeartbeatFields extends React.Component {
             className="switch-input"
             name="arguments.includeTelemetryUUID"
             initialValue={recipeArguments.get('includeTelemetryUUID', false)}
-            config={{ valuePropName: 'checked' }}
-            label="Include UUID in Post-Answer URL and Telemetry"
           >
-            <Switch disabled={disabled} />
+            <SwitchBox disabled={disabled}>
+              Include UUID in Post-Answer URL and Telemetry
+            </SwitchBox>
           </FormItem>
         </Col>
         <Col sm={24}>

--- a/recipe-server/client/control_new/less/main.less
+++ b/recipe-server/client/control_new/less/main.less
@@ -161,3 +161,14 @@ fieldset {
     font-weight: bold;
   }
 }
+
+.switchbox {
+  align-items: center;
+  display: flex;
+
+  .label {
+    cursor: pointer;
+    line-height: 1.5em;
+    padding-left: 1em;
+  }
+}

--- a/recipe-server/client/control_new/state/app/extensions/selectors.js
+++ b/recipe-server/client/control_new/state/app/extensions/selectors.js
@@ -14,8 +14,8 @@ export function getExtensionListingCount(state) {
 
 
 export function getExtensionListing(state) {
-  const recipes = state.app.extensions.listing.get('results', new List([]));
-  return recipes.map(id => getExtension(state, id));
+  const extensions = state.app.extensions.listing.get('results', new List([]));
+  return extensions.map(id => getExtension(state, id));
 }
 
 

--- a/recipe-server/client/control_new/tests/components/recipes/test_OptOutStudyFields.js
+++ b/recipe-server/client/control_new/tests/components/recipes/test_OptOutStudyFields.js
@@ -1,0 +1,19 @@
+import { List, Map } from 'immutable';
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import OptOutStudyFields from 'control_new/components/recipes/OptOutStudyFields';
+
+describe('<OptOutStudyFields>', () => {
+  const props = {
+    disabled: false,
+    extensions: new List(),
+    recipeArguments: new Map(),
+  };
+
+  it('should work', () => {
+    const wrapper = () => shallow(<OptOutStudyFields {...props} />);
+
+    expect(wrapper).not.toThrow();
+  });
+});

--- a/recipe-server/client/control_new/tests/components/recipes/test_SwitchBox.js
+++ b/recipe-server/client/control_new/tests/components/recipes/test_SwitchBox.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import SwitchBox from 'control_new/components/forms/SwitchBox';
+
+describe('<SwitchBox>', () => {
+  const props = {
+    children: null,
+    onChange: ()=>{},
+    value: null,
+  };
+
+  it('should work', () => {
+    const wrapper = () => shallow(<SwitchBox {...props} />);
+
+    expect(wrapper).not.toThrow();
+  });
+});

--- a/recipe-server/client/control_new/tests/components/recipes/test_SwitchBox.js
+++ b/recipe-server/client/control_new/tests/components/recipes/test_SwitchBox.js
@@ -1,5 +1,6 @@
+import { Switch } from 'antd';
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import SwitchBox from 'control_new/components/forms/SwitchBox';
 
@@ -10,9 +11,46 @@ describe('<SwitchBox>', () => {
     value: null,
   };
 
-  it('should work', () => {
-    const wrapper = () => shallow(<SwitchBox {...props} />);
+  const factory = (customProps = {}) => mount(<SwitchBox {...props} {...customProps} />);
 
-    expect(wrapper).not.toThrow();
+  it('should work', () => {
+    expect(factory).not.toThrow();
+  });
+
+  describe('the label', () => {
+    it('should not render if there is no label', () => {
+      const wrapper = factory();
+      expect(wrapper.find('.label').length).toBe(0);
+    });
+
+    it('should render the passed in children', () => {
+      const label = 'Root beer\'s flavor comes from sassafras and/or sarsaparilla!';
+      const wrapper = factory({ children: label });
+
+      // The label should render..
+      expect(wrapper.find('.label').length).toBe(1);
+      // ..And it should contain the text we passed in.
+      expect(wrapper.find('.label').text()).toContain(label);
+    });
+
+    it('should trigger an onChange when clicked', () => {
+      let called = false;
+      const handleChange = () => { called = true; };
+      const wrapper = factory({ onChange: handleChange, children: 'Click me!' });
+
+      wrapper.find('.label').simulate('click');
+      expect(called).toBe(true);
+    });
+  });
+
+  describe('the Switch', () => {
+    it('should inherit the `value` as a `checked` prop', () => {
+      const wrapper = factory({ value: true });
+      expect(wrapper.find(Switch).length).toBe(1);
+      expect(wrapper.find(Switch).props().checked).toBe(true);
+
+      wrapper.setProps({ value: false });
+      expect(wrapper.find(Switch).props().checked).toBe(false);
+    });
   });
 });

--- a/recipe-server/client/control_new/tests/components/recipes/test_SwitchBox.js
+++ b/recipe-server/client/control_new/tests/components/recipes/test_SwitchBox.js
@@ -6,7 +6,7 @@ import SwitchBox from 'control_new/components/forms/SwitchBox';
 describe('<SwitchBox>', () => {
   const props = {
     children: null,
-    onChange: ()=>{},
+    onChange: () => {},
     value: null,
   };
 


### PR DESCRIPTION
Fixes #984 

- Adds `opt-out-study` action UI
- Adds `SwitchBox` form component (basically Ant's `Switch` with a label wrapper)


<img alt="screen shot 2017-08-15 at 10 05 13 am" src="https://user-images.githubusercontent.com/2767162/29324555-b23ba2b8-81a1-11e7-8a2c-d6a7ddad217c.png">
