### PR TITLE
recipe-server: Reduce the number of DB queries on API listing pages.

### DIFF
--- a/recipe-server/normandy/recipes/api/v1/views.py
+++ b/recipe-server/normandy/recipes/api/v1/views.py
@@ -83,7 +83,17 @@ class RecipeFilters(django_filters.FilterSet):
 
 class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
     """Viewset for viewing and uploading recipes."""
-    queryset = Recipe.objects.all()
+    queryset = (
+        Recipe.objects.all()
+        # Foreign keys
+        .select_related('latest_revision')
+        .select_related('latest_revision__action')
+        .select_related('latest_revision__approval_request')
+        # Many-to-many
+        .prefetch_related('latest_revision__channels')
+        .prefetch_related('latest_revision__countries')
+        .prefetch_related('latest_revision__locales')
+    )
     serializer_class = RecipeSerializer
     filter_class = RecipeFilters
     permission_classes = [
@@ -163,7 +173,16 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
 
 
 class RecipeRevisionViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = RecipeRevision.objects.all()
+    queryset = (
+        RecipeRevision.objects.all()
+        .select_related('action')
+        .select_related('approval_request')
+        .select_related('recipe')
+        # Many-to-many
+        .prefetch_related('channels')
+        .prefetch_related('countries')
+        .prefetch_related('locales')
+    )
     serializer_class = RecipeRevisionSerializer
     permission_classes = [
         AdminEnabledOrReadOnly,

--- a/recipe-server/normandy/recipes/api/v2/views.py
+++ b/recipe-server/normandy/recipes/api/v2/views.py
@@ -49,7 +49,17 @@ class RecipeOrderingFilter(AliasedOrderingFilter):
 
 class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
     """Viewset for viewing and uploading recipes."""
-    queryset = Recipe.objects.all()
+    queryset = (
+        Recipe.objects.all()
+        # Foreign keys
+        .select_related('latest_revision')
+        .select_related('latest_revision__action')
+        .select_related('latest_revision__approval_request')
+        # Many-to-many
+        .prefetch_related('latest_revision__channels')
+        .prefetch_related('latest_revision__countries')
+        .prefetch_related('latest_revision__locales')
+    )
     serializer_class = RecipeSerializer
     filter_class = RecipeFilters
     filter_backends = [
@@ -125,7 +135,16 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
 
 
 class RecipeRevisionViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = RecipeRevision.objects.all()
+    queryset = (
+        RecipeRevision.objects.all()
+        .select_related('action')
+        .select_related('approval_request')
+        .select_related('recipe')
+        # Many-to-many
+        .prefetch_related('channels')
+        .prefetch_related('countries')
+        .prefetch_related('locales')
+    )
     serializer_class = RecipeRevisionSerializer
     permission_classes = [
         AdminEnabledOrReadOnly,


### PR DESCRIPTION
tl;dr: O(1) is better than O(n).

Prior to this change, many API listing were making several DB queries per object. On prod this could result in several hundred individual queries on a page, making things pretty slow. Concretely, `/api/v1/recipe/` was doing `9n+1` queries, for a total of 900 queries when there are 100 recipes. After this patch it does a constant 4 queries, regardless of the number of recipes.

In my testing this has has about a 5x speed up querying `/api/v1/recipe/` in a test when there are 1000 recipes. With 100 recipes, the control interface loaded about 20% faster (4.5 to 3.5 seconds) and the `/api/v1/recipe/` endpoint in HTML format loaded about 30% faster (4.5 to 3 seconds). These measurements are all very low sample size with lots of noise, so I wouldn't look too much in to them.

The tests are pretty duplicated, and I'm open for ideas to DRY them up where reasonable.