### PR TITLE
Fix #1036: Remove OSX-specific close button CSS for Heartbeat bar.

### DIFF
--- a/recipe-client-addon/skin/osx/Heartbeat.css
+++ b/recipe-client-addon/skin/osx/Heartbeat.css
@@ -9,16 +9,3 @@ notification.heartbeat {
   border-bottom: 1px solid #C1C1C1 !important;
   height: 40px;
 }
-
-/* In themes/osx/global/notification.css the close icon is inverted because notifications
-   on OSX are usually dark. Heartbeat is light, so override that behaviour. */
-
-notification.heartbeat[type="info"] .close-icon:not(:hover) {
-  -moz-image-region: rect(0, 16px, 16px, 0) !important;
-}
-
-@media (min-resolution: 2dppx) {
-  notification.heartbeat[type="info"] .close-icon:not(:hover) {
-    -moz-image-region: rect(0, 32px, 32px, 0) !important;
-  }
-}


### PR DESCRIPTION
Due to changes in browser styles for Photon, the fix is no longer necessary, and
in fact makes the close button look wrong. Without the fix, the close button
looks and behaves the same as the tab bar close buttons.

Here's what the bar looks like on Nightly OSX now:

<img width="751" alt="screen shot 2017-09-05 at 2 24 16 pm" src="https://user-images.githubusercontent.com/193106/30085461-661003a6-924b-11e7-91f8-5799a582aeba.png">

And here's what it looks like with the workaround removed:

<img width="854" alt="screen shot 2017-09-05 at 3 03 03 pm" src="https://user-images.githubusercontent.com/193106/30085469-6de46810-924b-11e7-8dbd-ab9d186d1691.png">

I tested the bar on Windows and Linux (via mythmon) and the close button looks fine on those platforms.

This is a small enough PR that one review is enough IMO.