### PR TITLE
Fix bug 1393257: Stop in-progress studies when opt-out pref changes.

### DIFF
--- a/recipe-client-addon/lib/AddonStudies.jsm
+++ b/recipe-client-addon/lib/AddonStudies.jsm
@@ -97,7 +97,7 @@ async function markAsEnded(db, study) {
   study.active = false;
   study.studyEndDate = new Date();
   await getStore(db).put(study);
-  Services.obs.notifyObservers(study, STUDY_ENDED_TOPIC);
+  Services.obs.notifyObservers(study, STUDY_ENDED_TOPIC, `${study.recipeId}`);
 }
 
 this.AddonStudies = {

--- a/recipe-client-addon/lib/ShieldPreferences.jsm
+++ b/recipe-client-addon/lib/ShieldPreferences.jsm
@@ -11,6 +11,9 @@ XPCOMUtils.defineLazyModuleGetter(
   this, "AppConstants", "resource://gre/modules/AppConstants.jsm"
 );
 XPCOMUtils.defineLazyModuleGetter(
+  this, "AddonStudies", "resource://shield-recipe-client/lib/AddonStudies.jsm"
+);
+XPCOMUtils.defineLazyModuleGetter(
   this, "CleanupManager", "resource://shield-recipe-client/lib/CleanupManager.jsm"
 );
 
@@ -37,6 +40,12 @@ this.ShieldPreferences = {
       Services.prefs.removeObserver(FHR_UPLOAD_ENABLED_PREF, this);
     });
 
+    // Watch for changes to the Opt-out pref
+    Services.prefs.addObserver(OPT_OUT_STUDIES_ENABLED_PREF, this);
+    CleanupManager.addCleanupHandler(() => {
+      Services.prefs.removeObserver(OPT_OUT_STUDIES_ENABLED_PREF, this);
+    });
+
     // Disabled outside of en-* locales temporarily (bug 1377192).
     // Disabled when MOZ_DATA_REPORTING is false since the FHR UI is also hidden
     // when data reporting is false.
@@ -56,11 +65,31 @@ this.ShieldPreferences = {
           this.injectOptOutStudyCheckbox(subject.document);
         }
         break;
-      // If the FHR pref changes, set the opt-out-study pref to the value it is changing to.
       case NS_PREFBRANCH_PREFCHANGE_TOPIC_ID:
-        if (data === FHR_UPLOAD_ENABLED_PREF) {
-          const fhrUploadEnabled = Services.prefs.getBoolPref(FHR_UPLOAD_ENABLED_PREF);
-          Services.prefs.setBoolPref(OPT_OUT_STUDIES_ENABLED_PREF, fhrUploadEnabled);
+        this.observePrefChange(data);
+        break;
+    }
+  },
+
+  async observePrefChange(prefName) {
+    let prefValue;
+    switch (prefName) {
+      // If the FHR pref changes, set the opt-out-study pref to the value it is changing to.
+      case FHR_UPLOAD_ENABLED_PREF:
+        prefValue = Services.prefs.getBoolPref(FHR_UPLOAD_ENABLED_PREF);
+        Services.prefs.setBoolPref(OPT_OUT_STUDIES_ENABLED_PREF, prefValue);
+        break;
+
+      // If the opt-out pref changes to be false, disable all current studies.
+      case OPT_OUT_STUDIES_ENABLED_PREF:
+        prefValue = Services.prefs.getBoolPref(OPT_OUT_STUDIES_ENABLED_PREF);
+        if (!prefValue) {
+          for (const study of await AddonStudies.getAll()) {
+            if (study.active) {
+              dump(`\nSTOPPING ${study.recipeId}\n`);
+              await AddonStudies.stop(study.recipeId);
+            }
+          }
         }
         break;
     }

--- a/recipe-client-addon/lib/ShieldPreferences.jsm
+++ b/recipe-client-addon/lib/ShieldPreferences.jsm
@@ -86,7 +86,6 @@ this.ShieldPreferences = {
         if (!prefValue) {
           for (const study of await AddonStudies.getAll()) {
             if (study.active) {
-              dump(`\nSTOPPING ${study.recipeId}\n`);
               await AddonStudies.stop(study.recipeId);
             }
           }

--- a/recipe-client-addon/test/browser/browser.ini
+++ b/recipe-client-addon/test/browser/browser.ini
@@ -15,6 +15,7 @@ head = head.js
 [browser_LogManager.js]
 [browser_ClientEnvironment.js]
 [browser_ShieldRecipeClient.js]
+[browser_ShieldPreferences.js]
 [browser_PreferenceExperiments.js]
 [browser_about_studies.js]
 [browser_about_preferences.js]

--- a/recipe-client-addon/test/browser/browser_ShieldPreferences.js
+++ b/recipe-client-addon/test/browser/browser_ShieldPreferences.js
@@ -1,0 +1,31 @@
+"use strict";
+
+Cu.import("resource://gre/modules/Services.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/AddonStudies.jsm", this);
+
+const OPT_OUT_PREF = "app.shield.optoutstudies.enabled";
+
+decorate_task(
+  withPrefEnv({
+    set: [[OPT_OUT_PREF, true]],
+  }),
+  AddonStudies.withStudies([
+    studyFactory({active: true}),
+    studyFactory({active: true}),
+  ]),
+  async function testDisableStudiesWhenOptOutDisabled([study1, study2]) {
+    const observers = [
+      studyEndObserved(study1.recipeId),
+      studyEndObserved(study2.recipeId),
+    ];
+    Services.prefs.setBoolPref(OPT_OUT_PREF, false);
+    await Promise.all(observers);
+
+    const newStudy1 = await AddonStudies.get(study1.recipeId);
+    const newStudy2 = await AddonStudies.get(study2.recipeId);
+    ok(
+      !newStudy1.active && !newStudy2.active,
+      "Setting the opt-out pref to false stops all active opt-out studies."
+    );
+  }
+);

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -3,6 +3,7 @@ const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 
 Cu.import("resource://gre/modules/Preferences.jsm", this);
 Cu.import("resource://testing-common/AddonTestUtils.jsm", this);
+Cu.import("resource://testing-common/TestUtils.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/Addons.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/SandboxManager.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/NormandyDriver.jsm", this);
@@ -275,4 +276,11 @@ this.withStub = function(...stubArgs) {
       }
     };
   };
+};
+
+this.studyEndObserved = function(recipeId) {
+  return TestUtils.topicObserved(
+    "shield-study-ended",
+    (subject, endedRecipeId) => Number.parseInt(endedRecipeId) === recipeId,
+  );
 };


### PR DESCRIPTION
It looks like the `subject` of the notification is being wrapped in some way I'm not familiar with, so I used the data field (which must be a string) instead to transfer the recipe ID for the study. Not entirely pleased with it but it does the trick.