### PR TITLE
Bug 1392738: Update how we open the new preferences UI.

### DIFF
--- a/recipe-client-addon/content/AboutPages.jsm
+++ b/recipe-client-addon/content/AboutPages.jsm
@@ -142,6 +142,7 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
     registerParentListeners() {
       Services.mm.addMessageListener("Shield:GetStudyList", this);
       Services.mm.addMessageListener("Shield:RemoveStudy", this);
+      Services.mm.addMessageListener("Shield:OpenDataPreferences", this);
     },
 
     /**
@@ -150,6 +151,7 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
     unregisterParentListeners() {
       Services.mm.removeMessageListener("Shield:GetStudyList", this);
       Services.mm.removeMessageListener("Shield:RemoveStudy", this);
+      Services.mm.removeMessageListener("Shield:OpenDataPreferences", this);
     },
 
     /**
@@ -164,6 +166,9 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
           break;
         case "Shield:RemoveStudy":
           this.removeStudy(message.data);
+          break;
+        case "Shield:OpenDataPreferences":
+          this.openDataPreferences();
           break;
       }
     },
@@ -197,6 +202,11 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
       Services.mm.broadcastAsyncMessage("Shield:ReceiveStudyList", {
         studies: await AddonStudies.getAll(),
       });
+    },
+
+    openDataPreferences() {
+      const browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
+      browserWindow.openPreferences("privacy-reports", {origin: "aboutStudies"});
     },
 
     getShieldLearnMoreHref() {

--- a/recipe-client-addon/content/shield-content-frame.js
+++ b/recipe-client-addon/content/shield-content-frame.js
@@ -57,7 +57,7 @@ class ShieldFrameListener {
         );
         break;
       case "NavigateToDataPreferences":
-        this.navigateToDataPreferences();
+        sendAsyncMessage("Shield:OpenDataPreferences");
         break;
     }
   }
@@ -109,10 +109,6 @@ class ShieldFrameListener {
     removeMessageListener("Shield:SendStudyList", this);
     removeMessageListener("Shield:ShuttingDown", this);
     removeEventListener("Shield", this);
-  }
-
-  navigateToDataPreferences() {
-    content.location = "about:preferences#privacy-reports";
   }
 }
 

--- a/recipe-client-addon/test/browser/browser_about_studies.js
+++ b/recipe-client-addon/test/browser/browser_about_studies.js
@@ -42,16 +42,26 @@ decorate_task(
 decorate_task(
   withAboutStudies,
   async function testUpdatePreferencesNewOrganization(browser) {
-    ContentTask.spawn(browser, null, () => {
-      content.document.getElementById("shield-studies-update-preferences").click();
+    // We have to use gBrowser instead of browser in most spots since we're
+    // dealing with a new tab outside of the about:studies tab.
+    const tab = await BrowserTestUtils.switchTab(gBrowser, () => {
+      ContentTask.spawn(browser, null, () => {
+        content.document.getElementById("shield-studies-update-preferences").click();
+      });
     });
-    await BrowserTestUtils.waitForLocationChange(gBrowser);
 
+    if (gBrowser.contentDocument.readyState !== "complete") {
+      await BrowserTestUtils.waitForEvent(gBrowser.contentWindow, "load");
+    }
+
+    const location = gBrowser.contentWindow.location.href;
     is(
-      browser.currentURI.spec,
-      "about:preferences#privacy-reports",
-      "Clicking Update Preferences opens the privacy section of the new about:prefernces.",
+      location,
+      "about:preferences#privacy",
+      "Clicking Update Preferences opens the privacy section of the new about:preferences.",
     );
+
+    await BrowserTestUtils.removeTab(tab);
   }
 );
 


### PR DESCRIPTION
This brings us more inline with other implementations within mozilla-central. The leak from [bug 1392738](https://bugzilla.mozilla.org/show_bug.cgi?id=1392738) doesn't appear to affect the test for the old preferences, which leads me to believe that this may also solve that otherwise-puzzling leak.