### PR TITLE
Fix ExtensionSelect

### DIFF
--- a/recipe-server/client/control_new/components/extensions/ExtensionSelect.js
+++ b/recipe-server/client/control_new/components/extensions/ExtensionSelect.js
@@ -57,7 +57,12 @@ export default class ExtensionSelect extends React.Component {
       noOptionsDisplay,
     } = ExtensionSelect;
 
-    if (this.props.isLoadingSearch) {
+    const {
+      isLoadingSearch,
+      ...rest
+    } = this.props;
+
+    if (isLoadingSearch) {
       displayedList = new List();
     }
 
@@ -65,9 +70,10 @@ export default class ExtensionSelect extends React.Component {
       <div>
         <QueryMultipleExtensions filters={queryFilters} pageNumber={1} />
         <Select
+          {...rest}
           filterOption={false}
           placeholder={placeholderElement}
-          notFoundContent={this.props.isLoadingSearch ? loadingDisplay : noOptionsDisplay}
+          notFoundContent={isLoadingSearch ? loadingDisplay : noOptionsDisplay}
           onSearch={this.updateSearch}
           showSearch
         >


### PR DESCRIPTION
This fixes an issue with the `ExtensionSelect` component not displaying loaded values correctly. The problem was that the internal `Select` component was not inheriting any of the form props such as `onChange`, `initialValue`, etc.

I can whip up a test for this if necessary, I'll let @Osmose make that call!