### PR TITLE
Fix mock-server to work with signed actions.

### DIFF
--- a/mock-recipe-server/conftest.py
+++ b/mock-recipe-server/conftest.py
@@ -12,4 +12,4 @@ def root_path(request):
     build_dir = request.config.getoption('--mock-server-dir')
     if not build_dir:
         pytest.fail('--mock-server-dir was not provided, but is required for this test')
-    return APIPath(build_dir, 'http://example.com/')
+    return APIPath(build_dir)

--- a/mock-recipe-server/docker-compose.yml
+++ b/mock-recipe-server/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     links:
       - database
       - autograph
-      - proxy
     volumes: # Relative to /compose/docker-compose.yml
       - ../mock-recipe-server:/mock-server
       - "${MOCK_SERVER_ARTIFACTS}:/build"

--- a/mock-recipe-server/generate.py
+++ b/mock-recipe-server/generate.py
@@ -10,8 +10,6 @@ from pathlib import Path
 
 import configurations
 
-from utils import APIPath
-
 
 # Add normandy to the import path and setup Django stuff.
 sys.path.insert(0, '/app')
@@ -24,6 +22,7 @@ configurations.setup()
 from django.template import Context, Template  # noqa
 
 from testcases import get_testcases  # noqa
+from utils import APIPath  # noqa
 
 
 def main():
@@ -36,7 +35,7 @@ def main():
     testcases = get_testcases()
     for testcase in testcases:
         testcase.load()
-        testcase_api_path = APIPath(build_path / testcase.name, 'https://proxy:8443')
+        testcase_api_path = APIPath(build_path / testcase.name)
         testcase.serialize_api(testcase_api_path, domain)
 
     # Write the root index page.

--- a/mock-recipe-server/test_mock_server.py
+++ b/mock-recipe-server/test_mock_server.py
@@ -9,7 +9,7 @@ def test_testcase_difference(root_path):
     recipes = set()
 
     testcase_paths = (
-        APIPath(path, 'http://example.com')
+        APIPath(path)
         for path in root_path.path.iterdir() if path.is_dir()
     )
     for testcase_path in testcase_paths:

--- a/mock-recipe-server/utils.py
+++ b/mock-recipe-server/utils.py
@@ -1,20 +1,22 @@
 from pathlib import Path
-from urllib.parse import urljoin
 
-import requests
+from django.test import Client
+
+
+client = Client()
 
 
 class APIPath(object):
     """Represents an API URL that is mirrored on the filesystem."""
-    def __init__(self, base_path, base_url, segments=None):
+    def __init__(self, base_path, segments=None):
         self.base_path = base_path
-        self.base_url = base_url
         self.segments = segments or []
 
     @property
     def url(self):
         """Generate the current URL string."""
-        return urljoin(self.base_url, '/'.join(self.segments) + '/')
+        path = '/'.join(self.segments)
+        return f'/{path}/'
 
     @property
     def path(self):
@@ -28,13 +30,11 @@ class APIPath(object):
 
     def add(self, *paths):
         """Add segments to the current URL."""
-        return APIPath(self.base_path, self.base_url, self.segments + list(paths))
+        return APIPath(self.base_path, self.segments + list(paths))
 
     def fetch(self):
         """Fetch the response text for the current URL."""
-        response = requests.get(self.url, verify=False)
-        response.raise_for_status()
-        return response.text
+        return client.get(self.url).content.decode()
 
     def read(self):
         """Read data on the filesystem for the current URL."""


### PR DESCRIPTION
Since actions are signed now, we can't modify the URLs in the actions since
that would invalidate the signature. Instead, we switch to using the Django
test client for making API responses, which allows us to temporarily modify the
CDN_URL setting to the URL prefix we need for a testcase.

This is urgent as it is blocking QA from finishing.