### PR TITLE
Added new text filter for extensions.

### DIFF
--- a/recipe-server/normandy/studies/api/v2/views.py
+++ b/recipe-server/normandy/studies/api/v2/views.py
@@ -1,3 +1,5 @@
+from django.db.models import Q
+
 from rest_framework import permissions, viewsets
 
 from normandy.base.api.mixins import CachingViewsetMixin
@@ -13,3 +15,13 @@ class ExtensionViewSet(CachingViewsetMixin, viewsets.ModelViewSet):
         AdminEnabledOrReadOnly,
         permissions.DjangoModelPermissionsOrAnonReadOnly,
     ]
+
+    def get_queryset(self):
+        queryset = self.queryset
+
+        if 'text' in self.request.GET:
+            text = self.request.GET.get('text')
+            queryset = queryset.filter(Q(name__icontains=text) |
+                                       Q(xpi__icontains=text))
+
+        return queryset

--- a/recipe-server/normandy/studies/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/studies/tests/api/v2/test_api.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import pytest
 
 from normandy.base.tests import Whatever
@@ -51,3 +53,20 @@ class TestExtensionAPI(object):
         res = api_client.get('/api/v2/extension/{id}/'.format(id=extension.id))
         assert res.status_code == 200
         assert res.client.cookies == {}
+
+    def test_filtering_by_name(self, api_client):
+        matching_extension = ExtensionFactory()
+        ExtensionFactory()  # Generate another extension that will not match
+
+        res = api_client.get(f'/api/v2/extension/?text={matching_extension.name}')
+        assert res.status_code == 200
+        assert [ext['name'] for ext in res.data['results']] == [matching_extension.name]
+
+    def test_filtering_by_xpi(self, api_client):
+        matching_extension = ExtensionFactory()
+        ExtensionFactory()  # Generate another extension that will not match
+
+        res = api_client.get(f'/api/v2/extension/?text={matching_extension.xpi}')
+        assert res.status_code == 200
+        expected_path = matching_extension.xpi.url
+        assert [urlparse(ext['xpi']).path for ext in res.data['results']] == [expected_path]


### PR DESCRIPTION
See #1006 for motivation: a text search filter is needed for the extensions endpoint. This is implemented by searching either the `name` or `xpi` field for the query parameter.

@andymikulski  is tagged for review to make sure the API fits his needs.