### PR TITLE
Make implementation URLs more permissive of different hash formats.

### DIFF
--- a/recipe-server/normandy/recipes/urls.py
+++ b/recipe-server/normandy/recipes/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     url(r'^api/v2/', include(v2_router.urls)),
     url(r'^api/v1/', include(v1_router.urls)),
     url(
-        r'^api/v1/action/(?P<name>[_\-\w]+)/implementation/(?P<impl_hash>[0-9a-f]{40})/$',
+        r'^api/v1/action/(?P<name>[_\-\w]+)/implementation/(?P<impl_hash>[^/]+)/$',
         api_v1_views.ActionImplementationView.as_view(),
         name='action-implementation'
     ),


### PR DESCRIPTION
This is intended to be a point release branched off from `v57`. It is a temporary measure to make `v57` and v69 compatible enough. I intend to tag the resulting merge of this as `v57.1`.

Note that this is not merging into master, but a branch named `v57-branch`, which currently points to the same place as the `v57` tag. We could delete this branch after `v57.1` is tagged, if we wanted.

CC @relud