### PR TITLE
Sync changes from mozilla-central.

### DIFF
--- a/recipe-client-addon/content/AboutPages.jsm
+++ b/recipe-client-addon/content/AboutPages.jsm
@@ -142,7 +142,6 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
     registerParentListeners() {
       Services.mm.addMessageListener("Shield:GetStudyList", this);
       Services.mm.addMessageListener("Shield:RemoveStudy", this);
-      Services.mm.addMessageListener("Shield:OpenOldDataPreferences", this);
     },
 
     /**
@@ -151,7 +150,6 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
     unregisterParentListeners() {
       Services.mm.removeMessageListener("Shield:GetStudyList", this);
       Services.mm.removeMessageListener("Shield:RemoveStudy", this);
-      Services.mm.removeMessageListener("Shield:OpenOldDataPreferences", this);
     },
 
     /**
@@ -166,9 +164,6 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
           break;
         case "Shield:RemoveStudy":
           this.removeStudy(message.data);
-          break;
-        case "Shield:OpenOldDataPreferences":
-          this.openOldDataPreferences();
           break;
       }
     },
@@ -202,11 +197,6 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
       Services.mm.broadcastAsyncMessage("Shield:ReceiveStudyList", {
         studies: await AddonStudies.getAll(),
       });
-    },
-
-    openOldDataPreferences() {
-      const browserWindow = Services.wm.getMostRecentWindow("navigator:browser");
-      browserWindow.openAdvancedPreferences("dataChoicesTab", {origin: "aboutStudies"});
     },
 
     getShieldLearnMoreHref() {

--- a/recipe-client-addon/content/shield-content-frame.js
+++ b/recipe-client-addon/content/shield-content-frame.js
@@ -24,8 +24,6 @@ XPCOMUtils.defineLazyModuleGetter(
   frameGlobal, "AboutPages", "resource://shield-recipe-client-content/AboutPages.jsm",
 );
 
-const USE_OLD_PREF_ORGANIZATION_PREF = "browser.preferences.useOldOrganization";
-
 /**
  * Handles incoming events from the parent process and about:studies.
  * @implements nsIMessageListener
@@ -114,11 +112,7 @@ class ShieldFrameListener {
   }
 
   navigateToDataPreferences() {
-    if (Services.prefs.getBoolPref(USE_OLD_PREF_ORGANIZATION_PREF)) {
-      sendAsyncMessage("Shield:OpenOldDataPreferences");
-    } else {
-      content.location = "about:preferences#privacy-reports";
-    }
+    content.location = "about:preferences#privacy-reports";
   }
 }
 

--- a/recipe-client-addon/lib/ShieldPreferences.jsm
+++ b/recipe-client-addon/lib/ShieldPreferences.jsm
@@ -50,9 +50,9 @@ this.ShieldPreferences = {
     // Disabled when MOZ_DATA_REPORTING is false since the FHR UI is also hidden
     // when data reporting is false.
     if (AppConstants.MOZ_DATA_REPORTING && Services.locale.getAppLocaleAsLangTag().startsWith("en")) {
-      Services.obs.addObserver(this, "advanced-pane-loaded");
+      Services.obs.addObserver(this, "privacy-pane-loaded");
       CleanupManager.addCleanupHandler(() => {
-        Services.obs.removeObserver(this, "advanced-pane-loaded");
+        Services.obs.removeObserver(this, "privacy-pane-loaded");
       });
     }
   },
@@ -60,10 +60,8 @@ this.ShieldPreferences = {
   observe(subject, topic, data) {
     switch (topic) {
       // Add the opt-out-study checkbox to the Privacy preferences when it is shown.
-      case "advanced-pane-loaded":
-        if (!Services.prefs.getBoolPref("browser.preferences.useOldOrganization", false)) {
-          this.injectOptOutStudyCheckbox(subject.document);
-        }
+      case "privacy-pane-loaded":
+        this.injectOptOutStudyCheckbox(subject.document);
         break;
       case NS_PREFBRANCH_PREFCHANGE_TOPIC_ID:
         this.observePrefChange(data);

--- a/recipe-client-addon/test/browser/browser_RecipeRunner.js
+++ b/recipe-client-addon/test/browser/browser_RecipeRunner.js
@@ -376,7 +376,7 @@ decorate_task(
     ok(!runStub.called, "RecipeRunner.run is not called immediately");
     ok(!registerTimerStub.called, "RecipeRunner.registerTimer is not called immediately");
 
-    Services.obs.notifyObservers(null, "sessionstore-windows-restored");
+    RecipeRunner.observe(null, "sessionstore-windows-restored");
     await TestUtils.topicObserved("shield-init-complete");
     ok(runStub.called, "RecipeRunner.run is called after the UI is available");
     ok(registerTimerStub.called, "RecipeRunner.registerTimer is called after the UI is available");

--- a/recipe-client-addon/test/browser/browser_about_studies.js
+++ b/recipe-client-addon/test/browser/browser_about_studies.js
@@ -40,9 +40,6 @@ decorate_task(
 );
 
 decorate_task(
-  withPrefEnv({
-    set: [["browser.preferences.useOldOrganization", false]],
-  }),
   withAboutStudies,
   async function testUpdatePreferencesNewOrganization(browser) {
     ContentTask.spawn(browser, null, () => {
@@ -55,41 +52,6 @@ decorate_task(
       "about:preferences#privacy-reports",
       "Clicking Update Preferences opens the privacy section of the new about:prefernces.",
     );
-  }
-);
-
-decorate_task(
-  withPrefEnv({
-    set: [["browser.preferences.useOldOrganization", true]],
-  }),
-  withAboutStudies,
-  async function testUpdatePreferencesOldOrganization(browser) {
-    // We have to use gBrowser instead of browser in most spots since we're
-    // dealing with a new tab outside of the about:studies tab.
-    const tab = await BrowserTestUtils.switchTab(gBrowser, () => {
-      ContentTask.spawn(browser, null, () => {
-        content.document.getElementById("shield-studies-update-preferences").click();
-      });
-    });
-
-    if (gBrowser.contentDocument.readyState !== "complete") {
-      await BrowserTestUtils.waitForEvent(gBrowser.contentWindow, "load");
-    }
-
-    const location = gBrowser.contentWindow.location.href;
-    is(
-      location,
-      "about:preferences#advanced",
-      "Clicking Update Preferences opens the advanced section of the old about:prefernces.",
-    );
-
-    const dataChoicesTab = gBrowser.contentDocument.getElementById("dataChoicesTab");
-    ok(
-      dataChoicesTab.selected,
-      "Click Update preferences selects the Data Choices tab in the old about:preferences."
-    );
-
-    await BrowserTestUtils.removeTab(tab);
   }
 );
 


### PR DESCRIPTION
Bugs synced:
- Bug 1349689: Remove old preferences fork
- Bug 1392648: Avoid using sessionrestore event in RecipeRunner tests.

This should fix #1030. This change already got reviewed by a Firefox peer when it landed in m-c.