### PR TITLE
Fix #957: Use UpdateUtils.jsm to determine the update channel.

### DIFF
--- a/recipe-client-addon/lib/ClientEnvironment.jsm
+++ b/recipe-client-addon/lib/ClientEnvironment.jsm
@@ -12,6 +12,7 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "ShellService", "resource:///modules/ShellService.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "AddonManager", "resource://gre/modules/AddonManager.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "TelemetryArchive", "resource://gre/modules/TelemetryArchive.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "UpdateUtils", "resource://gre/modules/UpdateUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "NormandyApi", "resource://shield-recipe-client/lib/NormandyApi.jsm");
 XPCOMUtils.defineLazyModuleGetter(
     this,
@@ -128,7 +129,7 @@ this.ClientEnvironment = {
     });
 
     XPCOMUtils.defineLazyGetter(environment, "channel", () => {
-      return Services.appinfo.defaultUpdateChannel;
+      return UpdateUtils.getUpdateChannel(false);
     });
 
     XPCOMUtils.defineLazyGetter(environment, "isDefaultBrowser", () => {

--- a/recipe-client-addon/lib/NormandyDriver.jsm
+++ b/recipe-client-addon/lib/NormandyDriver.jsm
@@ -21,6 +21,7 @@ Cu.import("resource://shield-recipe-client/lib/ClientEnvironment.jsm");
 Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm");
 Cu.import("resource://shield-recipe-client/lib/Sampling.jsm");
 
+XPCOMUtils.defineLazyModuleGetter(this, "UpdateUtils", "resource://gre/modules/UpdateUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(
   this, "AddonStudies", "resource://shield-recipe-client/lib/AddonStudies.jsm");
 
@@ -82,7 +83,7 @@ this.NormandyDriver = function(sandboxManager) {
     client() {
       const appinfo = {
         version: Services.appinfo.version,
-        channel: Services.appinfo.defaultUpdateChannel,
+        channel: UpdateUtils.getUpdateChannel(false),
         isDefaultBrowser: ShellService.isDefaultBrowser() || null,
         searchEngine: null,
         syncSetup: Preferences.isSet("services.sync.username"),


### PR DESCRIPTION
Small enough not to need two reviewers.

@gijsk I couldn't think of any good tests to add for this; mocking `getUpdateChannel` wouldn't really test much of anything, and I don't think a test that duplicated the logic in `getUpdateChannel` would help much either. I think what I really want is some sort of test that downloads Firefox from specific channels and checks the value, but that's way out of scope for the automation we have now. Thoughts?