### PR TITLE
Use the correct attribute name when comparing telemetry timestamps.

### DIFF
--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -107,7 +107,7 @@ this.ClientEnvironment = {
       const mostRecentPings = {};
       for (const ping of pings) {
         if (ping.type in mostRecentPings) {
-          if (mostRecentPings[ping.type].timeStampCreated < ping.timeStampCreated) {
+          if (mostRecentPings[ping.type].timestampCreated < ping.timestampCreated) {
             mostRecentPings[ping.type] = ping;
           }
         } else {

--- a/recipe-client-addon/test/browser/browser_ClientEnvironment.js
+++ b/recipe-client-addon/test/browser/browser_ClientEnvironment.js
@@ -12,6 +12,7 @@ add_task(async function testTelemetry() {
   // setup
   await TelemetryController.submitExternalPing("testfoo", {foo: 1});
   await TelemetryController.submitExternalPing("testbar", {bar: 2});
+  await TelemetryController.submitExternalPing("testfoo", {foo: 3});
   const environment = ClientEnvironment.getEnvironment();
 
   // Test it can access telemetry
@@ -19,8 +20,8 @@ add_task(async function testTelemetry() {
   is(typeof telemetry, "object", "Telemetry is accesible");
 
   // Test it reads different types of telemetry
-  is(telemetry.testfoo.payload.foo, 1, "value 'foo' is in mock telemetry");
-  is(telemetry.testbar.payload.bar, 2, "value 'bar' is in mock telemetry");
+  is(telemetry.testfoo.payload.foo, 3, "telemetry filters pull the latest ping from a type");
+  is(telemetry.testbar.payload.bar, 2, "telemetry filters pull from submitted telemetry pings");
 });
 
 add_task(async function testUserId() {


### PR DESCRIPTION
This bug means that we currently are not filtering on the latest version of each type of telemetry ping, but instead on whatever one is returned first by `TelemetryArchive.getArchivedPings`, which is typically the oldest.

I noticed this when trying to test if we could filter on the channel attribute in the main ping. When a profile created on beta was switched to release, it still returned `true` for a beta channel check since it still had the archived ping from when it was on beta.