### PR TITLE
Fix data loss bug in migration.

### DIFF
--- a/recipe-server/normandy/recipes/migrations/0046_reset_signatures.py
+++ b/recipe-server/normandy/recipes/migrations/0046_reset_signatures.py
@@ -29,7 +29,7 @@ def remove_signatures(apps, schema_editor):
         sig = action.signature
         action.signature = None
         action.save()
-        action.delete()
+        sig.delete()
 
     for sig in Signature.objects.all():
         sig.delete()


### PR DESCRIPTION
We should be deleting the signature to invalidate it, not the action itself.