### PR TITLE
#1051: Fix ExtensionSelect placeholder

### DIFF
--- a/recipe-server/client/control_new/components/extensions/ExtensionSelect.js
+++ b/recipe-server/client/control_new/components/extensions/ExtensionSelect.js
@@ -27,12 +27,14 @@ export default class ExtensionSelect extends React.Component {
     isLoadingSearch: PropTypes.bool.isRequired,
     onChange: PropTypes.func,
     size: PropTypes.oneOf(['small', 'large']),
+    value: PropTypes.any,
   };
 
   static defaultProps = {
     disabled: false,
     onChange: null,
     size: 'default',
+    value: null,
   };
 
   // Define the commonly-used elements on the class, so they're compiled only once.
@@ -71,6 +73,7 @@ export default class ExtensionSelect extends React.Component {
       disabled,
       onChange,
       size,
+      value,
     } = this.props;
 
     if (isLoadingSearch) {
@@ -81,6 +84,7 @@ export default class ExtensionSelect extends React.Component {
       <div>
         <QueryMultipleExtensions filters={queryFilters} pageNumber={1} />
         <Select
+          value={value || undefined}
           disabled={disabled}
           onChange={onChange}
           size={size}
@@ -90,9 +94,12 @@ export default class ExtensionSelect extends React.Component {
           onSearch={this.updateSearch}
           showSearch
         >
-          {displayedList.map(item =>
-            <Option key={item.get('xpi')}>{item.get('name')}</Option>,
-          )}
+          {displayedList.map(item => {
+            const xpi = item.get('xpi');
+            const name = item.get('name');
+
+            return (<Option key={xpi} value={xpi} title={name}>{name}</Option>);
+          })}
         </Select>
       </div>
     );

--- a/recipe-server/client/control_new/components/extensions/ExtensionSelect.js
+++ b/recipe-server/client/control_new/components/extensions/ExtensionSelect.js
@@ -22,8 +22,17 @@ const { Option } = Select;
 @autobind
 export default class ExtensionSelect extends React.Component {
   static propTypes = {
+    disabled: PropTypes.bool,
     extensions: PropTypes.instanceOf(List).isRequired,
     isLoadingSearch: PropTypes.bool.isRequired,
+    onChange: PropTypes.func,
+    size: PropTypes.oneOf(['small', 'large']),
+  };
+
+  static defaultProps = {
+    disabled: false,
+    onChange: null,
+    size: 'default',
   };
 
   // Define the commonly-used elements on the class, so they're compiled only once.
@@ -59,7 +68,9 @@ export default class ExtensionSelect extends React.Component {
 
     const {
       isLoadingSearch,
-      ...rest
+      disabled,
+      onChange,
+      size,
     } = this.props;
 
     if (isLoadingSearch) {
@@ -70,7 +81,9 @@ export default class ExtensionSelect extends React.Component {
       <div>
         <QueryMultipleExtensions filters={queryFilters} pageNumber={1} />
         <Select
-          {...rest}
+          disabled={disabled}
+          onChange={onChange}
+          size={size}
           filterOption={false}
           placeholder={placeholderElement}
           notFoundContent={isLoadingSearch ? loadingDisplay : noOptionsDisplay}

--- a/recipe-server/client/control_new/tests/components/extensions/test_ExtensionSelect.js
+++ b/recipe-server/client/control_new/tests/components/extensions/test_ExtensionSelect.js
@@ -1,0 +1,39 @@
+import { mount } from 'enzyme';
+import { List } from 'immutable';
+import React from 'react';
+
+import { wrapMockStore } from 'control_new/tests/mockStore';
+import TestComponent from 'control_new/components/extensions/ExtensionSelect';
+
+const { WrappedComponent: ExtensionSelect } = TestComponent;
+
+
+describe('<ExtensionSelect>', () => {
+  const props = {
+    disabled: false,
+    extensions: new List(),
+    isLoadingSearch: false,
+    onChange: () => {},
+    size: 'default',
+  };
+
+  it('should work', () => {
+    // Need to wrap the components with a mock store in order to mount the nested
+    // (but connected) query component.
+    const wrapper = () => mount(wrapMockStore(<ExtensionSelect {...props} />));
+
+    expect(wrapper).not.toThrow();
+  });
+
+  it('should display the placeholder element appropriately', () => {
+    const wrapper = mount(wrapMockStore(<ExtensionSelect {...props} />));
+
+    // Determine if the ant placeholder is present on the page.
+    const placeholderElement = wrapper.find('.ant-select-selection__placeholder');
+    expect(placeholderElement.length).toBe(1);
+
+    // Determine if the placeholder is actually visible to the user.
+    const placeholderStyle = placeholderElement.get(0).style;
+    expect(placeholderStyle.display).toBe('block');
+  });
+});

--- a/recipe-server/client/control_new/tests/mockStore.js
+++ b/recipe-server/client/control_new/tests/mockStore.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { applyMiddleware, compose, createStore } from 'redux';
+import thunk from 'redux-thunk';
+
+import reducers from 'control_new/state';
+
+export function createMockStore() {
+  return createStore(
+    reducers,
+    reducers(undefined, { type: 'initial' }),
+    compose(applyMiddleware(thunk)),
+  );
+}
+
+export function wrapMockStore(element) {
+  return (
+    <Provider store={createMockStore()}>
+      { element }
+    </Provider>
+  );
+}


### PR DESCRIPTION
Fixes #1051 

- Corrects bug where passing in inherited props broke the displayed placeholder.
  - Specifies which props to inherit, adds them to `propTypes` and `defaultProps` as appropriate
- Adds tests to determine that `ExtensionSelect` works and that the placeholder appears.
- Adds a `tests/mockStore.js` util file that allows us to wrap a component in a `Provider` with a mock `store`. This was needed in order to `mount` the component, since there is a nested Query component which is `connect`ed and requires a store etc.