### PR TITLE
recipe-server: Add cache-control headers when redirecting to add slashes.

### DIFF
--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -188,6 +188,12 @@ in other Django projects.
     :envvar:`DJANGO_API_CACHE_TIME`. If false, API views will send headers
     indicating that they should never be cached.
 
+.. envvar:: DJANGO_PERMANENT_REDIRECT_CACHE_TIME
+
+   :default: ``2592000`` (30 days)
+
+   The time in seconds to set in cache headers for permanent redirects.
+
 .. envvar:: DJANGO_LOGGING_USE_JSON
 
     :default: ``True``

--- a/recipe-server/normandy/base/tests/test_middleware.py
+++ b/recipe-server/normandy/base/tests/test_middleware.py
@@ -1,0 +1,23 @@
+from random import randint
+
+from normandy.base.middleware import NormandyCommonMiddleware
+
+
+class TestNormandyCommonMiddleware(object):
+
+    def test_append_slash_redirects_with_cache_headers(self, rf, settings):
+        cache_time = randint(100, 1000)
+        # This must be a URL that is valid with a slash but not without a slash
+        url = '/api/v1'
+        settings.APPEND_SLASH = True
+        settings.PERMANENT_REDIRECT_CACHE_TIME = cache_time
+
+        middleware = NormandyCommonMiddleware()
+        req = rf.get(url)
+        res = middleware.process_request(req)
+
+        assert res is not None
+        assert res.status_code == 301
+        assert res['Location'] == url + '/'
+        cache_control = set(res['Cache-Control'].split(', '))
+        assert cache_control == {'public', f'max-age={cache_time}'}

--- a/recipe-server/normandy/base/tests/test_urls.py
+++ b/recipe-server/normandy/base/tests/test_urls.py
@@ -1,0 +1,7 @@
+def test_slash_redirects_have_cache_control_headers(client, settings):
+    res = client.get('/api/v2')
+    assert res.status_code == 301
+    assert 'Location' in res
+    # It isn't important to assert a particular value for max-age
+    assert 'max-age=' in res['Cache-Control']
+    assert 'public' in res['Cache-Control']

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -41,7 +41,7 @@ class Core(Configuration):
         'normandy.base.middleware.RequestSummaryLogger',
         'django.middleware.security.SecurityMiddleware',
         'normandy.base.middleware.NormandyWhiteNoiseMiddleware',
-        'django.middleware.common.CommonMiddleware',
+        'normandy.base.middleware.NormandyCommonMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
         'csp.middleware.CSPMiddleware',
     ]
@@ -329,6 +329,7 @@ class Base(Core):
     NUM_PROXIES = values.IntegerValue(0)
     API_CACHE_TIME = values.IntegerValue(30)
     API_CACHE_ENABLED = values.BooleanValue(True)
+    PERMANENT_REDIRECT_CACHE_TIME = values.IntegerValue(60 * 60 * 24 * 30)
 
     # If true, approvals must come from two separate users. If false, the same
     # user can approve their own request.


### PR DESCRIPTION
This will allow us to remove blanket 301 caching from Nginx, replacing it with the automatic caching we get when there are cache control headers.