### PR TITLE
Fix bug 1390918: Move DLL plugin to control-only webpack config. 

### DIFF
--- a/docs/dev/recipe-server/workflow.rst
+++ b/docs/dev/recipe-server/workflow.rst
@@ -50,7 +50,7 @@ steps, as they don't affect your setup if nothing has changed:
    python manage.py initial_data
 
    # Build frontend files
-   ./node_modules/.bin/webpack --config ./webpack.config.js --update-actions
+   ./node_modules/.bin/webpack --config ./webpack.config.js --env.update-actions
 
 Building the Documentation
 --------------------------
@@ -98,13 +98,13 @@ make changes:
 
    npm run watch
 
-Running the command with ``--update-actions`` will automatically call
+Running the command with ``--env.update-actions`` will automatically call
 ``manage.py update_actions`` when action code is built. Arguments are separated
 from the rest of the command by ``--``:
 
 .. code-block:: bash
 
-   npm run watch -- --update-actions
+   npm run watch -- --env.update-actions
 
 .. _Webpack: http://webpack.github.io/
 

--- a/recipe-server/karma.conf.js
+++ b/recipe-server/karma.conf.js
@@ -4,7 +4,7 @@
 // Karma configuration
 
 
-const WEBPACK_CONFIG = require('./webpack.config.js');
+const WEBPACK_CONFIG = require('./webpack.config.js')();
 
 module.exports = function (config) {
   var karmaConfig = {

--- a/recipe-server/package.json
+++ b/recipe-server/package.json
@@ -120,7 +120,6 @@
     "uglifyjs-webpack-plugin": "0.4.6",
     "webpack": "3.4.0",
     "webpack-async-await": "1.0.4",
-    "webpack-bundle-tracker": "0.2.0",
-    "yargs": "5.0.0"
+    "webpack-bundle-tracker": "0.2.0"
   }
 }

--- a/recipe-server/webpack.config.js
+++ b/recipe-server/webpack.config.js
@@ -57,7 +57,11 @@ if (production) {
   ]);
 }
 
-module.exports = function(env) {
+module.exports = function (webpackEnvOptions) {
+  var envOptions = webpackEnvOptions || {
+    'update-actions': false,
+  };
+
   return [
     {
       context: __dirname,
@@ -165,7 +169,7 @@ module.exports = function(env) {
         function updateActions() {
           this.plugin('done', function () {
             var cmd;
-            if (env['update-actions']) {
+            if (envOptions['update-actions']) {
               // Don't disable actions since this is mostly for development.
               cmd = 'python manage.py update_actions';
 

--- a/recipe-server/webpack.config.js
+++ b/recipe-server/webpack.config.js
@@ -36,10 +36,6 @@ var plugins = [
       },
     },
   }),
-  new webpack.DllReferencePlugin({
-    context: '.',
-    manifest: path.resolve('./assets/bundles/vendor-manifest.json'),
-  }),
 ];
 
 if (production) {
@@ -94,6 +90,10 @@ module.exports = function(env) {
 
       plugins: plugins.concat([
         new BundleTracker({ filename: './webpack-stats.json' }),
+        new webpack.DllReferencePlugin({
+          context: '.',
+          manifest: path.resolve('./assets/bundles/vendor-manifest.json'),
+        }),
       ]),
 
       module: {

--- a/recipe-server/webpack.config.js
+++ b/recipe-server/webpack.config.js
@@ -6,7 +6,6 @@ var BundleTracker = require('webpack-bundle-tracker');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var AsyncAwaitPlugin = require('webpack-async-await');
 var BabiliPlugin = require('babili-webpack-plugin');
-var argv = require('yargs').argv;
 var childProcess = require('child_process');
 var babiliPreset = require('babel-preset-babili');
 var babelCore = require('babel-core');
@@ -40,7 +39,7 @@ var plugins = [
   new webpack.DllReferencePlugin({
     context: '.',
     manifest: path.resolve('./assets/bundles/vendor-manifest.json'),
-  })
+  }),
 ];
 
 if (production) {
@@ -62,138 +61,140 @@ if (production) {
   ]);
 }
 
-module.exports = [
-  {
-    context: __dirname,
-    devtool: production ? undefined : 'cheap-module-source-map',
+module.exports = function(env) {
+  return [
+    {
+      context: __dirname,
+      devtool: production ? undefined : 'cheap-module-source-map',
 
-    entry: {
-      control: [
-        'babel-polyfill',
-        './client/control/index.js',
-        './client/control/sass/control.scss',
-        './node_modules/font-awesome/scss/font-awesome.scss',
-      ],
-      control_new: [
-        'babel-polyfill',
-        './client/control_new/index.js',
-        './client/control_new/less/main.less',
-      ],
-    },
+      entry: {
+        control: [
+          'babel-polyfill',
+          './client/control/index.js',
+          './client/control/sass/control.scss',
+          './node_modules/font-awesome/scss/font-awesome.scss',
+        ],
+        control_new: [
+          'babel-polyfill',
+          './client/control_new/index.js',
+          './client/control_new/less/main.less',
+        ],
+      },
 
-    output: {
-      path: path.resolve('./assets/bundles/'),
-      filename: jsNamePattern,
-      chunkFilename: '[id].bundle.js',
-    },
-    externals: {
-      'react/lib/ExecutionEnvironment': true,
-      'react/lib/ReactContext': true,
-      'react/addons': true,
-    },
+      output: {
+        path: path.resolve('./assets/bundles/'),
+        filename: jsNamePattern,
+        chunkFilename: '[id].bundle.js',
+      },
+      externals: {
+        'react/lib/ExecutionEnvironment': true,
+        'react/lib/ReactContext': true,
+        'react/addons': true,
+      },
 
-    plugins: plugins.concat([
-      new BundleTracker({ filename: './webpack-stats.json' }),
-    ]),
+      plugins: plugins.concat([
+        new BundleTracker({ filename: './webpack-stats.json' }),
+      ]),
 
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          exclude: /node_modules/,
-          loader: 'babel-loader',
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            loader: 'babel-loader',
+          },
+          {
+            test: /\.scss$/,
+            use: ExtractTextPlugin.extract({
+              allChunks: true,
+              fallback: 'style-loader',
+              use: [
+                'css-loader?sourceMap',
+                'postcss-loader',
+                'sass-loader?sourceMap',
+              ],
+            }),
+          },
+          {
+            test: /\.less$/,
+            exclude: /node_modules/,
+            use: ExtractTextPlugin.extract({
+              allChunks: true,
+              fallback: 'style-loader',
+              use: [
+                'css-loader?sourceMap',
+                'less-loader',
+              ],
+            }),
+          },
+          {
+            test: /\.(png|ttf|eot|svg|woff(2)?)(\?[a-z0-9=&.]+)?$/,
+            loader: 'file-loader',
+          },
+        ],
+      },
+
+      resolve: {
+        alias: {
+          client: path.resolve(__dirname, './client'),
+          actions: path.resolve(__dirname, './client/actions'),
+          control: path.resolve(__dirname, './client/control'),
+          tests: path.resolve(__dirname, './client/tests'),
+          control_new: path.resolve(__dirname, './client/control_new'),
         },
-        {
-          test: /\.scss$/,
-          use: ExtractTextPlugin.extract({
-            allChunks: true,
-            fallback: 'style-loader',
-            use: [
-              'css-loader?sourceMap',
-              'postcss-loader',
-              'sass-loader?sourceMap',
-            ],
-          }),
-        },
-        {
-          test: /\.less$/,
-          exclude: /node_modules/,
-          use: ExtractTextPlugin.extract({
-            allChunks: true,
-            fallback: 'style-loader',
-            use: [
-              'css-loader?sourceMap',
-              'less-loader',
-            ],
-          }),
-        },
-        {
-          test: /\.(png|ttf|eot|svg|woff(2)?)(\?[a-z0-9=&.]+)?$/,
-          loader: 'file-loader',
-        },
-      ],
-    },
+      },
 
-    resolve: {
-      alias: {
-        client: path.resolve(__dirname, './client'),
-        actions: path.resolve(__dirname, './client/actions'),
-        control: path.resolve(__dirname, './client/control'),
-        tests: path.resolve(__dirname, './client/tests'),
-        control_new: path.resolve(__dirname, './client/control_new'),
+      node: {
+        fs: 'empty',
       },
     },
+    {
+      devtool: production ? undefined : 'cheap-module-source-map',
 
-    node: {
-      fs: 'empty',
-    },
-  },
-  {
-    devtool: production ? undefined : 'cheap-module-source-map',
-
-    entry: {
-      'console-log': './client/actions/console-log/index',
-      'show-heartbeat': './client/actions/show-heartbeat/index',
-      'preference-experiment': './client/actions/preference-experiment/index',
-      'opt-out-study': './client/actions/opt-out-study/index',
-    },
-
-    plugins: plugins.concat([
-      new BundleTracker({ filename: './webpack-stats-actions.json' }),
-      // Small plugin to update the actions in the database if
-      // --update-actions was passed.
-      function updateActions() {
-        this.plugin('done', function () {
-          var cmd;
-          if (argv['update-actions']) {
-            // Don't disable actions since this is mostly for development.
-            cmd = 'python manage.py update_actions';
-
-            childProcess.exec(cmd, function (err, stdout, stderr) {
-              console.log('\n' + BOLD + 'Updating Actions' + END_BOLD);
-              console.log(stdout);
-              if (stderr) {
-                console.error(stderr);
-              }
-            });
-          }
-        });
+      entry: {
+        'console-log': './client/actions/console-log/index',
+        'show-heartbeat': './client/actions/show-heartbeat/index',
+        'preference-experiment': './client/actions/preference-experiment/index',
+        'opt-out-study': './client/actions/opt-out-study/index',
       },
-    ]),
 
-    output: {
-      path: path.resolve('./assets/bundles/'),
-      filename: jsNamePattern,
-    },
+      plugins: plugins.concat([
+        new BundleTracker({ filename: './webpack-stats-actions.json' }),
+        // Small plugin to update the actions in the database if
+        // --env.update-actions was passed.
+        function updateActions() {
+          this.plugin('done', function () {
+            var cmd;
+            if (env['update-actions']) {
+              // Don't disable actions since this is mostly for development.
+              cmd = 'python manage.py update_actions';
 
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          exclude: /node_modules/,
-          loader: 'babel-loader',
+              childProcess.exec(cmd, function (err, stdout, stderr) {
+                console.log('\n' + BOLD + 'Updating Actions' + END_BOLD);
+                console.log(stdout);
+                if (stderr) {
+                  console.error(stderr);
+                }
+              });
+            }
+          });
         },
-      ],
+      ]),
+
+      output: {
+        path: path.resolve('./assets/bundles/'),
+        filename: jsNamePattern,
+      },
+
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            loader: 'babel-loader',
+          },
+        ],
+      },
     },
-  },
-];
+  ];
+};


### PR DESCRIPTION
Also includes a fix for the `--update-actions` argument to our webpack config that broke with Webpack 2/3. The diff is a little easier to read with whitespace changes hidden.

I couldn't figure out a good way to test this with our current automation, as you'd need to load the action code with the add-on. Manual testing can be done with an opt-out-study recipe and an add-on build from this commit, at least.