### PR TITLE
PureComponents

### DIFF
--- a/recipe-server/client/control_new/components/App.js
+++ b/recipe-server/client/control_new/components/App.js
@@ -14,7 +14,7 @@ import QueryServiceInfo from 'control_new/components/data/QueryServiceInfo';
 const { Content, Header, Sider } = Layout;
 
 
-export default class App extends React.Component {
+export default class App extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node,
   };

--- a/recipe-server/client/control_new/components/common/BooleanIcon.js
+++ b/recipe-server/client/control_new/components/common/BooleanIcon.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 
-export default class BooleanIcon extends React.Component {
+export default class BooleanIcon extends React.PureComponent {
   static propTypes = {
     value: PropTypes.bool.isRequired,
   };

--- a/recipe-server/client/control_new/components/common/CheckboxMenu.js
+++ b/recipe-server/client/control_new/components/common/CheckboxMenu.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 
-export default class CheckboxMenu extends React.Component {
+export default class CheckboxMenu extends React.PureComponent {
   static propTypes = {
     checkboxes: PropTypes.array,
     label: PropTypes.string,

--- a/recipe-server/client/control_new/components/common/CurrentUserDetails.js
+++ b/recipe-server/client/control_new/components/common/CurrentUserDetails.js
@@ -16,7 +16,7 @@ import {
     logoutUrl: getLogoutUrl(state, ''),
   }),
 )
-export default class CurrentUserDetails extends React.Component {
+export default class CurrentUserDetails extends React.PureComponent {
   static propTypes = {
     logoutUrl: PropTypes.string.isRequired,
     user: PropTypes.instanceOf(Map).isRequired,

--- a/recipe-server/client/control_new/components/common/NavigationCrumbs.js
+++ b/recipe-server/client/control_new/components/common/NavigationCrumbs.js
@@ -11,7 +11,7 @@ import { Link } from 'redux-little-router';
   }),
 )
 @autobind
-export default class NavigationCrumbs extends React.Component {
+export default class NavigationCrumbs extends React.PureComponent {
   static propTypes = {
     router: PropTypes.object.isRequired,
   };

--- a/recipe-server/client/control_new/components/common/NavigationMenu.js
+++ b/recipe-server/client/control_new/components/common/NavigationMenu.js
@@ -17,7 +17,7 @@ const { Divider, Item, SubMenu } = Menu;
     router: state.router,
   }),
 )
-export default class NavigationMenu extends React.Component {
+export default class NavigationMenu extends React.PureComponent {
   static propTypes = {
     recipeSessionHistory: PropTypes.instanceOf(List).isRequired,
     extensionSessionHistory: PropTypes.instanceOf(List).isRequired,

--- a/recipe-server/client/control_new/components/data/QueryActions.js
+++ b/recipe-server/client/control_new/components/data/QueryActions.js
@@ -10,7 +10,7 @@ import { fetchAllActions } from 'control_new/state/app/actions/actions';
     fetchAllActions,
   },
 )
-export default class QueryActions extends React.Component {
+export default class QueryActions extends React.PureComponent {
   static propTypes = {
     fetchAllActions: PropTypes.func.isRequired,
   }

--- a/recipe-server/client/control_new/components/data/QueryExtension.js
+++ b/recipe-server/client/control_new/components/data/QueryExtension.js
@@ -11,7 +11,7 @@ import { fetchExtension } from 'control_new/state/app/extensions/actions';
     fetchExtension,
   },
 )
-export default class QueryExtension extends React.Component {
+export default class QueryExtension extends React.PureComponent {
   static propTypes = {
     fetchExtension: PropTypes.func.isRequired,
     pk: PropTypes.number.isRequired,

--- a/recipe-server/client/control_new/components/data/QueryExtensionListingColumns.js
+++ b/recipe-server/client/control_new/components/data/QueryExtensionListingColumns.js
@@ -11,7 +11,7 @@ import { loadExtensionListingColumns } from 'control_new/state/app/extensions/ac
     loadExtensionListingColumns,
   },
 )
-export default class QueryExtensionListingColumns extends React.Component {
+export default class QueryExtensionListingColumns extends React.PureComponent {
   static propTypes = {
     loadExtensionListingColumns: PropTypes.func.isRequired,
   };

--- a/recipe-server/client/control_new/components/data/QueryFilteredRecipes.js
+++ b/recipe-server/client/control_new/components/data/QueryFilteredRecipes.js
@@ -12,7 +12,7 @@ import { fetchFilteredRecipesPage } from 'control_new/state/app/recipes/actions'
     fetchFilteredRecipesPage,
   },
 )
-export default class QueryFilteredRecipes extends React.Component {
+export default class QueryFilteredRecipes extends React.PureComponent {
   static propTypes = {
     fetchFilteredRecipesPage: PropTypes.func,
     filters: PropTypes.object,

--- a/recipe-server/client/control_new/components/data/QueryMultipleExtensions.js
+++ b/recipe-server/client/control_new/components/data/QueryMultipleExtensions.js
@@ -14,7 +14,7 @@ import {
     fetchExtensionsPage: fetchExtensionsPageAction,
   },
 )
-export default class QueryMultipleExtensions extends React.Component {
+export default class QueryMultipleExtensions extends React.PureComponent {
   static propTypes = {
     fetchExtensionsPage: PropTypes.func.isRequired,
     filters: PropTypes.object,

--- a/recipe-server/client/control_new/components/data/QueryRecipe.js
+++ b/recipe-server/client/control_new/components/data/QueryRecipe.js
@@ -13,7 +13,7 @@ import {
     fetchRecipe: fetchRecipeAction,
   },
 )
-export default class QueryRecipe extends React.Component {
+export default class QueryRecipe extends React.PureComponent {
   static propTypes = {
     fetchRecipe: PropTypes.func.isRequired,
     pk: PropTypes.number.isRequired,

--- a/recipe-server/client/control_new/components/data/QueryRecipeHistory.js
+++ b/recipe-server/client/control_new/components/data/QueryRecipeHistory.js
@@ -12,7 +12,7 @@ import {
     fetchRecipeHistory: fetchRecipeHistoryAction,
   },
 )
-export default class QueryRecipeHistory extends React.Component {
+export default class QueryRecipeHistory extends React.PureComponent {
   static propTypes = {
     fetchRecipeHistory: PropTypes.func.isRequired,
     pk: PropTypes.number.isRequired,

--- a/recipe-server/client/control_new/components/data/QueryRecipeListingColumns.js
+++ b/recipe-server/client/control_new/components/data/QueryRecipeListingColumns.js
@@ -11,7 +11,7 @@ import { loadRecipeListingColumns } from 'control_new/state/app/recipes/actions'
     loadRecipeListingColumns,
   },
 )
-export default class QueryRecipeListingColumns extends React.Component {
+export default class QueryRecipeListingColumns extends React.PureComponent {
   static propTypes = {
     loadRecipeListingColumns: PropTypes.func.isRequired,
   };

--- a/recipe-server/client/control_new/components/data/QueryRevision.js
+++ b/recipe-server/client/control_new/components/data/QueryRevision.js
@@ -13,7 +13,7 @@ import {
     fetchRevision: fetchRevisionAction,
   },
 )
-export default class QueryRevision extends React.Component {
+export default class QueryRevision extends React.PureComponent {
   static propTypes = {
     fetchRevision: PropTypes.func.isRequired,
     pk: PropTypes.string.isRequired,

--- a/recipe-server/client/control_new/components/data/QueryServiceInfo.js
+++ b/recipe-server/client/control_new/components/data/QueryServiceInfo.js
@@ -11,7 +11,7 @@ import { fetchServiceInfo } from 'control_new/state/app/serviceInfo/actions';
     fetchServiceInfo,
   },
 )
-export default class QueryServiceInfo extends React.Component {
+export default class QueryServiceInfo extends React.PureComponent {
   static propTypes = {
     fetchServiceInfo: PropTypes.func.isRequired,
   }

--- a/recipe-server/client/control_new/components/extensions/CreateExtensionPage.js
+++ b/recipe-server/client/control_new/components/extensions/CreateExtensionPage.js
@@ -19,7 +19,7 @@ import {
   },
 )
 @autobind
-export default class CreateExtensionPage extends React.Component {
+export default class CreateExtensionPage extends React.PureComponent {
   static propTypes = {
     createExtension: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/extensions/EditExtensionPage.js
+++ b/recipe-server/client/control_new/components/extensions/EditExtensionPage.js
@@ -30,7 +30,7 @@ import { addSessionView as addSessionViewAction } from 'control_new/state/app/se
   },
 )
 @autobind
-export default class EditExtensionPage extends React.Component {
+export default class EditExtensionPage extends React.PureComponent {
   static propTypes = {
     extension: PropTypes.instanceOf(Map).isRequired,
     extensionId: PropTypes.number.isRequired,

--- a/recipe-server/client/control_new/components/extensions/ExtensionForm.js
+++ b/recipe-server/client/control_new/components/extensions/ExtensionForm.js
@@ -30,7 +30,7 @@ import { createForm } from 'control_new/utils/forms';
   },
 })
 @autobind
-export default class ExtensionForm extends React.Component {
+export default class ExtensionForm extends React.PureComponent {
   static propTypes = {
     extension: PropTypes.instanceOf(Map),
     form: PropTypes.object.isRequired,

--- a/recipe-server/client/control_new/components/extensions/ExtensionListing.js
+++ b/recipe-server/client/control_new/components/extensions/ExtensionListing.js
@@ -37,7 +37,7 @@ import {
   },
 )
 @autobind
-export default class ExtensionListing extends React.Component {
+export default class ExtensionListing extends React.PureComponent {
   static propTypes = {
     columns: PropTypes.instanceOf(List).isRequired,
     count: PropTypes.number,

--- a/recipe-server/client/control_new/components/extensions/ListingActionBar.js
+++ b/recipe-server/client/control_new/components/extensions/ListingActionBar.js
@@ -28,7 +28,7 @@ import {
   },
 )
 @autobind
-export default class ListingActionBar extends React.Component {
+export default class ListingActionBar extends React.PureComponent {
   static propTypes = {
     columns: PropTypes.instanceOf(List).isRequired,
     getCurrentURL: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/forms/DocumentUrlInput.js
+++ b/recipe-server/client/control_new/components/forms/DocumentUrlInput.js
@@ -5,7 +5,7 @@ import React from 'react';
 /**
  * URL input that displays a clickable link to its value.
  */
-export default class DocumentUrlInput extends React.Component {
+export default class DocumentUrlInput extends React.PureComponent {
   static propTypes = {
     disabled: PropTypes.bool,
     // rc-form warns if the component already has a value prop, but doesn't

--- a/recipe-server/client/control_new/components/forms/FormActions.js
+++ b/recipe-server/client/control_new/components/forms/FormActions.js
@@ -16,11 +16,11 @@ import React from 'react';
  *   </FormActions.Secondary>
  * </FormActions>
  */
-export default class FormActions extends React.Component {
+export default class FormActions extends React.PureComponent {
   /**
    * Container for the primary actions (floated to the right).
    */
-  static Primary = class Primary extends React.Component {
+  static Primary = class Primary extends React.PureComponent {
     static propTypes = {
       children: PropTypes.node,
     };
@@ -38,7 +38,7 @@ export default class FormActions extends React.Component {
   /**
    * Container for the secondary actions (floated to the left).
    */
-  static Secondary = class Secondary extends React.Component {
+  static Secondary = class Secondary extends React.PureComponent {
     static propTypes = {
       children: PropTypes.node,
     };

--- a/recipe-server/client/control_new/components/forms/FormItem.js
+++ b/recipe-server/client/control_new/components/forms/FormItem.js
@@ -19,7 +19,7 @@ import { connectFormProps } from 'control_new/utils/forms';
  */
 @autobind
 @connectFormProps
-export default class FormItem extends React.Component {
+export default class FormItem extends React.PureComponent {
   static propTypes = {
     // The input component used to enter data for this field.
     children: PropTypes.node.isRequired,

--- a/recipe-server/client/control_new/components/forms/SwitchBox.js
+++ b/recipe-server/client/control_new/components/forms/SwitchBox.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 @autobind
-export default class SwitchBox extends React.Component {
+export default class SwitchBox extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node,
     onChange: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/pages/Gateway.js
+++ b/recipe-server/client/control_new/components/pages/Gateway.js
@@ -4,7 +4,7 @@ import { Link } from 'redux-little-router';
 import { Row, Col, Icon, Card } from 'antd';
 
 
-export default class Gateway extends React.Component {
+export default class Gateway extends React.PureComponent {
   render() {
     return (
       <Row className="page-gateway" type="flex" justify="space-around" align="top">

--- a/recipe-server/client/control_new/components/pages/MissingPage.js
+++ b/recipe-server/client/control_new/components/pages/MissingPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 
-export default class MissingPage extends React.Component {
+export default class MissingPage extends React.PureComponent {
   render() {
     return (
       <div className="page-404">

--- a/recipe-server/client/control_new/components/recipes/ApprovalForm.js
+++ b/recipe-server/client/control_new/components/recipes/ApprovalForm.js
@@ -22,7 +22,7 @@ import { createForm } from 'control_new/utils/forms';
 )
 @createForm({})
 @autobind
-export default class ApprovalForm extends React.Component {
+export default class ApprovalForm extends React.PureComponent {
   static propTypes = {
     approvalRequest: PropTypes.instanceOf(Map).isRequired,
     closeApprovalRequest: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/recipes/ApprovalHistoryPage.js
+++ b/recipe-server/client/control_new/components/recipes/ApprovalHistoryPage.js
@@ -23,7 +23,7 @@ import { getUrlParamAsInt } from 'control_new/state/router/selectors';
     };
   },
 )
-export default class ApprovalHistoryPage extends React.Component {
+export default class ApprovalHistoryPage extends React.PureComponent {
   static propTypes = {
     history: PropTypes.instanceOf(List).isRequired,
     recipeId: PropTypes.number.isRequired,

--- a/recipe-server/client/control_new/components/recipes/ApprovalRequest.js
+++ b/recipe-server/client/control_new/components/recipes/ApprovalRequest.js
@@ -31,7 +31,7 @@ import {
   },
 )
 @autobind
-export default class ApprovalRequest extends React.Component {
+export default class ApprovalRequest extends React.PureComponent {
   static propTypes = {
     approvalRequest: PropTypes.instanceOf(Map).isRequired,
     approveApprovalRequest: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/CloneRecipePage.js
@@ -39,7 +39,7 @@ import { getLatestRevisionIdForRecipe } from 'control_new/state/app/recipes/sele
   },
 )
 @autobind
-export default class CloneRecipePage extends React.Component {
+export default class CloneRecipePage extends React.PureComponent {
   static propTypes = {
     createRecipe: PropTypes.func.isRequired,
     isLatestRevision: PropTypes.bool.isRequired,

--- a/recipe-server/client/control_new/components/recipes/ConsoleLogFields.js
+++ b/recipe-server/client/control_new/components/recipes/ConsoleLogFields.js
@@ -6,7 +6,7 @@ import React from 'react';
 import FormItem from 'control_new/components/forms/FormItem';
 
 
-export default class ConsoleLogFields extends React.Component {
+export default class ConsoleLogFields extends React.PureComponent {
   static propTypes = {
     disabled: PropTypes.bool,
     recipeArguments: PropTypes.instanceOf(Map),

--- a/recipe-server/client/control_new/components/recipes/CreateRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/CreateRecipePage.js
@@ -17,7 +17,7 @@ import { createRecipe as createAction } from 'control_new/state/app/recipes/acti
   },
 )
 @autobind
-export default class CreateRecipePage extends React.Component {
+export default class CreateRecipePage extends React.PureComponent {
   static propTypes = {
     createRecipe: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/recipes/DetailsActionBar.js
+++ b/recipe-server/client/control_new/components/recipes/DetailsActionBar.js
@@ -55,7 +55,7 @@ import {
   },
 )
 @autobind
-export default class DetailsActionBar extends React.Component {
+export default class DetailsActionBar extends React.PureComponent {
   static propTypes = {
     disableRecipe: PropTypes.func.isRequired,
     enableRecipe: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/recipes/EditRecipePage.js
+++ b/recipe-server/client/control_new/components/recipes/EditRecipePage.js
@@ -33,7 +33,7 @@ import { getUrlParamAsInt } from 'control_new/state/router/selectors';
   },
 )
 @autobind
-export default class EditRecipePage extends React.Component {
+export default class EditRecipePage extends React.PureComponent {
   static propTypes = {
     addSessionView: PropTypes.func.isRequired,
     updateRecipe: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/recipes/HistoryTimeline.js
+++ b/recipe-server/client/control_new/components/recipes/HistoryTimeline.js
@@ -20,7 +20,7 @@ import {
     isLatestRevision: id => isLatestRevisionSelector(state, id),
   }),
 )
-export default class HistoryTimeline extends React.Component {
+export default class HistoryTimeline extends React.PureComponent {
   static propTypes = {
     history: PropTypes.instanceOf(List).isRequired,
     isLatestRevision: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/recipes/ListingActionBar.js
+++ b/recipe-server/client/control_new/components/recipes/ListingActionBar.js
@@ -31,7 +31,7 @@ import {
   },
 )
 @autobind
-export default class ListingActionBar extends React.Component {
+export default class ListingActionBar extends React.PureComponent {
   static propTypes = {
     columns: PropTypes.instanceOf(List).isRequired,
     getCurrentURL: PropTypes.func.isRequired,

--- a/recipe-server/client/control_new/components/recipes/OptOutStudyFields.js
+++ b/recipe-server/client/control_new/components/recipes/OptOutStudyFields.js
@@ -10,7 +10,7 @@ import ExtensionSelect from 'control_new/components/extensions/ExtensionSelect';
 import { connectFormProps } from 'control_new/utils/forms';
 
 @connectFormProps
-export default class OptOutStudyFields extends React.Component {
+export default class OptOutStudyFields extends React.PureComponent {
   static propTypes = {
     disabled: PropTypes.bool,
     recipeArguments: PropTypes.instanceOf(Map).isRequired,

--- a/recipe-server/client/control_new/components/recipes/PreferenceExperimentFields.js
+++ b/recipe-server/client/control_new/components/recipes/PreferenceExperimentFields.js
@@ -11,7 +11,7 @@ import { connectFormProps } from 'control_new/utils/forms';
 
 
 @connectFormProps
-export default class PreferenceExperimentFields extends React.Component {
+export default class PreferenceExperimentFields extends React.PureComponent {
   static propTypes = {
     disabled: PropTypes.bool,
     form: PropTypes.object.isRequired,
@@ -120,7 +120,7 @@ export default class PreferenceExperimentFields extends React.Component {
  * Select that shows a warning when the user preference branch is selected.
  */
 @connectFormProps
-export class PreferenceBranchSelect extends React.Component {
+export class PreferenceBranchSelect extends React.PureComponent {
   static propTypes = {
     disabled: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
@@ -157,7 +157,7 @@ export class PreferenceBranchSelect extends React.Component {
  */
 @connectFormProps
 @autobind
-export class ExperimentBranches extends React.Component {
+export class ExperimentBranches extends React.PureComponent {
   static propTypes = {
     disabled: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
@@ -221,7 +221,7 @@ export class ExperimentBranches extends React.Component {
 }
 
 @autobind
-export class StringPreferenceField extends React.Component {
+export class StringPreferenceField extends React.PureComponent {
   static propTypes = {
     onChange: PropTypes.func.isRequired,
   };
@@ -241,7 +241,7 @@ export class StringPreferenceField extends React.Component {
   }
 }
 
-export class BooleanPreferenceField extends React.Component {
+export class BooleanPreferenceField extends React.PureComponent {
   static propTypes = {
     value: PropTypes.bool,
   }
@@ -264,7 +264,7 @@ export class BooleanPreferenceField extends React.Component {
   }
 }
 
-export class IntegerPreferenceField extends React.Component {
+export class IntegerPreferenceField extends React.PureComponent {
   render() {
     return (
       <InputNumber {...this.props} />
@@ -274,7 +274,7 @@ export class IntegerPreferenceField extends React.Component {
 
 @connectFormProps
 @autobind
-export class ExperimentBranchFields extends React.Component {
+export class ExperimentBranchFields extends React.PureComponent {
   static propTypes = {
     branch: PropTypes.instanceOf(Map).isRequired,
     disabled: PropTypes.bool,

--- a/recipe-server/client/control_new/components/recipes/RecipeDetailPage.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeDetailPage.js
@@ -33,7 +33,7 @@ import { getUrlParam, getUrlParamAsInt } from 'control_new/state/router/selector
     };
   },
 )
-export default class RecipeDetailPage extends React.Component {
+export default class RecipeDetailPage extends React.PureComponent {
   static propTypes = {
     history: PropTypes.instanceOf(List).isRequired,
     recipeId: PropTypes.number.isRequired,

--- a/recipe-server/client/control_new/components/recipes/RecipeDetails.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeDetails.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { addSessionView } from 'control_new/state/app/session/actions';
 
 @connect(() => ({}), { addSessionView })
-export default class RecipeDetails extends React.Component {
+export default class RecipeDetails extends React.PureComponent {
   static propTypes = {
     addSessionView: PropTypes.func.isRequired,
     recipe: PropTypes.instanceOf(Map).isRequired,

--- a/recipe-server/client/control_new/components/recipes/RecipeForm.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeForm.js
@@ -33,7 +33,7 @@ import QueryServiceInfo from 'control_new/components/data/QueryServiceInfo';
   },
 )
 @autobind
-export default class RecipeForm extends React.Component {
+export default class RecipeForm extends React.PureComponent {
   static propTypes = {
     form: PropTypes.object.isRequired,
     isLoading: PropTypes.bool,
@@ -128,7 +128,7 @@ export default class RecipeForm extends React.Component {
     actions: getAllActions(state, new Map()),
   }),
 )
-class ActionSelect extends React.Component {
+class ActionSelect extends React.PureComponent {
   static propTypes = {
     actions: PropTypes.instanceOf(Map).isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/recipe-server/client/control_new/components/recipes/RecipeListing.js
+++ b/recipe-server/client/control_new/components/recipes/RecipeListing.js
@@ -45,7 +45,7 @@ import {
   },
 )
 @autobind
-export default class RecipeListing extends React.Component {
+export default class RecipeListing extends React.PureComponent {
   static propTypes = {
     columns: PropTypes.instanceOf(List).isRequired,
     count: PropTypes.number,

--- a/recipe-server/client/control_new/components/recipes/RevisionApprovalTag.js
+++ b/recipe-server/client/control_new/components/recipes/RevisionApprovalTag.js
@@ -22,7 +22,7 @@ import {
     status: getRevisionStatus(state, revision.get('id')),
   }),
 )
-export default class RevisionApprovalTag extends React.Component {
+export default class RevisionApprovalTag extends React.PureComponent {
   static propTypes = {
     revision: PropTypes.instanceOf(Map).isRequired,
     status: PropTypes.string,

--- a/recipe-server/client/control_new/components/recipes/RevisionNotice.js
+++ b/recipe-server/client/control_new/components/recipes/RevisionNotice.js
@@ -20,7 +20,7 @@ import {
     status: getRevisionDraftStatus(state, revision.get('id')),
   }),
 )
-export default class RevisionNotice extends React.Component {
+export default class RevisionNotice extends React.PureComponent {
   static propTypes = {
     enabled: PropTypes.bool.isRequired,
     isPendingApproval: PropTypes.bool.isRequired,

--- a/recipe-server/client/control_new/components/recipes/ShowHeartbeatFields.js
+++ b/recipe-server/client/control_new/components/recipes/ShowHeartbeatFields.js
@@ -11,7 +11,7 @@ import { connectFormProps } from 'control_new/utils/forms';
 
 
 @connectFormProps
-export default class ShowHeartbeatFields extends React.Component {
+export default class ShowHeartbeatFields extends React.PureComponent {
   static propTypes = {
     disabled: PropTypes.bool,
     form: PropTypes.object.isRequired,
@@ -137,7 +137,7 @@ export default class ShowHeartbeatFields extends React.Component {
 }
 
 @autobind
-class RepeatSelect extends React.Component {
+class RepeatSelect extends React.PureComponent {
   static propTypes = {
     repeatCount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   };

--- a/recipe-server/client/control_new/components/tables/DataList.js
+++ b/recipe-server/client/control_new/components/tables/DataList.js
@@ -21,7 +21,7 @@ import {
   },
 )
 @autobind
-export default class DataList extends React.Component {
+export default class DataList extends React.PureComponent {
   static propTypes = {
     columnRenderers: PropTypes.object.isRequired,
     columns: PropTypes.instanceOf(List).isRequired,

--- a/recipe-server/client/control_new/index.js
+++ b/recipe-server/client/control_new/index.js
@@ -39,7 +39,7 @@ if (initialLocation) {
   store.dispatch(initializeCurrentLocation(initialLocation));
 }
 
-class Root extends React.Component {
+class Root extends React.PureComponent {
   render() {
     return (
       <Provider store={store}>

--- a/recipe-server/client/control_new/routes.js
+++ b/recipe-server/client/control_new/routes.js
@@ -80,7 +80,7 @@ export const {
 @connect(state => ({
   router: state.router,
 }))
-export default class Router extends React.Component {
+export default class Router extends React.PureComponent {
   static propTypes = {
     router: PropTypes.object.isRequired,
   };

--- a/recipe-server/client/control_new/tests/utils/test_forms.js
+++ b/recipe-server/client/control_new/tests/utils/test_forms.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 
 import { createForm, connectFormProps } from 'control_new/utils/forms';
 
-class FakeComponent extends React.Component { render() { return null; } }
+class FakeComponent extends React.PureComponent { render() { return null; } }
 
 describe('Forms utils', () => {
   describe('createForm', () => {

--- a/recipe-server/client/control_new/utils/forms.js
+++ b/recipe-server/client/control_new/utils/forms.js
@@ -25,7 +25,7 @@ import React from 'react';
  * Usage example:
  *
  * @createForm({})
- * class MyForm extends React.Component {
+ * class MyForm extends React.PureComponent {
  *   render() {
  *     const { onSubmit } = this.props;
  *     return (


### PR DESCRIPTION
- Converts almost every React component we have into a `PureComponent`.
  - The exception being some of the wrapped form inputs.

With this approach, our pages will render far fewer times than necessary, which is a decent performance increase. For upcoming features such as graphs, this will be a great. I'd like to point out this was very easy to accomplish because we went with Immutable!