### PR TITLE
Disallow duplicate extension filenames and fix action admin

### DIFF
--- a/recipe-server/normandy/base/templates/admin/field_recipe_list.html
+++ b/recipe-server/normandy/base/templates/admin/field_recipe_list.html
@@ -1,0 +1,9 @@
+{% if recipes %}
+  <ul>
+    {% for recipe in recipes %}
+      <li>{{ recipe.name }} (id={{ recipe.id }})</li>
+    {% endfor %}
+  </ul>
+{% else %}
+  <p>Not used in any recipes.</p>
+{% endif %}

--- a/recipe-server/normandy/recipes/admin/model_admins.py
+++ b/recipe-server/normandy/recipes/admin/model_admins.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.template.loader import render_to_string
 
 from normandy.recipes import models
 
@@ -16,16 +15,9 @@ class ActionAdmin(VersionAdmin):
                 'implementation_hash',
                 'implementation',
                 'arguments_schema_json',
-                'recipe_list',
-            ]
+                'recipes_used_by_html',
+            ],
         }],
     ]
 
-    readonly_fields = ['implementation_hash', 'recipe_list']
-
-    def recipe_list(self, action):
-        """List all recipes that the action is being used by."""
-        return render_to_string('admin/field_recipe_list.html', {
-            'recipes': action.recipes_used_by.order_by('name'),
-        })
-    recipe_list.short_description = 'Used in Recipes'
+    readonly_fields = ['implementation_hash', 'recipes_used_by_html']

--- a/recipe-server/normandy/recipes/models.py
+++ b/recipe-server/normandy/recipes/models.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models, transaction
+from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.functional import cached_property
 
@@ -545,7 +546,14 @@ class Action(DirtyFieldsMixin, models.Model):
         """Set of enabled recipes that are using this action."""
         return Recipe.objects.filter(
             latest_revision_id__in=self.recipe_revisions.values_list('id', flat=True),
-            enabled=True)
+            enabled=True
+        )
+
+    def recipes_used_by_html(self):
+        return render_to_string('admin/field_recipe_list.html', {
+            'recipes': self.recipes_used_by.order_by('latest_revision__name'),
+        })
+    recipes_used_by_html.short_description = 'Used in Recipes'
 
     def __str__(self):
         return self.name

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -383,6 +383,7 @@ class Production(Base):
     LOGGING_USE_JSON = values.Value(True)
     SECURE_HSTS_SECONDS = values.IntegerValue(31536000)  # 1 year
     DEFAULT_FILE_STORAGE = values.Value('storages.backends.s3boto3.S3Boto3Storage')
+    AWS_S3_FILE_OVERWRITE = False
 
 
 class ProductionReadOnly(Production):

--- a/recipe-server/normandy/studies/admin.py
+++ b/recipe-server/normandy/studies/admin.py
@@ -1,0 +1,19 @@
+from django.contrib import admin
+
+from normandy.studies import models
+
+
+@admin.register(models.Extension)
+class ExtensionAdmin(admin.ModelAdmin):
+    list_display = ['name', 'xpi']
+    fieldsets = [
+        [None, {
+            'fields': [
+                'name',
+                'xpi',
+                'recipes_used_by_html',
+            ]
+        }],
+    ]
+
+    readonly_fields = ['recipes_used_by_html']

--- a/recipe-server/normandy/studies/models.py
+++ b/recipe-server/normandy/studies/models.py
@@ -1,6 +1,22 @@
 from django.db import models
+from django.template.loader import render_to_string
+
+from normandy.recipes.models import Recipe
 
 
 class Extension(models.Model):
     name = models.CharField(max_length=255)
     xpi = models.FileField(upload_to='extensions')
+
+    @property
+    def recipes_used_by(self):
+        """Set of enabled recipes that are using this extension."""
+        return Recipe.objects.filter(
+            latest_revision__arguments_json__contains=self.xpi.url,
+        )
+
+    def recipes_used_by_html(self):
+        return render_to_string('admin/field_recipe_list.html', {
+            'recipes': self.recipes_used_by.order_by('latest_revision__name'),
+        })
+    recipes_used_by_html.short_description = 'Used in Recipes'

--- a/recipe-server/normandy/studies/tests/test_models.py
+++ b/recipe-server/normandy/studies/tests/test_models.py
@@ -1,0 +1,20 @@
+import pytest
+
+from normandy.recipes.tests import RecipeFactory
+from normandy.studies.tests import ExtensionFactory
+
+
+@pytest.mark.django_db
+def test_recipes_used_by():
+    extension = ExtensionFactory()
+    RecipeFactory()  # Create a recipe that doesn't use the extension
+    used_in_recipe_1 = RecipeFactory(
+        name="test 1",
+        arguments_json=f'{{"xpi_url": "{extension.xpi.url}"}}',
+    )
+    used_in_recipe_2 = RecipeFactory(
+        name="test 2",
+        arguments_json=f'{{"xpi_url": "{extension.xpi.url}"}}',
+    )
+
+    assert set(extension.recipes_used_by) == set([used_in_recipe_1, used_in_recipe_2])


### PR DESCRIPTION
[Bug 1393751](https://bugzilla.mozilla.org/show_bug.cgi?id=1393751) came up due to extension objects with the same filename. This removes that possibility in prod environments by adding a config from django-storages. I'd like to have marked the field as unique as well, but doing that for FileFields wasn't supported until Django 1.11.

Since we'll need to clean up the data on staging once this deploys, I decided to add Extensions to the Django admin to make the cleanup easier. And, since extension URLs are in the recipe arguments, there's no relational cascade to warn when you delete an extension that is currently being used, so I added a list of recipes that are currently using an extension to the admin. While doing that, I noticed that the similar list we had for the action admin was broken, and fixed that.