### PR TITLE
 #996: Process recipes in bulk

### DIFF
--- a/recipe-server/client/control/state/app/recipes/actions.js
+++ b/recipe-server/client/control/state/app/recipes/actions.js
@@ -46,27 +46,6 @@ export function fetchRecipe(pk) {
   };
 }
 
-
-export function fetchRecipesPage(pageNumber = 1) {
-  return async dispatch => {
-    const requestId = `fetch-recipes-page-${pageNumber}`;
-    const recipes = await dispatch(makeApiRequest(requestId, 'v2/recipe/', {
-      data: { page: pageNumber },
-    }));
-
-    recipes.results.forEach(recipe => {
-      dispatch(recipeReceived(recipe));
-    });
-
-    dispatch({
-      type: RECIPE_PAGE_RECEIVE,
-      pageNumber,
-      recipes,
-    });
-  };
-}
-
-
 export function fetchFilteredRecipesPage(pageNumber = 1, filters = {}) {
   return async dispatch => {
     const filterIds = Object.keys(filters).map(key => `${key}-${filters[key]}`);
@@ -77,10 +56,6 @@ export function fetchFilteredRecipesPage(pageNumber = 1, filters = {}) {
         page: pageNumber,
       },
     }));
-
-    recipes.results.forEach(recipe => {
-      dispatch(recipeReceived(recipe));
-    });
 
     dispatch({
       type: RECIPE_PAGE_RECEIVE,
@@ -159,10 +134,6 @@ export function fetchRecipeHistory(pk) {
   return async dispatch => {
     const requestId = `fetch-recipe-history-${pk}`;
     const revisions = await dispatch(makeApiRequest(requestId, `v2/recipe/${pk}/history/`));
-
-    revisions.forEach(revision => {
-      dispatch(revisionReceived(revision));
-    });
 
     dispatch({
       type: RECIPE_HISTORY_RECEIVE,

--- a/recipe-server/client/control/state/app/recipes/reducers.js
+++ b/recipe-server/client/control/state/app/recipes/reducers.js
@@ -39,13 +39,13 @@ function history(state = new Map(), action) {
 }
 
 const formatRecipe = recipe =>
-  recipe
-    .set('action_id', recipe.getIn(['action', 'id'], null))
-    .set('latest_revision_id', recipe.getIn(['latest_revision', 'id'], null))
-    .set('approved_revision_id', recipe.getIn(['approved_revision', 'id'], null))
-    .remove('action')
-    .remove('latest_revision')
-    .remove('approved_revision');
+  recipe.withMutations(mutRecipe =>
+    mutRecipe.set('action_id', mutRecipe.getIn(['action', 'id'], null))
+      .set('latest_revision_id', mutRecipe.getIn(['latest_revision', 'id'], null))
+      .set('approved_revision_id', mutRecipe.getIn(['approved_revision', 'id'], null))
+      .remove('action')
+      .remove('latest_revision')
+      .remove('approved_revision'));
 
 function items(state = new Map(), action) {
   switch (action.type) {

--- a/recipe-server/client/control/state/app/recipes/reducers.js
+++ b/recipe-server/client/control/state/app/recipes/reducers.js
@@ -38,23 +38,31 @@ function history(state = new Map(), action) {
   }
 }
 
+const formatRecipe = recipe =>
+  recipe
+    .set('action_id', recipe.getIn(['action', 'id'], null))
+    .set('latest_revision_id', recipe.getIn(['latest_revision', 'id'], null))
+    .set('approved_revision_id', recipe.getIn(['approved_revision', 'id'], null))
+    .remove('action')
+    .remove('latest_revision')
+    .remove('approved_revision');
 
 function items(state = new Map(), action) {
-  let recipe;
-
   switch (action.type) {
     case RECIPE_RECEIVE: {
-      recipe = fromJS(action.recipe);
+      const recipe = fromJS(action.recipe);
+      return state.set(action.recipe.id, formatRecipe(recipe));
+    }
 
-      recipe = recipe
-        .set('action_id', recipe.getIn(['action', 'id'], null))
-        .set('latest_revision_id', recipe.getIn(['latest_revision', 'id'], null))
-        .set('approved_revision_id', recipe.getIn(['approved_revision', 'id'], null))
-        .remove('action')
-        .remove('latest_revision')
-        .remove('approved_revision');
+    case RECIPE_PAGE_RECEIVE: {
+      const recipes = fromJS(action.recipes.results);
+      let newState = state;
 
-      return state.set(action.recipe.id, recipe);
+      recipes.forEach(receivedRecipe => {
+        newState = newState.set(receivedRecipe.get('id'), formatRecipe(receivedRecipe));
+      });
+
+      return newState;
     }
 
     case RECIPE_DELETE:

--- a/recipe-server/client/control/state/app/recipes/reducers.js
+++ b/recipe-server/client/control/state/app/recipes/reducers.js
@@ -56,13 +56,12 @@ function items(state = new Map(), action) {
 
     case RECIPE_PAGE_RECEIVE: {
       const recipes = fromJS(action.recipes.results);
-      let newState = state;
 
-      recipes.forEach(receivedRecipe => {
-        newState = newState.set(receivedRecipe.get('id'), formatRecipe(receivedRecipe));
+      return state.withMutations(mutState => {
+        recipes.forEach(receivedRecipe => {
+          mutState.set(receivedRecipe.get('id'), formatRecipe(receivedRecipe));
+        });
       });
-
-      return newState;
     }
 
     case RECIPE_DELETE:

--- a/recipe-server/client/control/state/app/revisions/reducers.js
+++ b/recipe-server/client/control/state/app/revisions/reducers.js
@@ -22,15 +22,12 @@ function items(state = new Map(), action) {
   switch (action.type) {
     case RECIPE_HISTORY_RECEIVE: {
       const revisions = fromJS(action.revisions);
-      let newState = state;
 
-      revisions.forEach(revision => {
-        const newRevision = formatRevision(revision);
-
-        newState = newState.set(revision.get('id'), newRevision);
+      return state.withMutations(mutState => {
+        revisions.forEach(revision => {
+          mutState.set(revision.get('id'), formatRevision(revision));
+        });
       });
-
-      return newState;
     }
 
     case REVISION_RECEIVE: {

--- a/recipe-server/client/control/state/app/revisions/reducers.js
+++ b/recipe-server/client/control/state/app/revisions/reducers.js
@@ -5,25 +5,40 @@ import {
   APPROVAL_REQUEST_CREATE,
   APPROVAL_REQUEST_DELETE,
   RECIPE_DELETE,
+  RECIPE_HISTORY_RECEIVE,
   REVISION_RECEIVE,
 } from 'control/state/action-types';
 
+const formatRevision = revision =>
+  revision
+    .setIn(['recipe', 'action_id'], revision.getIn(['recipe', 'action', 'id'], null))
+    .removeIn(['recipe', 'action'])
+    .set('approval_request_id', revision.getIn(['approval_request', 'id'], null))
+    .remove('approval_request')
+    .set('user_id', revision.getIn(['user', 'id'], null))
+    .remove('user');
 
 function items(state = new Map(), action) {
-  let revision;
-
   switch (action.type) {
-    case REVISION_RECEIVE:
-      revision = fromJS(action.revision);
-      revision = revision
-        .setIn(['recipe', 'action_id'], revision.getIn(['recipe', 'action', 'id'], null))
-        .removeIn(['recipe', 'action'])
-        .set('approval_request_id', revision.getIn(['approval_request', 'id'], null))
-        .remove('approval_request')
-        .set('user_id', revision.getIn(['user', 'id'], null))
-        .remove('user');
+    case RECIPE_HISTORY_RECEIVE: {
+      const revisions = fromJS(action.revisions);
+      let newState = state;
+
+      revisions.forEach(revision => {
+        const newRevision = formatRevision(revision);
+
+        newState = newState.set(revision.get('id'), newRevision);
+      });
+
+      return newState;
+    }
+
+    case REVISION_RECEIVE: {
+      let revision = fromJS(action.revision);
+      revision = formatRevision(revision);
 
       return state.set(action.revision.id, revision);
+    }
 
     case RECIPE_DELETE:
       return state.filterNot(item => item.getIn(['recipe', 'id']) === action.recipeId);

--- a/recipe-server/client/control/state/app/revisions/reducers.js
+++ b/recipe-server/client/control/state/app/revisions/reducers.js
@@ -10,13 +10,13 @@ import {
 } from 'control/state/action-types';
 
 const formatRevision = revision =>
-  revision
-    .setIn(['recipe', 'action_id'], revision.getIn(['recipe', 'action', 'id'], null))
-    .removeIn(['recipe', 'action'])
-    .set('approval_request_id', revision.getIn(['approval_request', 'id'], null))
-    .remove('approval_request')
-    .set('user_id', revision.getIn(['user', 'id'], null))
-    .remove('user');
+  revision.withMutations(mutRevision =>
+    mutRevision.setIn(['recipe', 'action_id'], mutRevision.getIn(['recipe', 'action', 'id'], null))
+      .removeIn(['recipe', 'action'])
+      .set('approval_request_id', mutRevision.getIn(['approval_request', 'id'], null))
+      .remove('approval_request')
+      .set('user_id', mutRevision.getIn(['user', 'id'], null))
+      .remove('user'));
 
 function items(state = new Map(), action) {
   switch (action.type) {


### PR DESCRIPTION
Fixes #996 - Long listing page load times

- Replaces firing multiple `dispatch`ed actions with one 'bulk' handler action
  - Specifically, instead of firing a bunch of `recipeReceived`s, we fire one action with type `RECIPE_PAGE_RECEIVE` and process all the recipes in one go in the reducer.
- This approach cuts the measured front end 'load time' by ~40-60% and greatly improves the UX around the two components
- This PR contains the changes for bulk processing the recipe listing and recipe histories.