### PR TITLE
Add ExtensionSelect tests

### DIFF
--- a/recipe-server/client/control/components/extensions/ExtensionSelect.js
+++ b/recipe-server/client/control/components/extensions/ExtensionSelect.js
@@ -59,7 +59,6 @@ export default class ExtensionSelect extends React.Component {
 
   render() {
     const { search } = this.state;
-    let displayedList = this.props.extensions;
     const queryFilters = search ? { text: search } : {};
 
     const {
@@ -76,9 +75,7 @@ export default class ExtensionSelect extends React.Component {
       value,
     } = this.props;
 
-    if (isLoadingSearch) {
-      displayedList = new List();
-    }
+    const displayedList = isLoadingSearch ? new List() : this.props.extensions;
 
     return (
       <div>

--- a/recipe-server/client/control/tests/components/extensions/test_ExtensionSelect.js
+++ b/recipe-server/client/control/tests/components/extensions/test_ExtensionSelect.js
@@ -1,12 +1,12 @@
+import { Select } from 'antd';
 import { mount } from 'enzyme';
-import { List } from 'immutable';
+import { fromJS, List } from 'immutable';
 import React from 'react';
 
 import { wrapMockStore } from 'control/tests/mockStore';
 import TestComponent from 'control/components/extensions/ExtensionSelect';
 
 const { WrappedComponent: ExtensionSelect } = TestComponent;
-
 
 describe('<ExtensionSelect>', () => {
   const props = {
@@ -35,5 +35,43 @@ describe('<ExtensionSelect>', () => {
     // Determine if the placeholder is actually visible to the user.
     const placeholderStyle = placeholderElement.get(0).style;
     expect(placeholderStyle.display).toBe('block');
+  });
+
+  it('should display its inherited value prop', () => {
+    const wrapper = mount(wrapMockStore(
+      <ExtensionSelect
+        {...props}
+        extensions={fromJS([{ xpi: '1', name: 'one' }, { xpi: '2', name: 'two' }])}
+        value="2"
+      />,
+    ));
+
+    expect(wrapper.find('.ant-select-selection-selected-value').text()).toBe('two');
+  });
+
+  it('should fire an onChange event appropriately', async () => {
+    let selected;
+    const wrapper = mount(wrapMockStore(
+      <ExtensionSelect
+        {...props}
+        extensions={
+          fromJS([{ xpi: '1', name: 'one' }, { xpi: '2', name: 'two' }])
+        }
+        onChange={val => {
+          selected = val;
+        }}
+      />,
+    ));
+
+    wrapper.find('.ant-select-selection__placeholder').simulate('click');
+    expect(wrapper.find(Select).props().children.size).toBe(2);
+
+    // Ant does some weird positioning to handle its custom dropdown menus, so it's
+    // harder to do UI tests to trigger changes. This test checks against the actual
+    // Ant Select component's onChange, which just fires off ExtensionSelect's onChange
+    // under the hood.
+    wrapper.find(Select).props().onChange('2');
+
+    expect(selected).toBe('2');
   });
 });

--- a/recipe-server/client/control/tests/components/extensions/test_ExtensionSelect.js
+++ b/recipe-server/client/control/tests/components/extensions/test_ExtensionSelect.js
@@ -63,15 +63,10 @@ describe('<ExtensionSelect>', () => {
       />,
     ));
 
-    wrapper.find('.ant-select-selection__placeholder').simulate('click');
-    expect(wrapper.find(Select).props().children.size).toBe(2);
+    const selectEl = wrapper.find(Select);
+    expect(selectEl.props().children.size).toBe(2);
 
-    // Ant does some weird positioning to handle its custom dropdown menus, so it's
-    // harder to do UI tests to trigger changes. This test checks against the actual
-    // Ant Select component's onChange, which just fires off ExtensionSelect's onChange
-    // under the hood.
-    wrapper.find(Select).props().onChange('2');
-
+    selectEl.props().onChange('2');
     expect(selected).toBe('2');
   });
 });


### PR DESCRIPTION
Fixes #1050 

- Adds tests for ExtensionSelect component

Apparently, it's a little difficult to test against Ant's dropdowns since it uses some weird CSS for positioning. As a result, the test against `onChange` feels a little weak, so I'm open to any ideas to expand on it.

Ready for review.