### PR TITLE
Bug 1371350: Delay almost all startup tasks until after sessionstore-windows-restored

### DIFF
--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -20,7 +20,7 @@ this.EXPORTED_SYMBOLS = ["Bootstrap"];
 
 const REASON_APP_STARTUP = 1;
 const UI_AVAILABLE_NOTIFICATION = "sessionstore-windows-restored";
-const STARTUP_EXPERIMENT_PREFS_BRANCH = "extensions.shield-recipe-client.startupExperimentPrefs";
+const STARTUP_EXPERIMENT_PREFS_BRANCH = "extensions.shield-recipe-client.startupExperimentPrefs.";
 const PREF_LOGGING_LEVEL = "extensions.shield-recipe-client.logging.level";
 const BOOTSTRAP_LOGGER_NAME = "extensions.shield-recipe-client.bootstrap";
 const DEFAULT_PREFS = {
@@ -67,37 +67,36 @@ this.Bootstrap = {
     const defaultBranch = Services.prefs.getDefaultBranch("");
     const experimentBranch = Services.prefs.getBranch(STARTUP_EXPERIMENT_PREFS_BRANCH);
 
-    for (const childPrefName of experimentBranch.getChildList("")) {
-      const experimentPrefType = experimentBranch.getPrefType(childPrefName);
-      const realPrefName = childPrefName.slice(1); // Remove leading dot
-      const realPrefType = defaultBranch.getPrefType(realPrefName);
+    for (const prefName of experimentBranch.getChildList("")) {
+      const experimentPrefType = experimentBranch.getPrefType(prefName);
+      const realPrefType = defaultBranch.getPrefType(prefName);
 
       if (realPrefType !== Services.prefs.PREF_INVALID && realPrefType !== experimentPrefType) {
-        log.error(`Error setting startup pref ${realPrefName}; pref type does not match.`);
+        log.error(`Error setting startup pref ${prefName}; pref type does not match.`);
         continue;
       }
 
       switch (experimentPrefType) {
         case Services.prefs.PREF_STRING:
-          defaultBranch.setCharPref(realPrefName, experimentBranch.getCharPref(childPrefName));
+          defaultBranch.setCharPref(prefName, experimentBranch.getCharPref(prefName));
           break;
 
         case Services.prefs.PREF_INT:
-          defaultBranch.setIntPref(realPrefName, experimentBranch.getIntPref(childPrefName));
+          defaultBranch.setIntPref(prefName, experimentBranch.getIntPref(prefName));
           break;
 
         case Services.prefs.PREF_BOOL:
-          defaultBranch.setBoolPref(realPrefName, experimentBranch.getBoolPref(childPrefName));
+          defaultBranch.setBoolPref(prefName, experimentBranch.getBoolPref(prefName));
           break;
 
         case Services.prefs.PREF_INVALID:
           // This should never happen.
-          log.error(`Error setting startup pref ${childPrefName}; pref type is invalid (${experimentPrefType}).`);
+          log.error(`Error setting startup pref ${prefName}; pref type is invalid (${experimentPrefType}).`);
           break;
 
         default:
           // This should never happen either.
-          log.error(`Error getting startup pref ${childPrefName}; unknown value type ${experimentPrefType}.`);
+          log.error(`Error getting startup pref ${prefName}; unknown value type ${experimentPrefType}.`);
       }
     }
   },

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -14,7 +14,11 @@ XPCOMUtils.defineLazyModuleGetter(this, "LogManager",
 XPCOMUtils.defineLazyModuleGetter(this, "ShieldRecipeClient",
   "resource://shield-recipe-client/lib/ShieldRecipeClient.jsm");
 
+const REASON_APP_STARTUP = 1;
 const UI_AVAILABLE_NOTIFICATION = "sessionstore-windows-restored";
+const STARTUP_EXPERIMENT_PREFS_BRANCH = "extensions.shield-recipe-client.startupExperimentPrefs";
+const PREF_LOGGING_LEVEL = "extensions.shield-recipe-client.logging.level";
+const BOOTSTRAP_LOGGER_NAME = "extensions.shield-recipe-client.bootstrap";
 const DEFAULT_PREFS = {
   "extensions.shield-recipe-client.api_url": "https://normandy.cdn.mozilla.net/api/v1",
   "extensions.shield-recipe-client.dev_mode": false,
@@ -29,6 +33,11 @@ const DEFAULT_PREFS = {
   ),
   "app.shield.optoutstudies.enabled": AppConstants.MOZ_DATA_REPORTING,
 };
+
+// Logging
+const log = Log.repository.getLogger(BOOTSTRAP_LOGGER_NAME);
+log.addAppender(new Log.ConsoleAppender(new Log.BasicFormatter()));
+log.level = Services.prefs.getIntPref(PREF_LOGGING_LEVEL, Log.Level.Warn);
 
 function initializeShieldPreferences() {
   const prefBranch = Services.prefs.getDefaultBranch("");
@@ -49,6 +58,39 @@ function initializeShieldPreferences() {
   }
 }
 
+function initializeExperimentPreferences() {
+  const defaultBranch = Services.prefs.getDefaultBranch("");
+  const experimentBranch = Services.prefs.getBranch(STARTUP_EXPERIMENT_PREFS_BRANCH);
+
+  for (const childPrefName of experimentBranch.getChildList("")) {
+    const realPrefName = childPrefName.slice(1); // Remove leading dot
+    const prefType = experimentBranch.getPrefType(childPrefName);
+
+    switch (prefType) {
+      case Services.prefs.PREF_STRING:
+        defaultBranch.setStringPref(realPrefName, experimentBranch.getStringPref(childPrefName));
+        break;
+
+      case Services.prefs.PREF_INT:
+        defaultBranch.setIntPref(realPrefName, experimentBranch.getIntPref(childPrefName));
+        break;
+
+      case Services.prefs.PREF_BOOL:
+        defaultBranch.setBoolPref(realPrefName, experimentBranch.getBoolPref(childPrefName));
+        break;
+
+      case Services.prefs.PREF_INVALID:
+        // This should never happen.
+        log.error(`Error setting startup pref ${childPrefName}; pref type is invalid (${prefType}).`);
+        break;
+
+      default:
+        // This should never happen either.
+        log.error(`Error getting startup pref ${childPrefName}; unknown value type ${prefType}.`);
+    }
+  }
+}
+
 const uiAvailableObserver = {
   observe(subject, topic, data) {
     Services.obs.removeObserver(uiAvailableObserver, UI_AVAILABLE_NOTIFICATION);
@@ -58,23 +100,29 @@ const uiAvailableObserver = {
 
 this.install = function() {};
 
-this.startup = function() {
+this.startup = function(data, reason) {
   // Initialization that needs to happen before the first paint on startup.
   initializeShieldPreferences();
+  initializeExperimentPreferences();
 
-  // Wait until the UI is available for remaining startup tasks
-  Services.obs.addObserver(uiAvailableObserver, UI_AVAILABLE_NOTIFICATION);
+  // If the app is starting up, wait until the UI is available before finishing
+  // init.
+  if (reason === REASON_APP_STARTUP) {
+    Services.obs.addObserver(uiAvailableObserver, UI_AVAILABLE_NOTIFICATION);
+  } else {
+    ShieldRecipeClient.startup();
+  }
 };
 
-this.shutdown = function(data, reason) {
-  ShieldRecipeClient.shutdown(reason);
+this.shutdown = async function(data, reason) {
+  // Wait for async write operations during shutdown before unloading modules.
+  await ShieldRecipeClient.shutdown(reason);
 
   // In case the observer didn't run, clean it up.
-  Services.obs.addObserver(uiAvailableObserver, UI_AVAILABLE_NOTIFICATION);
+  Services.obs.removeObserver(uiAvailableObserver, UI_AVAILABLE_NOTIFICATION);
 
   // Unload add-on modules. We don't do this in ShieldRecipeClient so that
   // modules are not unloaded accidentally during tests.
-  const log = LogManager.getLogger("bootstrap");
   let modules = [
     "lib/ActionSandboxManager.jsm",
     "lib/Addons.jsm",

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -14,6 +14,10 @@ XPCOMUtils.defineLazyModuleGetter(this, "LogManager",
 XPCOMUtils.defineLazyModuleGetter(this, "ShieldRecipeClient",
   "resource://shield-recipe-client/lib/ShieldRecipeClient.jsm");
 
+// Act as both a normal bootstrap.js and a JS module so that we can test
+// startup methods without having to install/uninstall the add-on.
+this.EXPORTED_SYMBOLS = ["Bootstrap"];
+
 const REASON_APP_STARTUP = 1;
 const UI_AVAILABLE_NOTIFICATION = "sessionstore-windows-restored";
 const STARTUP_EXPERIMENT_PREFS_BRANCH = "extensions.shield-recipe-client.startupExperimentPrefs";
@@ -39,123 +43,141 @@ const log = Log.repository.getLogger(BOOTSTRAP_LOGGER_NAME);
 log.addAppender(new Log.ConsoleAppender(new Log.BasicFormatter()));
 log.level = Services.prefs.getIntPref(PREF_LOGGING_LEVEL, Log.Level.Warn);
 
-function initializeShieldPreferences() {
-  const prefBranch = Services.prefs.getDefaultBranch("");
-  for (const [name, value] of Object.entries(DEFAULT_PREFS)) {
-    switch (typeof value) {
-      case "string":
-        prefBranch.setCharPref(name, value);
-        break;
-      case "number":
-        prefBranch.setIntPref(name, value);
-        break;
-      case "boolean":
-        prefBranch.setBoolPref(name, value);
-        break;
-      default:
-        throw new Error(`Invalid default preference type ${typeof value}`);
+this.Bootstrap = {
+  initShieldPrefs(defaultPrefs) {
+    const prefBranch = Services.prefs.getDefaultBranch("");
+    for (const [name, value] of Object.entries(defaultPrefs)) {
+      switch (typeof value) {
+        case "string":
+          prefBranch.setCharPref(name, value);
+          break;
+        case "number":
+          prefBranch.setIntPref(name, value);
+          break;
+        case "boolean":
+          prefBranch.setBoolPref(name, value);
+          break;
+        default:
+          throw new Error(`Invalid default preference type ${typeof value}`);
+      }
     }
-  }
-}
+  },
 
-function initializeExperimentPreferences() {
-  const defaultBranch = Services.prefs.getDefaultBranch("");
-  const experimentBranch = Services.prefs.getBranch(STARTUP_EXPERIMENT_PREFS_BRANCH);
+  initExperimentPrefs() {
+    const defaultBranch = Services.prefs.getDefaultBranch("");
+    const experimentBranch = Services.prefs.getBranch(STARTUP_EXPERIMENT_PREFS_BRANCH);
 
-  for (const childPrefName of experimentBranch.getChildList("")) {
-    const realPrefName = childPrefName.slice(1); // Remove leading dot
-    const prefType = experimentBranch.getPrefType(childPrefName);
+    for (const childPrefName of experimentBranch.getChildList("")) {
+      const realPrefName = childPrefName.slice(1); // Remove leading dot
+      const realPrefType = defaultBranch.getPrefType(childPrefName);
+      const experimentPrefType = experimentBranch.getPrefType(childPrefName);
 
-    switch (prefType) {
-      case Services.prefs.PREF_STRING:
-        defaultBranch.setStringPref(realPrefName, experimentBranch.getStringPref(childPrefName));
-        break;
+      // TODO: This never passes?
+      if (realPrefType !== Services.prefs.PREF_INVALID && realPrefType !== experimentPrefType) {
+        log.error(`Error setting startup pref ${childPrefName}; pref type does not match.`);
+        continue;
+      }
 
-      case Services.prefs.PREF_INT:
-        defaultBranch.setIntPref(realPrefName, experimentBranch.getIntPref(childPrefName));
-        break;
+      switch (experimentPrefType) {
+        case Services.prefs.PREF_STRING:
+          defaultBranch.setCharPref(realPrefName, experimentBranch.getCharPref(childPrefName));
+          break;
 
-      case Services.prefs.PREF_BOOL:
-        defaultBranch.setBoolPref(realPrefName, experimentBranch.getBoolPref(childPrefName));
-        break;
+        case Services.prefs.PREF_INT:
+          defaultBranch.setIntPref(realPrefName, experimentBranch.getIntPref(childPrefName));
+          break;
 
-      case Services.prefs.PREF_INVALID:
-        // This should never happen.
-        log.error(`Error setting startup pref ${childPrefName}; pref type is invalid (${prefType}).`);
-        break;
+        case Services.prefs.PREF_BOOL:
+          defaultBranch.setBoolPref(realPrefName, experimentBranch.getBoolPref(childPrefName));
+          break;
 
-      default:
-        // This should never happen either.
-        log.error(`Error getting startup pref ${childPrefName}; unknown value type ${prefType}.`);
+        case Services.prefs.PREF_INVALID:
+          // This should never happen.
+          log.error(`Error setting startup pref ${childPrefName}; pref type is invalid (${experimentPrefType}).`);
+          break;
+
+        default:
+          // This should never happen either.
+          log.error(`Error getting startup pref ${childPrefName}; unknown value type ${experimentPrefType}.`);
+      }
     }
-  }
-}
+  },
 
-const uiAvailableObserver = {
   observe(subject, topic, data) {
-    Services.obs.removeObserver(uiAvailableObserver, UI_AVAILABLE_NOTIFICATION);
-    ShieldRecipeClient.startup();
+    if (topic === UI_AVAILABLE_NOTIFICATION) {
+      Services.obs.removeObserver(this, UI_AVAILABLE_NOTIFICATION);
+      ShieldRecipeClient.startup();
+    }
+  },
+
+  install() {
+    // Nothing to do during install
+  },
+
+  startup(data, reason) {
+    // Initialization that needs to happen before the first paint on startup.
+    this.initShieldPrefs(DEFAULT_PREFS);
+    this.initExperimentPrefs();
+
+    // If the app is starting up, wait until the UI is available before finishing
+    // init.
+    if (reason === REASON_APP_STARTUP) {
+      Services.obs.addObserver(this, UI_AVAILABLE_NOTIFICATION);
+    } else {
+      ShieldRecipeClient.startup();
+    }
+  },
+
+  async shutdown(data, reason) {
+    // Wait for async write operations during shutdown before unloading modules.
+    await ShieldRecipeClient.shutdown(reason);
+
+    // In case the observer didn't run, clean it up.
+    Services.obs.removeObserver(this, UI_AVAILABLE_NOTIFICATION);
+
+    // Unload add-on modules. We don't do this in ShieldRecipeClient so that
+    // modules are not unloaded accidentally during tests.
+    let modules = [
+      "lib/ActionSandboxManager.jsm",
+      "lib/Addons.jsm",
+      "lib/AddonStudies.jsm",
+      "lib/CleanupManager.jsm",
+      "lib/ClientEnvironment.jsm",
+      "lib/FilterExpressions.jsm",
+      "lib/EventEmitter.jsm",
+      "lib/Heartbeat.jsm",
+      "lib/LogManager.jsm",
+      "lib/NormandyApi.jsm",
+      "lib/NormandyDriver.jsm",
+      "lib/PreferenceExperiments.jsm",
+      "lib/RecipeRunner.jsm",
+      "lib/Sampling.jsm",
+      "lib/SandboxManager.jsm",
+      "lib/ShieldPreferences.jsm",
+      "lib/ShieldRecipeClient.jsm",
+      "lib/Storage.jsm",
+      "lib/Uptake.jsm",
+      "lib/Utils.jsm",
+    ].map(m => `resource://shield-recipe-client/${m}`);
+    modules = modules.concat([
+      "AboutPages.jsm",
+    ].map(m => `resource://shield-recipe-client-content/${m}`));
+    modules = modules.concat([
+      "mozjexl.js",
+    ].map(m => `resource://shield-recipe-client-vendor/${m}`));
+
+    for (const module of modules) {
+      log.debug(`Unloading ${module}`);
+      Cu.unload(module);
+    }
+  },
+
+  uninstall() {
+    // Do nothing
   },
 };
 
-this.install = function() {};
-
-this.startup = function(data, reason) {
-  // Initialization that needs to happen before the first paint on startup.
-  initializeShieldPreferences();
-  initializeExperimentPreferences();
-
-  // If the app is starting up, wait until the UI is available before finishing
-  // init.
-  if (reason === REASON_APP_STARTUP) {
-    Services.obs.addObserver(uiAvailableObserver, UI_AVAILABLE_NOTIFICATION);
-  } else {
-    ShieldRecipeClient.startup();
-  }
-};
-
-this.shutdown = async function(data, reason) {
-  // Wait for async write operations during shutdown before unloading modules.
-  await ShieldRecipeClient.shutdown(reason);
-
-  // In case the observer didn't run, clean it up.
-  Services.obs.removeObserver(uiAvailableObserver, UI_AVAILABLE_NOTIFICATION);
-
-  // Unload add-on modules. We don't do this in ShieldRecipeClient so that
-  // modules are not unloaded accidentally during tests.
-  let modules = [
-    "lib/ActionSandboxManager.jsm",
-    "lib/Addons.jsm",
-    "lib/AddonStudies.jsm",
-    "lib/CleanupManager.jsm",
-    "lib/ClientEnvironment.jsm",
-    "lib/FilterExpressions.jsm",
-    "lib/EventEmitter.jsm",
-    "lib/Heartbeat.jsm",
-    "lib/LogManager.jsm",
-    "lib/NormandyApi.jsm",
-    "lib/NormandyDriver.jsm",
-    "lib/PreferenceExperiments.jsm",
-    "lib/RecipeRunner.jsm",
-    "lib/Sampling.jsm",
-    "lib/SandboxManager.jsm",
-    "lib/ShieldPreferences.jsm",
-    "lib/ShieldRecipeClient.jsm",
-    "lib/Storage.jsm",
-    "lib/Uptake.jsm",
-    "lib/Utils.jsm",
-  ].map(m => `resource://shield-recipe-client/${m}`);
-  modules = modules.concat([
-    "AboutPages.jsm",
-  ].map(m => `resource://shield-recipe-client-content/${m}`));
-  modules = modules.concat([
-    "mozjexl.js",
-  ].map(m => `resource://shield-recipe-client-vendor/${m}`));
-
-  for (const module of modules) {
-    log.debug(`Unloading ${module}`);
-    Cu.unload(module);
-  }
-};
-
-this.uninstall = function() {};
+// Expose bootstrap methods on the global
+for (const methodName of ["install", "startup", "shutdown", "uninstall"]) {
+  this[methodName] = Bootstrap[methodName].bind(Bootstrap);
+}

--- a/recipe-client-addon/lib/CleanupManager.jsm
+++ b/recipe-client-addon/lib/CleanupManager.jsm
@@ -32,7 +32,6 @@ class CleanupManagerClass {
           try {
             await handler();
           } catch (ex) {
-            // TODO: Log error in a way that persists after shutdown
             Cu.reportError(ex);
           }
         }

--- a/recipe-client-addon/lib/CleanupManager.jsm
+++ b/recipe-client-addon/lib/CleanupManager.jsm
@@ -11,22 +11,24 @@ XPCOMUtils.defineLazyModuleGetter(this, "AsyncShutdown", "resource://gre/modules
 
 this.EXPORTED_SYMBOLS = ["CleanupManager"];
 
-let cleanupPromise = null;
-const cleanupHandlers = new Set();
+class CleanupManagerClass {
+  constructor() {
+    this.handlers = new Set();
+    this.cleanupPromise = null;
+  }
 
-this.CleanupManager = {
   addCleanupHandler(handler) {
-    cleanupHandlers.add(handler);
-  },
+    this.handlers.add(handler);
+  }
 
   removeCleanupHandler(handler) {
-    cleanupHandlers.delete(handler);
-  },
+    this.handlers.delete(handler);
+  }
 
   async cleanup() {
-    if (cleanupPromise === null) {
-      cleanupPromise = (async () => {
-        for (const handler of cleanupHandlers) {
+    if (this.cleanupPromise === null) {
+      this.cleanupPromise = (async () => {
+        for (const handler of this.handlers) {
           try {
             await handler();
           } catch (ex) {
@@ -40,10 +42,12 @@ this.CleanupManager = {
       // finished.
       AsyncShutdown.profileBeforeChange.addBlocker(
         "ShieldRecipeClient: Cleaning up",
-        cleanupPromise,
+        this.cleanupPromise,
       );
     }
 
-    return cleanupPromise;
-  },
-};
+    return this.cleanupPromise;
+  }
+}
+
+this.CleanupManager = new CleanupManagerClass();

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -172,11 +172,7 @@ this.PreferenceExperiments = {
    */
   async saveStartupPrefs() {
     const prefBranch = Services.prefs.getBranch(STARTUP_EXPERIMENT_PREFS_BRANCH);
-    try {
-      prefBranch.resetBranch();
-    } catch (err) {
-      log.debug(`Could not reset startup pref branch: ${err.message}`);
-    }
+    prefBranch.deleteBranch("");
 
     for (const experiment of await this.getAllActive()) {
       const name = experiment.preferenceName;
@@ -327,7 +323,7 @@ this.PreferenceExperiments = {
     const observerInfo = {
       preferenceName,
       observer() {
-        let newValue = getPref(UserPreferences, preferenceName, preferenceType, undefined);
+        const newValue = getPref(UserPreferences, preferenceName, preferenceType, undefined);
         if (newValue !== preferenceValue) {
           PreferenceExperiments.stop(experimentName, false)
                                .catch(Cu.reportError);

--- a/recipe-client-addon/lib/ShieldRecipeClient.jsm
+++ b/recipe-client-addon/lib/ShieldRecipeClient.jsm
@@ -70,8 +70,6 @@ this.ShieldRecipeClient = {
       log.error("Failed to initialize addon studies:", err);
     }
 
-    // Initialize experiments first to avoid a race between initializing prefs
-    // and recipes rolling back pref changes when experiments end.
     try {
       await PreferenceExperiments.init();
     } catch (err) {
@@ -88,7 +86,7 @@ this.ShieldRecipeClient = {
     Services.obs.notifyObservers(null, SHIELD_INIT_NOTIFICATION);
   },
 
-  shutdown(reason) {
-    CleanupManager.cleanup();
+  async shutdown(reason) {
+    await CleanupManager.cleanup();
   },
 };

--- a/recipe-client-addon/lib/ShieldRecipeClient.jsm
+++ b/recipe-client-addon/lib/ShieldRecipeClient.jsm
@@ -39,6 +39,7 @@ const REASONS = {
 };
 const PREF_DEV_MODE = "extensions.shield-recipe-client.dev_mode";
 const PREF_LOGGING_LEVEL = "extensions.shield-recipe-client.logging.level";
+const SHIELD_INIT_NOTIFICATION = "shield-init-complete";
 
 let log = null;
 
@@ -84,6 +85,7 @@ this.ShieldRecipeClient = {
     }
 
     await RecipeRunner.init();
+    Services.obs.notifyObservers(null, SHIELD_INIT_NOTIFICATION);
   },
 
   shutdown(reason) {

--- a/recipe-client-addon/test/browser/browser.ini
+++ b/recipe-client-addon/test/browser/browser.ini
@@ -6,6 +6,8 @@ head = head.js
 [browser_ActionSandboxManager.js]
 [browser_Addons.js]
 [browser_AddonStudies.js]
+[browser_bootstrap.js]
+[browser_CleanupManager.js]
 [browser_NormandyDriver.js]
 [browser_FilterExpressions.js]
 [browser_EventEmitter.js]

--- a/recipe-client-addon/test/browser/browser_CleanupManager.js
+++ b/recipe-client-addon/test/browser/browser_CleanupManager.js
@@ -1,0 +1,24 @@
+"use strict";
+
+Cu.import("resource://shield-recipe-client/lib/CleanupManager.jsm", this); /* global CleanupManagerClass */
+
+add_task(async function testCleanupManager() {
+  const spy1 = sinon.spy();
+  const spy2 = sinon.spy();
+  const spy3 = sinon.spy();
+
+  const manager = new CleanupManager.constructor();
+  manager.addCleanupHandler(spy1);
+  manager.addCleanupHandler(spy2);
+  manager.addCleanupHandler(spy3);
+  manager.removeCleanupHandler(spy2); // Test removal
+
+  await manager.cleanup();
+  ok(spy1.called, "cleanup called the spy1 handler");
+  ok(!spy2.called, "cleanup did not call the spy2 handler");
+  ok(spy3.called, "cleanup called the spy3 handler");
+
+  await manager.cleanup();
+  ok(spy1.calledOnce, "cleanup only called the spy1 handler once");
+  ok(spy3.calledOnce, "cleanup only called the spy3 handler once");
+});

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -7,6 +7,7 @@ Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm", this)
 // Save ourselves some typing
 const {withMockExperiments} = PreferenceExperiments;
 const DefaultPreferences = new Preferences({defaultBranch: true});
+const startupPrefs = "extensions.shield-recipe-client.startupExperimentPrefs";
 
 function experimentFactory(attrs) {
   return Object.assign({
@@ -82,52 +83,59 @@ add_task(withMockExperiments(async function() {
 
 // start should save experiment data, modify the preference, and register a
 // watcher.
-add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
-  const startObserver = sinon.stub(PreferenceExperiments, "startObserver");
-  mockPreferences.set("fake.preference", "oldvalue", "default");
-  mockPreferences.set("fake.preference", "uservalue", "user");
+decorate_task(
+  withMockExperiments,
+  withMockPreferences,
+  withStub(PreferenceExperiments, "startObserver"),
+  async function testStart(experiments, mockPreferences, startObserverStub) {
+    mockPreferences.set("fake.preference", "oldvalue", "default");
+    mockPreferences.set("fake.preference", "uservalue", "user");
 
-  await PreferenceExperiments.start({
-    name: "test",
-    branch: "branch",
-    preferenceName: "fake.preference",
-    preferenceValue: "newvalue",
-    preferenceBranchType: "default",
-    preferenceType: "string",
-  });
-  ok("test" in experiments, "start saved the experiment");
-  ok(
-    startObserver.calledWith("test", "fake.preference", "string", "newvalue"),
-    "start registered an observer",
-  );
+    await PreferenceExperiments.start({
+      name: "test",
+      branch: "branch",
+      preferenceName: "fake.preference",
+      preferenceValue: "newvalue",
+      preferenceBranchType: "default",
+      preferenceType: "string",
+    });
+    ok("test" in experiments, "start saved the experiment");
+    ok(
+      startObserverStub.calledWith("test", "fake.preference", "string", "newvalue"),
+      "start registered an observer",
+    );
 
-  const expectedExperiment = {
-    name: "test",
-    branch: "branch",
-    expired: false,
-    preferenceName: "fake.preference",
-    preferenceValue: "newvalue",
-    preferenceType: "string",
-    previousPreferenceValue: "oldvalue",
-    preferenceBranchType: "default",
-  };
-  const experiment = {};
-  Object.keys(expectedExperiment).forEach(key => experiment[key] = experiments.test[key]);
-  Assert.deepEqual(experiment, expectedExperiment, "start saved the experiment");
+    const expectedExperiment = {
+      name: "test",
+      branch: "branch",
+      expired: false,
+      preferenceName: "fake.preference",
+      preferenceValue: "newvalue",
+      preferenceType: "string",
+      previousPreferenceValue: "oldvalue",
+      preferenceBranchType: "default",
+    };
+    const experiment = {};
+    Object.keys(expectedExperiment).forEach(key => experiment[key] = experiments.test[key]);
+    Assert.deepEqual(experiment, expectedExperiment, "start saved the experiment");
 
-  is(
-    DefaultPreferences.get("fake.preference"),
-    "newvalue",
-    "start modified the default preference",
-  );
-  is(
-    Preferences.get("fake.preference"),
-    "uservalue",
-    "start did not modify the user preference",
-  );
-
-  startObserver.restore();
-})));
+    is(
+      DefaultPreferences.get("fake.preference"),
+      "newvalue",
+      "start modified the default preference",
+    );
+    is(
+      Preferences.get("fake.preference"),
+      "uservalue",
+      "start did not modify the user preference",
+    );
+    is(
+      Preferences.get(`${startupPrefs}.fake.preference`),
+      "newvalue",
+      "start saved the experiment value to the startup prefs tree",
+    );
+  },
+);
 
 // start should modify the user preference for the user branch type
 add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
@@ -205,13 +213,13 @@ add_task(withMockExperiments(async function() {
 // startObserver should register an observer that calls stop when a preference
 // changes from its experimental value.
 add_task(withMockExperiments(withMockPreferences(async function(mockExperiments, mockPreferences) {
-  let tests = [
+  const tests = [
     ["string", "startvalue", "experimentvalue", "newvalue"],
     ["boolean", false, true, false],
     ["integer", 1, 2, 42],
   ];
 
-  for (let [type, startvalue, experimentvalue, newvalue] of tests) {
+  for (const [type, startvalue, experimentvalue, newvalue] of tests) {
     const stop = sinon.stub(PreferenceExperiments, "stop");
     mockPreferences.set("fake.preference" + type, startvalue);
 
@@ -344,33 +352,40 @@ add_task(withMockExperiments(async function(experiments) {
 
 // stop should mark the experiment as expired, stop its observer, and revert the
 // preference value.
-add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
-  const stopObserver = sinon.spy(PreferenceExperiments, "stopObserver");
+decorate_task(
+  withMockExperiments,
+  withMockPreferences,
+  withSpy(PreferenceExperiments, "stopObserver"),
+  async function testStop(experiments, mockPreferences, stopObserverSpy) {
+    mockPreferences.set(`${startupPrefs}.fake.preference`, "experimentvalue", "user");
+    mockPreferences.set("fake.preference", "experimentvalue", "default");
+    experiments.test = experimentFactory({
+      name: "test",
+      expired: false,
+      preferenceName: "fake.preference",
+      preferenceValue: "experimentvalue",
+      preferenceType: "string",
+      previousPreferenceValue: "oldvalue",
+      preferenceBranchType: "default",
+    });
+    PreferenceExperiments.startObserver("test", "fake.preference", "string", "experimentvalue");
 
-  mockPreferences.set("fake.preference", "experimentvalue", "default");
-  experiments.test = experimentFactory({
-    name: "test",
-    expired: false,
-    preferenceName: "fake.preference",
-    preferenceValue: "experimentvalue",
-    preferenceType: "string",
-    previousPreferenceValue: "oldvalue",
-    preferenceBranchType: "default",
-  });
-  PreferenceExperiments.startObserver("test", "fake.preference", "string", "experimentvalue");
+    await PreferenceExperiments.stop("test");
+    ok(stopObserverSpy.calledWith("test"), "stop removed an observer");
+    is(experiments.test.expired, true, "stop marked the experiment as expired");
+    is(
+      DefaultPreferences.get("fake.preference"),
+      "oldvalue",
+      "stop reverted the preference to its previous value",
+    );
+    ok(
+      !Services.prefs.prefHasUserValue(`${startupPrefs}.fake.preference`),
+      "stop cleared the startup preference for fake.preference.",
+    );
 
-  await PreferenceExperiments.stop("test");
-  ok(stopObserver.calledWith("test"), "stop removed an observer");
-  is(experiments.test.expired, true, "stop marked the experiment as expired");
-  is(
-    DefaultPreferences.get("fake.preference"),
-    "oldvalue",
-    "stop reverted the preference to its previous value",
-  );
-
-  stopObserver.restore();
-  PreferenceExperiments.stopAllObservers();
-})));
+    PreferenceExperiments.stopAllObservers();
+  },
+);
 
 // stop should also support user pref experiments
 add_task(withMockExperiments(withMockPreferences(async function(experiments, mockPreferences) {
@@ -398,19 +413,6 @@ add_task(withMockExperiments(withMockPreferences(async function(experiments, moc
     "oldvalue",
     "stop reverted the preference to its previous value",
   );
-
-  stopObserver.restore();
-  hasObserver.restore();
-})));
-
-// stop should not call stopObserver if there is no observer registered.
-add_task(withMockExperiments(withMockPreferences(async function(experiments) {
-  const stopObserver = sinon.spy(PreferenceExperiments, "stopObserver");
-  experiments.test = experimentFactory({name: "test", expired: false});
-
-  await PreferenceExperiments.stop("test");
-  ok(!stopObserver.called, "stop did not bother to stop an observer that wasn't active");
-
   stopObserver.restore();
   PreferenceExperiments.stopAllObservers();
 })));
@@ -539,52 +541,6 @@ add_task(withMockExperiments(async function(experiments) {
   ok(!(await PreferenceExperiments.has("missing")), "has returned false for a missing experiment");
 }));
 
-// init should set the default preference value for active, default experiments
-add_task(withMockExperiments(withMockPreferences(async function testInit(experiments, mockPreferences) {
-  experiments.user = experimentFactory({
-    name: "user",
-    preferenceName: "user",
-    preferenceValue: true,
-    preferenceType: "boolean",
-    expired: false,
-    preferenceBranchType: "user",
-  });
-  experiments.default = experimentFactory({
-    name: "default",
-    preferenceName: "default",
-    preferenceValue: true,
-    preferenceType: "boolean",
-    expired: false,
-    preferenceBranchType: "default",
-  });
-  experiments.expireddefault = experimentFactory({
-    name: "expireddefault",
-    preferenceName: "expireddefault",
-    preferenceValue: true,
-    preferenceType: "boolean",
-    expired: true,
-    preferenceBranchType: "default",
-  });
-
-  for (const experiment of Object.values(experiments)) {
-    mockPreferences.set(experiment.preferenceName, false, "default");
-  }
-
-  await PreferenceExperiments.init();
-
-  is(DefaultPreferences.get("user"), false, "init ignored a user pref experiment");
-  is(
-    DefaultPreferences.get("default"),
-    true,
-    "init set the value for a default pref experiment",
-  );
-  is(
-    DefaultPreferences.get("expireddefault"),
-    false,
-    "init ignored an expired default pref experiment",
-  );
-})));
-
 // init should register telemetry experiments
 decorate_task(
   withMockExperiments,
@@ -681,3 +637,59 @@ add_task(withMockExperiments(withMockPreferences(async function testInitRegister
 
   startObserver.restore();
 })));
+
+decorate_task(
+  withMockExperiments,
+  async function testSaveStartupPrefs(experiments) {
+    const experimentPrefs = {
+      char: "string",
+      int: 2,
+      bool: true,
+    };
+
+    for (const [key, value] of Object.entries(experimentPrefs)) {
+      experiments[key] = experimentFactory({
+        preferenceName: `fake.${key}`,
+        preferenceValue: value,
+      });
+    }
+
+    Services.prefs.deleteBranch(startupPrefs);
+    Services.prefs.setBoolPref(`${startupPrefs}.fake.old`, true);
+    await PreferenceExperiments.saveStartupPrefs();
+
+    ok(
+      Services.prefs.getBoolPref(`${startupPrefs}.fake.bool`),
+      "The startup value for fake.bool was saved.",
+    );
+    is(
+      Services.prefs.getCharPref(`${startupPrefs}.fake.char`),
+      "string",
+      "The startup value for fake.char was saved.",
+    );
+    is(
+      Services.prefs.getIntPref(`${startupPrefs}.fake.int`),
+      2,
+      "The startup value for fake.int was saved.",
+    );
+    ok(
+      !Services.prefs.prefHasUserValue(`${startupPrefs}.fake.old`),
+      "saveStartupPrefs deleted old startup pref values.",
+    );
+  },
+);
+
+decorate_task(
+  withMockExperiments,
+  async function testSaveStartupPrefsError(experiments) {
+    experiments.test = experimentFactory({
+      preferenceName: "fake.invalidValue",
+      preferenceValue: new Date(),
+    });
+
+    await Assert.rejects(
+      PreferenceExperiments.saveStartupPrefs(),
+      "saveStartupPrefs throws if an experiment has an invalid preference value type",
+    );
+  },
+);

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -332,13 +332,11 @@ decorate_task(
     ],
   }),
   withStub(RecipeRunner, "run"),
-  withStub(CleanupManager, "addCleanupHandler"),
-  withStub(RecipeRunner, "updateRunInterval"),
-  async function testInitDevMode(runStub, addCleanupHandlerStub, updateRunIntervalStub) {
-    RecipeRunner.init();
+  withStub(RecipeRunner, "registerTimer"),
+  async function testInitDevMode(runStub, registerTimerStub, updateRunIntervalStub) {
+    await RecipeRunner.init();
     ok(runStub.called, "RecipeRunner.run is called immediately when in dev mode");
-    ok(addCleanupHandlerStub.called, "A cleanup function is registered when in dev mode");
-    ok(updateRunIntervalStub.called, "A timer is registered when in dev mode");
+    ok(registerTimerStub.called, "RecipeRunner.init registers a timer");
   }
 );
 
@@ -350,13 +348,11 @@ decorate_task(
     ],
   }),
   withStub(RecipeRunner, "run"),
-  withStub(CleanupManager, "addCleanupHandler"),
-  withStub(RecipeRunner, "updateRunInterval"),
-  async function testInit(runStub, addCleanupHandlerStub, updateRunIntervalStub) {
-    RecipeRunner.init();
-    ok(!runStub.called, "RecipeRunner.run is not called immediately when not in dev mode");
-    ok(addCleanupHandlerStub.called, "A cleanup function is registered when not in dev mode");
-    ok(updateRunIntervalStub.called, "A timer is registered when not in dev mode");
+  withStub(RecipeRunner, "registerTimer"),
+  async function testInit(runStub, registerTimerStub) {
+    await RecipeRunner.init();
+    ok(!runStub.called, "RecipeRunner.run is called immediately when not in dev mode or first run");
+    ok(registerTimerStub.called, "RecipeRunner.init registers a timer");
   }
 );
 
@@ -369,20 +365,13 @@ decorate_task(
   }),
   withStub(RecipeRunner, "run"),
   withStub(RecipeRunner, "registerTimer"),
-  withStub(CleanupManager, "addCleanupHandler"),
-  withStub(RecipeRunner, "updateRunInterval"),
   async function testInitFirstRun(runStub, registerTimerStub) {
-    RecipeRunner.init();
-    ok(!runStub.called, "RecipeRunner.run is not called immediately");
-    ok(!registerTimerStub.called, "RecipeRunner.registerTimer is not called immediately");
-
-    RecipeRunner.observe(null, "sessionstore-windows-restored");
-    await TestUtils.topicObserved("shield-init-complete");
-    ok(runStub.called, "RecipeRunner.run is called after the UI is available");
-    ok(registerTimerStub.called, "RecipeRunner.registerTimer is called after the UI is available");
+    await RecipeRunner.init();
+    ok(runStub.called, "RecipeRunner.run is called immediately on first run");
     ok(
       !Services.prefs.getBoolPref("extensions.shield-recipe-client.first_run"),
-      "On first run, the first run pref is set to false after the UI is available"
+      "On first run, the first run pref is set to false"
     );
+    ok(registerTimerStub.called, "RecipeRunner.registerTimer registers a timer");
   }
 );

--- a/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
+++ b/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
@@ -19,11 +19,13 @@ function withStubInits(testFunction) {
 decorate_task(
   withStubInits,
   async function testStartup() {
+    const initObserved = TestUtils.topicObserved("shield-init-complete");
     await ShieldRecipeClient.startup();
     ok(AboutPages.init.called, "startup calls AboutPages.init");
     ok(AddonStudies.init.called, "startup calls AddonStudies.init");
     ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
     ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+    await initObserved;
   }
 );
 

--- a/recipe-client-addon/test/browser/browser_bootstrap.js
+++ b/recipe-client-addon/test/browser/browser_bootstrap.js
@@ -165,7 +165,7 @@ decorate_task(
       "initExperimentPrefs skips prefs that don't match the existing default value's type.",
     );
   },
-).skip();
+);
 
 decorate_task(
   withBootstrap,

--- a/recipe-client-addon/test/browser/browser_bootstrap.js
+++ b/recipe-client-addon/test/browser/browser_bootstrap.js
@@ -1,0 +1,198 @@
+"use strict";
+
+Cu.import("resource://shield-recipe-client/lib/ShieldRecipeClient.jsm", this);
+
+// We can't import bootstrap.js directly since it isn't in the jar manifest, but
+// we can use Addon.getResourceURI to get a path to the file and import using
+// that instead.
+Cu.import("resource://gre/modules/AddonManager.jsm", this);
+const bootstrapPromise = AddonManager.getAddonByID("shield-recipe-client@mozilla.org").then(addon => {
+  const bootstrapUri = addon.getResourceURI("bootstrap.js");
+  const {Bootstrap} = Cu.import(bootstrapUri.spec, {});
+  return Bootstrap;
+});
+
+// Use a decorator to get around getAddonByID being async.
+function withBootstrap(testFunction) {
+  return async function wrappedTestFunction(...args) {
+    const Bootstrap = await bootstrapPromise;
+    return testFunction(...args, Bootstrap);
+  };
+}
+
+const initPref1 = "test.initShieldPrefs1";
+const initPref2 = "test.initShieldPrefs2";
+const initPref3 = "test.initShieldPrefs3";
+decorate_task(
+  withPrefEnv({
+    clear: [[initPref1], [initPref2], [initPref3]],
+  }),
+  withBootstrap,
+  async function testInitShieldPrefs(Bootstrap) {
+    const defaultBranch = Services.prefs.getDefaultBranch("");
+    const prefDefaults = {
+      [initPref1]: true,
+      [initPref2]: 2,
+      [initPref3]: "string",
+    };
+
+    for (const pref of Object.keys(prefDefaults)) {
+      is(
+        defaultBranch.getPrefType(pref),
+        defaultBranch.PREF_INVALID,
+        `Pref ${pref} don't exist before being initialized.`,
+      );
+    }
+
+    Bootstrap.initShieldPrefs(prefDefaults);
+
+    ok(
+      defaultBranch.getBoolPref(initPref1),
+      `Pref ${initPref1} has a default value after being initialized.`,
+    );
+    is(
+      defaultBranch.getIntPref(initPref2),
+      2,
+      `Pref ${initPref2} has a default value after being initialized.`,
+    );
+    is(
+      defaultBranch.getCharPref(initPref3),
+      "string",
+      `Pref ${initPref3} has a default value after being initialized.`,
+    );
+
+    for (const pref of Object.keys(prefDefaults)) {
+      ok(
+        !defaultBranch.prefHasUserValue(pref),
+        `Pref ${pref} doesn't have a user value after being initialized.`,
+      );
+    }
+  },
+);
+
+decorate_task(
+  withBootstrap,
+  async function testInitShieldPrefsError(Bootstrap) {
+    Assert.throws(
+      () => Bootstrap.initShieldPrefs({"test.prefTypeError": new Date()}),
+      "initShieldPrefs throws when given an invalid type for the pref value.",
+    );
+  },
+);
+
+const experimentPref1 = "test.initExperimentPrefs1";
+const experimentPref2 = "test.initExperimentPrefs2";
+const experimentPref3 = "test.initExperimentPrefs3";
+decorate_task(
+  withPrefEnv({
+    set: [
+      [`extensions.shield-recipe-client.startupExperimentPrefs.${experimentPref1}`, true],
+      [`extensions.shield-recipe-client.startupExperimentPrefs.${experimentPref2}`, 2],
+      [`extensions.shield-recipe-client.startupExperimentPrefs.${experimentPref3}`, "string"],
+    ],
+    clear: [[experimentPref1], [experimentPref2], [experimentPref3]],
+  }),
+  withBootstrap,
+  async function testInitExperimentPrefs(Bootstrap) {
+    const defaultBranch = Services.prefs.getDefaultBranch("");
+    for (const pref of [experimentPref1, experimentPref2, experimentPref3]) {
+      is(
+        defaultBranch.getPrefType(pref),
+        defaultBranch.PREF_INVALID,
+        `Pref ${pref} don't exist before being initialized.`,
+      );
+    }
+
+    Bootstrap.initExperimentPrefs();
+
+    ok(
+      defaultBranch.getBoolPref(experimentPref1),
+      `Pref ${experimentPref1} has a default value after being initialized.`,
+    );
+    is(
+      defaultBranch.getIntPref(experimentPref2),
+      2,
+      `Pref ${experimentPref2} has a default value after being initialized.`,
+    );
+    is(
+      defaultBranch.getCharPref(experimentPref3),
+      "string",
+      `Pref ${experimentPref3} has a default value after being initialized.`,
+    );
+
+    for (const pref of [experimentPref1, experimentPref2, experimentPref3]) {
+      ok(
+        !defaultBranch.prefHasUserValue(pref),
+        `Pref ${pref} doesn't have a user value after being initialized.`,
+      );
+    }
+  },
+);
+
+decorate_task(
+  withPrefEnv({
+    set: [
+      ["extensions.shield-recipe-client.startupExperimentPrefs.test.existingPref", "experiment"],
+    ],
+  }),
+  withBootstrap,
+  async function testInitExperimentPrefsExisting(Bootstrap) {
+    const defaultBranch = Services.prefs.getDefaultBranch("");
+    defaultBranch.setCharPref("test.existingPref", "default");
+    Bootstrap.initExperimentPrefs();
+    is(
+      defaultBranch.getCharPref("test.existingPref"),
+      "experiment",
+      "initExperimentPrefs overwrites the default values of existing preferences.",
+    );
+  },
+);
+
+decorate_task(
+  withPrefEnv({
+    set: [
+      ["extensions.shield-recipe-client.startupExperimentPrefs.test.mismatchPref", "experiment"],
+    ],
+  }),
+  withBootstrap,
+  async function testInitExperimentPrefsMismatch(Bootstrap) {
+    const defaultBranch = Services.prefs.getDefaultBranch("");
+    defaultBranch.setIntPref("test.mismatchPref", 2);
+    Bootstrap.initExperimentPrefs();
+    is(
+      defaultBranch.getPrefType("test.mismatchPref"),
+      Services.prefs.PREF_INT,
+      "initExperimentPrefs skips prefs that don't match the existing default value's type.",
+    );
+  },
+).skip();
+
+decorate_task(
+  withBootstrap,
+  withStub(ShieldRecipeClient, "startup"),
+  async function testStartupDelayed(Bootstrap, startupStub) {
+    Bootstrap.startup(undefined, 1); // 1 == APP_STARTUP
+    ok(
+      !startupStub.called,
+      "When started at app startup, do not call ShieldRecipeClient.startup immediately.",
+    );
+
+    Bootstrap.observe(null, "sessionstore-windows-restored");
+    ok(
+      startupStub.called,
+      "Once the sessionstore-windows-restored event is observed, call ShieldRecipeClient.startup.",
+    );
+  },
+);
+
+decorate_task(
+  withBootstrap,
+  withStub(ShieldRecipeClient, "startup"),
+  async function testStartupDelayed(Bootstrap, startupStub) {
+    Bootstrap.startup(undefined, 3); // 1 == ADDON_ENABLED
+    ok(
+      startupStub.called,
+      "When the add-on is enabled outside app startup, call ShieldRecipeClient.startup immediately.",
+    );
+  },
+);

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -278,6 +278,19 @@ this.withStub = function(...stubArgs) {
   };
 };
 
+this.withSpy = function(...spyArgs) {
+  return function wrapper(testFunction) {
+    return async function wrappedTestFunction(...args) {
+      const spy = sinon.spy(...spyArgs);
+      try {
+        await testFunction(...args, spy);
+      } finally {
+        spy.restore();
+      }
+    };
+  };
+};
+
 this.studyEndObserved = function(recipeId) {
   return TestUtils.topicObserved(
     "shield-study-ended",


### PR DESCRIPTION
This addresses the early JSM loads from [bug 1371350](https://bugzilla.mozilla.org/show_bug.cgi?id=1371350), and also should address a significant amount of the regression from [bug 1390325](https://bugzilla.mozilla.org/show_bug.cgi?id=1390325). My try tests (which were on a mildly-older version of this current PR) showed a confident improvement of 4-5% in the fileio measurements on xperf tests, mostly due to moving the IndexedDB reads (and potentially writes if we're initializing the database) to happen after first paint.

Along with moving init to happen after first paint, this moves the initialization of default preference values for experiments into `bootstrap.js` so that it happens as early as possible, since experiments may need prefs to be set to affect behavior before first paint. In order to avoid file reads during this early part of startup, the values to set are now stored in a preference subtree that is updated whenever experiments start/stop, and when the add-on shuts down. 

Comments are inline for a few unresolved issues, but otherwise this should be ready for review.