### PR TITLE
Backport fixes from mozilla-central.

### DIFF
--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -85,7 +85,6 @@ this.shutdown = function(data, reason) {
     "AboutPages.jsm",
   ].map(m => `resource://shield-recipe-client-content/${m}`));
   modules = modules.concat([
-    "ajv.js",
     "mozjexl.js",
   ].map(m => `resource://shield-recipe-client-vendor/${m}`));
 

--- a/recipe-client-addon/content/AboutPages.jsm
+++ b/recipe-client-addon/content/AboutPages.jsm
@@ -181,9 +181,14 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
      *   that requested a study list.
      */
     async sendStudyList(target) {
-      target.messageManager.sendAsyncMessage("Shield:ReceiveStudyList", {
-        studies: await AddonStudies.getAll(),
-      });
+      try {
+        target.messageManager.sendAsyncMessage("Shield:ReceiveStudyList", {
+          studies: await AddonStudies.getAll(),
+        });
+      } catch (err) {
+        // The child process might be gone, so no need to throw here.
+        Cu.reportError(err);
+      }
     },
 
     /**

--- a/recipe-client-addon/test/browser/browser_NormandyDriver.js
+++ b/recipe-client-addon/test/browser/browser_NormandyDriver.js
@@ -1,5 +1,6 @@
 "use strict";
 
+Cu.import("resource://gre/modules/AppConstants.jsm");
 Cu.import("resource://testing-common/AddonTestUtils.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/AddonStudies.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/NormandyDriver.jsm", this);
@@ -42,7 +43,13 @@ add_task(withDriver(Assert, async function uninstallInvalidAddonId(driver) {
 
 
 add_task(withDriver(Assert, async function installXpiBadURL(driver) {
-  const xpiUrl = "file:///tmp/invalid_xpi.xpi";
+  let xpiUrl;
+  if (AppConstants.platform === "win") {
+    xpiUrl = "file:///C:/invalid_xpi.xpi";
+  } else {
+    xpiUrl = "file:///tmp/invalid_xpi.xpi";
+  }
+
   try {
     await driver.addons.install(xpiUrl);
     ok(false, "Installation succeeded on an XPI that doesn't exist");

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -55,17 +55,17 @@ this.withWebExtension = function(manifestOverrides = {}) {
         },
       }, manifestOverrides);
 
-      const file = AddonTestUtils.createTempWebExtensionFile({manifest});
+      const addonFile = AddonTestUtils.createTempWebExtensionFile({manifest});
 
       // Workaround: Add-on files are cached by URL, and
       // createTempWebExtensionFile re-uses filenames if the previous file has
       // been deleted. So we need to flush the cache to avoid it.
-      Services.obs.notifyObservers(file, "flush-cache-entry");
+      Services.obs.notifyObservers(addonFile, "flush-cache-entry");
 
       try {
-        await testFunction(...args, [id, file]);
+        await testFunction(...args, [id, addonFile]);
       } finally {
-        file.remove(true);
+        AddonTestUtils.cleanupTempXPIs();
       }
     };
   };


### PR DESCRIPTION
Bugs backported from:
Bug 1388823: Sync shield-recipe-client v65 from GitHub

I just used `cp` to copy over our files with the ones from mozilla-central and it seemed to work fine. Yay!

These already have an r+ from Gijs on m-c so they don't need another review from him.