### PR TITLE
#1054, #1055: Prevent dupe recipes in recent history

### DIFF
--- a/recipe-server/client/control/components/common/NavigationCrumbs.js
+++ b/recipe-server/client/control/components/common/NavigationCrumbs.js
@@ -5,6 +5,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'redux-little-router';
 
+import { replaceUrlVariables } from 'control/routerUtils';
+
 @connect(
   state => ({
     router: state.router,
@@ -15,23 +17,6 @@ export default class NavigationCrumbs extends React.PureComponent {
   static propTypes = {
     router: PropTypes.object.isRequired,
   };
-
-  // Given a route (e.g. `/hello/:id/there`), finds params that need to be
-  // populated (e.g. `:id`) and replaces the values in order to link correctly
-  // when displayed as a Breadcrumb.
-  static replaceUrlVariables(url, params) {
-    let newUrl = url;
-    const urlParams = url.match(/:[a-z]+/gi);
-
-    if (urlParams) {
-      urlParams.forEach(piece => {
-        // Replace the found identifier with whatever the actual param is set to
-        newUrl = newUrl.replace(piece, params[piece.slice(1)]);
-      });
-    }
-
-    return newUrl;
-  }
 
   state = { breadcrumbs: [] };
 
@@ -58,7 +43,7 @@ export default class NavigationCrumbs extends React.PureComponent {
       if (currentRoute.crumb) {
         crumbs.push({
           name: currentRoute.crumb,
-          link: NavigationCrumbs.replaceUrlVariables(currentRoute.route || pathname, params),
+          link: replaceUrlVariables(currentRoute.route || pathname, params),
         });
       }
 

--- a/recipe-server/client/control/components/common/NavigationMenu.js
+++ b/recipe-server/client/control/components/common/NavigationMenu.js
@@ -7,6 +7,7 @@ import { Link } from 'redux-little-router';
 
 import QuerySessionInfo from 'control/components/data/QuerySessionInfo';
 import { getSessionHistory } from 'control/state/app/session/selectors';
+import ShieldIdenticon from 'control/components/common/ShieldIdenticon';
 
 const { Divider, Item, SubMenu } = Menu;
 
@@ -29,7 +30,7 @@ export default class NavigationMenu extends React.PureComponent {
     const { pathname, search } = router;
 
     return (
-      <div>
+      <div className="nav-menu">
         <QuerySessionInfo />
         <Menu
           defaultOpenKeys={['Recipes', 'Extensions']}
@@ -48,7 +49,10 @@ export default class NavigationMenu extends React.PureComponent {
             {
               recipeSessionHistory.map(item =>
                 (<Item key={item.get('url')}>
-                  <Link href={item.get('url')}>{ item.get('caption') }</Link>
+                  <Link href={item.get('url')}>
+                    <ShieldIdenticon seed={item.get('identicon')} size={20} />
+                    { item.get('caption') }
+                  </Link>
                 </Item>),
               )
             }

--- a/recipe-server/client/control/components/extensions/EditExtensionPage.js
+++ b/recipe-server/client/control/components/extensions/EditExtensionPage.js
@@ -45,7 +45,7 @@ export default class EditExtensionPage extends React.PureComponent {
   componentDidMount() {
     const extensionName = this.props.extension.get('name');
     if (extensionName) {
-      this.props.addSessionView('extension', extensionName);
+      this.props.addSessionView('extension', extensionName, this.props.extension.get('identicon_seed'));
     }
   }
 
@@ -55,7 +55,7 @@ export default class EditExtensionPage extends React.PureComponent {
     // New extension means we add a session view.
     if (!is(oldExtensions, extension) && oldExtensions.get('name') !== extension.get('name')) {
       const extensionName = extension.get('name');
-      this.props.addSessionView('extension', extensionName);
+      this.props.addSessionView('extension', extensionName, extension.get('identicon_seed'));
     }
   }
 

--- a/recipe-server/client/control/components/recipes/DetailsActionBar.js
+++ b/recipe-server/client/control/components/recipes/DetailsActionBar.js
@@ -108,7 +108,7 @@ export default class DetailsActionBar extends React.PureComponent {
 
     return (
       <div className="details-action-bar clearfix">
-        <Link href={`${routerPath}/clone/`} id="dab-clone-link">
+        <Link href={`${routerPath}clone/`} id="dab-clone-link">
           <Button icon="swap" type="primary" id="dab-clone-button">Clone</Button>
         </Link>
 

--- a/recipe-server/client/control/components/recipes/EditRecipePage.js
+++ b/recipe-server/client/control/components/recipes/EditRecipePage.js
@@ -52,7 +52,7 @@ export default class EditRecipePage extends React.PureComponent {
   componentDidMount() {
     const recipeName = this.props.recipe.get('name');
     if (recipeName) {
-      this.props.addSessionView('recipe', recipeName);
+      this.props.addSessionView('recipe', recipeName, this.props.recipe.get('identicon_seed'));
     }
   }
 
@@ -62,7 +62,7 @@ export default class EditRecipePage extends React.PureComponent {
     // New recipe means we add a session view.
     if (!is(oldRecipe, recipe)) {
       const recipeName = recipe.get('name');
-      this.props.addSessionView('recipe', recipeName);
+      this.props.addSessionView('recipe', recipeName, recipe.get('identicon_seed'));
     }
   }
 

--- a/recipe-server/client/control/components/recipes/RecipeDetails.js
+++ b/recipe-server/client/control/components/recipes/RecipeDetails.js
@@ -16,7 +16,7 @@ export default class RecipeDetails extends React.PureComponent {
   componentDidMount() {
     const recipeName = this.props.recipe.get('name');
     if (recipeName) {
-      this.props.addSessionView('recipe', recipeName);
+      this.props.addSessionView('recipe', recipeName, this.props.recipe.get('identicon_seed'));
     }
   }
 
@@ -26,7 +26,7 @@ export default class RecipeDetails extends React.PureComponent {
     // New recipe means we add a session view.
     if (!is(oldRecipe, recipe) && oldRecipe.get('name') !== recipe.get('name')) {
       const recipeName = recipe.get('name');
-      this.props.addSessionView('recipe', recipeName);
+      this.props.addSessionView('recipe', recipeName, recipe.get('identicon_seed'));
     }
   }
 

--- a/recipe-server/client/control/less/components/nav-menu.less
+++ b/recipe-server/client/control/less/components/nav-menu.less
@@ -1,0 +1,11 @@
+.nav-menu {
+  .shield-container {
+    margin-bottom: 0.7em;
+    margin-right: 0.5em;
+  }
+
+  .ant-menu-item > a {
+    align-items: center;
+    display: flex;
+  }
+}

--- a/recipe-server/client/control/less/main.less
+++ b/recipe-server/client/control/less/main.less
@@ -20,6 +20,7 @@
 @import 'components/form-actions';
 @import 'components/history-timeline';
 @import 'components/listing';
+@import 'components/nav-menu';
 @import 'components/switchbox';
 
 // Common

--- a/recipe-server/client/control/less/pages/recipe-form.less
+++ b/recipe-server/client/control/less/pages/recipe-form.less
@@ -92,7 +92,9 @@ fieldset {
   justify-content: center;
   padding-top: 0.75em;
   text-align: center;
+}
 
+.shield-container {
   img {
     /* Prevent the alt text from appearing on the page while the image is loading. */
     color: transparent;

--- a/recipe-server/client/control/routerUtils.js
+++ b/recipe-server/client/control/routerUtils.js
@@ -6,10 +6,7 @@ export const searchRouteTree = (tree, name, currentUrl = '') => {
 
   // If the slug doesn't match, iterate over the given route tree until
   // we find one that matches what we need (if any exist).
-  const keys = Object.keys(tree);
-  for (let i = 0; i < keys.length; i += 1) {
-    const curPath = keys[i];
-
+  for (const curPath of Object.keys(tree)) {
     // A key beginning with '/' indicates it is a route tree, which should be searched.
     if (curPath.charAt(0) === '/') {
       const val = searchRouteTree(tree[curPath], name, currentUrl + curPath);

--- a/recipe-server/client/control/routerUtils.js
+++ b/recipe-server/client/control/routerUtils.js
@@ -1,10 +1,10 @@
 export const searchRouteTree = (tree, name, currentUrl = '') => {
-  // If we have the crumb, we have the complete route.
-  if (tree.crumb === name) {
+  // If we have the slug, we have the complete route.
+  if (tree.slug === name) {
     return currentUrl;
   }
 
-  // If the crumb doesn't match, iterate over the given route tree until
+  // If the slug doesn't match, iterate over the given route tree until
   // we find one that matches what we need (if any exist).
   const keys = Object.keys(tree);
   for (let i = 0; i < keys.length; i += 1) {

--- a/recipe-server/client/control/routerUtils.js
+++ b/recipe-server/client/control/routerUtils.js
@@ -1,0 +1,43 @@
+export const searchRouteTree = (tree, name, currentUrl = '') => {
+  // If we have the crumb, we have the complete route.
+  if (tree.crumb === name) {
+    return currentUrl;
+  }
+
+  // If the crumb doesn't match, iterate over the given route tree until
+  // we find one that matches what we need (if any exist).
+  const keys = Object.keys(tree);
+  for (let i = 0; i < keys.length; i += 1) {
+    const curPath = keys[i];
+
+    // A key beginning with '/' indicates it is a route tree, which should be searched.
+    if (curPath.charAt(0) === '/') {
+      const val = searchRouteTree(tree[curPath], name, currentUrl + curPath);
+
+      // Non-null `val` indicates the route was found.
+      if (val !== null) {
+        // The base route's slash sometimes leads to `//` showing up in the result URL.
+        return val.replace('//', '/');
+      }
+    }
+  }
+
+  // If we've gotten this far, the route has not been found in this route tree.
+  return null;
+};
+
+
+// Given a route (e.g. `/hello/:id/there`), finds params that need to be
+// populated (e.g. `:id`) and returns a string with populated values.
+export const replaceUrlVariables = (url, params) => {
+  let newUrl = url;
+  const urlParams = url.match(/:[a-z]+/gi);
+
+  if (urlParams) {
+    urlParams.forEach(piece => {
+      newUrl = newUrl.replace(piece, params[piece.slice(1)] || piece);
+    });
+  }
+
+  return newUrl;
+};

--- a/recipe-server/client/control/routes.js
+++ b/recipe-server/client/control/routes.js
@@ -18,37 +18,53 @@ import RecipeDetailPage from 'control/components/recipes/RecipeDetailPage';
 
 import { searchRouteTree, replaceUrlVariables } from './routerUtils';
 
+
+/**
+ * @type {Route}
+ * @property {Component} component    React component used to render route
+ * @property {String}    crumb        Displayed text on navigational breadcrumbs
+ * @property {String}    slug         Internal route name
+ * @property {String}    sessionSlug  Optional replacement slug used with session history.
+ * @property {Route}     '/[...]'     Optional nested route tree(s).
+ */
+
 const routes = {
   '/': {
     component: Gateway,
     crumb: 'Home',
+    slug: 'home',
     '/recipe': {
       '/': {
         component: RecipeListing,
         crumb: 'Recipes Listing',
+        slug: 'recipe-listing',
       },
       '/new': {
         '/': {
           component: CreateRecipePage,
           crumb: 'New Recipe',
+          slug: 'recipe-new',
         },
       },
       '/:recipeId': {
         '/': {
           component: RecipeDetailPage,
           crumb: 'View Recipe',
+          slug: 'recipe-view',
         },
         '/rev/:revisionId': {
           '/': {
             component: RecipeDetailPage,
             crumb: 'Revision',
-            ignoreSession: true,
+            sessionSlug: 'recipe-view',
+            slug: 'recipe-revision',
           },
           '/clone': {
             '/': {
               component: CloneRecipePage,
               crumb: 'Clone Revision',
-              ignoreSession: true,
+              sessionSlug: 'recipe-view',
+              slug: 'recipe-revision-clone',
             },
           },
         },
@@ -56,21 +72,24 @@ const routes = {
           '/': {
             component: EditRecipePage,
             crumb: 'Edit Recipe',
-            ignoreSession: true,
+            sessionSlug: 'recipe-view',
+            slug: 'recipe-edit',
           },
         },
         '/approval_history': {
           '/': {
             component: ApprovalHistoryPage,
             crumb: 'Approval History',
-            ignoreSession: true,
+            sessionSlug: 'recipe-view',
+            slug: 'recipe-approval-history',
           },
         },
         '/clone': {
           '/': {
             component: CloneRecipePage,
             crumb: 'Clone Recipe',
-            ignoreSession: true,
+            sessionSlug: 'recipe-view',
+            slug: 'recipe-clone',
           },
         },
       },
@@ -79,17 +98,20 @@ const routes = {
       '/': {
         component: ExtensionListing,
         crumb: 'Extensions Listing',
+        slug: 'extension-listing',
       },
       '/new': {
         '/': {
           component: CreateExtensionPage,
           crumb: 'New Extension',
+          slug: 'extension-new',
         },
       },
       '/:extensionId': {
         '/': {
           component: EditExtensionPage,
           crumb: 'Edit Extension',
+          slug: 'extension-edit',
         },
       },
     },

--- a/recipe-server/client/control/routes.js
+++ b/recipe-server/client/control/routes.js
@@ -16,6 +16,7 @@ import RecipeListing from 'control/components/recipes/RecipeListing';
 import MissingPage from 'control/components/pages/MissingPage';
 import RecipeDetailPage from 'control/components/recipes/RecipeDetailPage';
 
+import { searchRouteTree, replaceUrlVariables } from './routerUtils';
 
 const routes = {
   '/': {
@@ -30,7 +31,6 @@ const routes = {
         '/': {
           component: CreateRecipePage,
           crumb: 'New Recipe',
-          isCreating: true,
         },
       },
       '/:recipeId': {
@@ -42,11 +42,13 @@ const routes = {
           '/': {
             component: RecipeDetailPage,
             crumb: 'Revision',
+            ignoreSession: true,
           },
           '/clone': {
             '/': {
               component: CloneRecipePage,
               crumb: 'Clone Revision',
+              ignoreSession: true,
             },
           },
         },
@@ -54,18 +56,21 @@ const routes = {
           '/': {
             component: EditRecipePage,
             crumb: 'Edit Recipe',
+            ignoreSession: true,
           },
         },
         '/approval_history': {
           '/': {
             component: ApprovalHistoryPage,
             crumb: 'Approval History',
+            ignoreSession: true,
           },
         },
         '/clone': {
           '/': {
             component: CloneRecipePage,
             crumb: 'Clone Recipe',
+            ignoreSession: true,
           },
         },
       },
@@ -89,6 +94,14 @@ const routes = {
       },
     },
   },
+};
+
+export const getNamedRoute = (name, params = {}) => {
+  const url = searchRouteTree(routes, name);
+  if (url) {
+    return replaceUrlVariables(url, params);
+  }
+  return null;
 };
 
 export const {

--- a/recipe-server/client/control/state/app/session/actions.js
+++ b/recipe-server/client/control/state/app/session/actions.js
@@ -61,13 +61,17 @@ export function saveSession() {
   };
 }
 
-export function addSessionView(category, caption) {
+export function addSessionView(category, caption, identicon) {
   return async (dispatch, getState) => {
-    const url = getState().router.pathname;
+    let url = getState().router.pathname;
+
+    // Prevent exact subpages (e.g. edit, clone pages) from appearing in the nav.
+    // Instead, this will link to the 'view' page for that recipe/revision.
+    url = url.replace(/\/(edit|clone|approval_history)/, '');
 
     dispatch({
       type: SESSION_INFO_HISTORY_VIEW,
-      item: new Map({ url, caption, category }),
+      item: new Map({ url, caption, category, identicon }),
     });
 
     // Automatically save the session when views are added.

--- a/recipe-server/client/control/state/app/session/actions.js
+++ b/recipe-server/client/control/state/app/session/actions.js
@@ -62,18 +62,17 @@ export function saveSession() {
   };
 }
 
-const capitalize = str => str.slice(0, 1).toUpperCase() + str.slice(1, str.length);
-
 export function addSessionView(category, caption, identicon) {
   return async (dispatch, getState) => {
     const { router } = getState();
     let url = router.pathname;
-    const ignoreSession = router.result && router.result.ignoreSession;
 
-    // Prevent exact subpages (e.g. edit, clone pages) from appearing in the nav.
-    // Instead, this will link to the proper 'View [Recipe|Extension]' page.
-    if (ignoreSession) {
-      url = getNamedRoute(`View ${capitalize(category)}`, router.params);
+    // If the route we are currently on has defined another slug to use for
+    // 'session' purposes, use that instead.
+    const slugRedirect = router.result && router.result.sessionSlug;
+
+    if (slugRedirect) {
+      url = getNamedRoute(slugRedirect, router.params);
     }
 
     dispatch({

--- a/recipe-server/client/control/state/app/session/actions.js
+++ b/recipe-server/client/control/state/app/session/actions.js
@@ -3,6 +3,7 @@
 import { List, Map } from 'immutable';
 import * as localForage from 'localforage';
 
+import { getNamedRoute } from 'control/routes';
 import {
   SESSION_INFO_RECEIVE,
   SESSION_INFO_HISTORY_VIEW,
@@ -61,13 +62,19 @@ export function saveSession() {
   };
 }
 
+const capitalize = str => str.slice(0, 1).toUpperCase() + str.slice(1, str.length);
+
 export function addSessionView(category, caption, identicon) {
   return async (dispatch, getState) => {
-    let url = getState().router.pathname;
+    const { router } = getState();
+    let url = router.pathname;
+    const ignoreSession = router.result && router.result.ignoreSession;
 
     // Prevent exact subpages (e.g. edit, clone pages) from appearing in the nav.
-    // Instead, this will link to the 'view' page for that recipe/revision.
-    url = url.replace(/\/(edit|clone|approval_history)/, '');
+    // Instead, this will link to the proper 'View [Recipe|Extension]' page.
+    if (ignoreSession) {
+      url = getNamedRoute(`View ${capitalize(category)}`, router.params);
+    }
 
     dispatch({
       type: SESSION_INFO_HISTORY_VIEW,

--- a/recipe-server/client/control/tests/components/common/test_NavigationCrumbs.js
+++ b/recipe-server/client/control/tests/components/common/test_NavigationCrumbs.js
@@ -16,39 +16,4 @@ describe('<NavigationCrumbs>', () => {
 
     expect(wrapper).not.toThrow();
   });
-
-  describe('replaceUrlVariables', () => {
-    it('should handle strings without variables', () => {
-      let url = NavigationCrumbs.replaceUrlVariables('/hey/ron', {});
-      expect(url).toBe('/hey/ron');
-
-      // Trailing slash
-      url = NavigationCrumbs.replaceUrlVariables('/hey/ron/', {});
-      expect(url).toBe('/hey/ron/');
-    });
-
-    it('should replace variables in strings', () => {
-      let url = NavigationCrumbs.replaceUrlVariables('/hey/:name', { name: 'billy' });
-      expect(url).toBe('/hey/billy');
-
-      // Trailing slash
-      url = NavigationCrumbs.replaceUrlVariables('/hey/:name/', { name: 'billy' });
-      expect(url).toBe('/hey/billy/');
-    });
-
-    it('should replace multiple variables', () => {
-      let url = NavigationCrumbs.replaceUrlVariables('/:one/:two', {
-        one: 'that',
-        two: 'hurt',
-      });
-      expect(url).toBe('/that/hurt');
-
-      // Trailing slash
-      url = NavigationCrumbs.replaceUrlVariables('/:one/:two/', {
-        one: 'that',
-        two: 'hurt',
-      });
-      expect(url).toBe('/that/hurt/');
-    });
-  });
 });

--- a/recipe-server/client/control/tests/state/session/test_actions.js
+++ b/recipe-server/client/control/tests/state/session/test_actions.js
@@ -1,0 +1,60 @@
+import { Map } from 'immutable';
+
+import {
+  SESSION_INFO_HISTORY_VIEW,
+} from 'control/state/action-types';
+
+import { addSessionView } from 'control/state/app/session/actions';
+
+describe('Session actions', () => {
+  describe('addSessionView', () => {
+    // Params = the 'default' test params passed into addSessionView
+    const defaultParams = ['category', 'caption', 'identicon'];
+    // Values = the 'default' dispatched values given our default params.
+    const defaultValues = { caption: 'caption', category: 'category', identicon: 'identicon' };
+
+
+    it('should dispatch a SESSION_INFO_HISTORY_VIEW event', async () => {
+      const meta = {
+        dispatch: () => {},
+      };
+      spyOn(meta, 'dispatch').and.callThrough();
+
+      const getState = () => ({ router: { pathname: '/fake/url' } });
+
+      await addSessionView(...defaultParams)(meta.dispatch, getState);
+
+      expect(meta.dispatch).toHaveBeenCalledWith({
+        type: SESSION_INFO_HISTORY_VIEW,
+        item: new Map({ url: '/fake/url', ...defaultValues }),
+      });
+    });
+
+    it('should prevent /edit, /clone, or /approval_history links from registering', async () => {
+      const meta = { dispatch: () => {} };
+      spyOn(meta, 'dispatch').and.callThrough();
+
+      let getState = () => ({ router: { pathname: '/fake/url/edit/' } });
+      await addSessionView(...defaultParams)(meta.dispatch, getState);
+      expect(meta.dispatch).toHaveBeenCalledWith({
+        type: SESSION_INFO_HISTORY_VIEW,
+        item: new Map({ url: '/fake/url/', ...defaultValues }),
+      });
+
+      getState = () => ({ router: { pathname: '/fake/url/clone/' } });
+      await addSessionView(...defaultParams)(meta.dispatch, getState);
+      expect(meta.dispatch).toHaveBeenCalledWith({
+        type: SESSION_INFO_HISTORY_VIEW,
+        item: new Map({ url: '/fake/url/', ...defaultValues }),
+      });
+
+      getState = () => ({ router: { pathname: '/fake/url/approval_history/' } });
+      await addSessionView(...defaultParams)(meta.dispatch, getState);
+      expect(meta.dispatch).toHaveBeenCalledWith({
+        type: SESSION_INFO_HISTORY_VIEW,
+        item: new Map({ url: '/fake/url/', ...defaultValues }),
+      });
+    });
+  });
+});
+

--- a/recipe-server/client/control/tests/state/session/test_actions.js
+++ b/recipe-server/client/control/tests/state/session/test_actions.js
@@ -15,50 +15,46 @@ describe('Session actions', () => {
 
 
     it('should dispatch a SESSION_INFO_HISTORY_VIEW event', async () => {
-      const meta = {
-        dispatch: () => {},
-      };
-      spyOn(meta, 'dispatch').and.callThrough();
+      const dispatch = jasmine.createSpy('dispatch');
 
       const getState = () => ({ router: { pathname: '/fake/url' } });
 
-      await addSessionView(...defaultParams)(meta.dispatch, getState);
+      await addSessionView(...defaultParams)(dispatch, getState);
 
-      expect(meta.dispatch).toHaveBeenCalledWith({
+      expect(dispatch).toHaveBeenCalledWith({
         type: SESSION_INFO_HISTORY_VIEW,
         item: new Map({ url: '/fake/url', ...defaultValues }),
       });
     });
 
-    it('should prevent `ignoreSesssion` routes from registering', async () => {
-      const meta = { dispatch: () => {} };
-      spyOn(meta, 'dispatch').and.callThrough();
+    it('should redirect session routes if given a `sessionSlug` property', async () => {
+      const dispatch = jasmine.createSpy('dispatch');
 
       let getState = () => ({
-        router: { pathname: '/fake/url/edit/', result: { ignoreSession: true } },
+        router: { pathname: '/recipe/:recipeId/edit/', result: { sessionSlug: 'recipe-view' } },
       });
-      await addSessionView(...defaultParams)(meta.dispatch, getState);
-      expect(meta.dispatch).toHaveBeenCalledWith({
+      await addSessionView(...defaultParams)(dispatch, getState);
+      expect(dispatch).toHaveBeenCalledWith({
         type: SESSION_INFO_HISTORY_VIEW,
-        item: new Map({ url: '/fake/url/', ...defaultValues }),
+        item: new Map({ url: '/recipe/:recipeId/', ...defaultValues }),
       });
 
       getState = () => ({
-        router: { pathname: '/fake/url/clone/', result: { ignoreSession: true } },
+        router: { pathname: '/recipe/:recipeId/clone/', result: { sessionSlug: 'recipe-new' } },
       });
-      await addSessionView(...defaultParams)(meta.dispatch, getState);
-      expect(meta.dispatch).toHaveBeenCalledWith({
+      await addSessionView(...defaultParams)(dispatch, getState);
+      expect(dispatch).toHaveBeenCalledWith({
         type: SESSION_INFO_HISTORY_VIEW,
-        item: new Map({ url: '/fake/url/', ...defaultValues }),
+        item: new Map({ url: '/recipe/new/', ...defaultValues }),
       });
 
       getState = () => ({
-        router: { pathname: '/fake/url/approval_history/', result: { ignoreSession: true } },
+        router: { pathname: '/recipe/:recipeId/approval_history/', result: { sessionSlug: 'recipe-edit' } },
       });
-      await addSessionView(...defaultParams)(meta.dispatch, getState);
-      expect(meta.dispatch).toHaveBeenCalledWith({
+      await addSessionView(...defaultParams)(dispatch, getState);
+      expect(dispatch).toHaveBeenCalledWith({
         type: SESSION_INFO_HISTORY_VIEW,
-        item: new Map({ url: '/fake/url/', ...defaultValues }),
+        item: new Map({ url: '/recipe/:recipeId/edit/', ...defaultValues }),
       });
     });
   });

--- a/recipe-server/client/control/tests/state/session/test_actions.js
+++ b/recipe-server/client/control/tests/state/session/test_actions.js
@@ -9,9 +9,9 @@ import { addSessionView } from 'control/state/app/session/actions';
 describe('Session actions', () => {
   describe('addSessionView', () => {
     // Params = the 'default' test params passed into addSessionView
-    const defaultParams = ['category', 'caption', 'identicon'];
+    const defaultParams = ['recipe', 'caption', 'identicon'];
     // Values = the 'default' dispatched values given our default params.
-    const defaultValues = { caption: 'caption', category: 'category', identicon: 'identicon' };
+    const defaultValues = { caption: 'caption', category: 'recipe', identicon: 'identicon' };
 
 
     it('should dispatch a SESSION_INFO_HISTORY_VIEW event', async () => {
@@ -30,25 +30,31 @@ describe('Session actions', () => {
       });
     });
 
-    it('should prevent /edit, /clone, or /approval_history links from registering', async () => {
+    it('should prevent `ignoreSesssion` routes from registering', async () => {
       const meta = { dispatch: () => {} };
       spyOn(meta, 'dispatch').and.callThrough();
 
-      let getState = () => ({ router: { pathname: '/fake/url/edit/' } });
+      let getState = () => ({
+        router: { pathname: '/fake/url/edit/', result: { ignoreSession: true } },
+      });
       await addSessionView(...defaultParams)(meta.dispatch, getState);
       expect(meta.dispatch).toHaveBeenCalledWith({
         type: SESSION_INFO_HISTORY_VIEW,
         item: new Map({ url: '/fake/url/', ...defaultValues }),
       });
 
-      getState = () => ({ router: { pathname: '/fake/url/clone/' } });
+      getState = () => ({
+        router: { pathname: '/fake/url/clone/', result: { ignoreSession: true } },
+      });
       await addSessionView(...defaultParams)(meta.dispatch, getState);
       expect(meta.dispatch).toHaveBeenCalledWith({
         type: SESSION_INFO_HISTORY_VIEW,
         item: new Map({ url: '/fake/url/', ...defaultValues }),
       });
 
-      getState = () => ({ router: { pathname: '/fake/url/approval_history/' } });
+      getState = () => ({
+        router: { pathname: '/fake/url/approval_history/', result: { ignoreSession: true } },
+      });
       await addSessionView(...defaultParams)(meta.dispatch, getState);
       expect(meta.dispatch).toHaveBeenCalledWith({
         type: SESSION_INFO_HISTORY_VIEW,

--- a/recipe-server/client/control/tests/utils/test_routerUtils.js
+++ b/recipe-server/client/control/tests/utils/test_routerUtils.js
@@ -1,0 +1,80 @@
+import { searchRouteTree, replaceUrlVariables } from 'control/routerUtils';
+
+describe('Router utils', () => {
+  describe('searchRouteTree', () => {
+    const routes = {
+      '/': {
+        slug: 'home',
+        '/test': {
+          slug: 'test',
+        },
+        '/test2': {
+          slug: 'other-test',
+          '/nested': {
+            '/even': {
+              '/further': {
+                slug: 'nested',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it('should find shallow routes', () => {
+      expect(searchRouteTree(routes, 'home')).toBe('/');
+      expect(searchRouteTree(routes, 'test')).toBe('/test');
+    });
+
+    it('should find deeply nested routes', () => {
+      expect(searchRouteTree(routes, 'nested')).toBe('/test2/nested/even/further');
+    });
+
+    it('should return `null` when a route is not found', () => {
+      expect(searchRouteTree(routes, 'not present')).toBe(null);
+      expect(searchRouteTree(routes, 'testtt')).toBe(null);
+      expect(searchRouteTree(routes, 'test ')).toBe(null);
+
+      expect(searchRouteTree({}, 'not present again')).toBe(null);
+    });
+  });
+
+  describe('replaceUrlVariables', () => {
+    it('should handle strings without variables', () => {
+      // No trailing slash
+      let url = replaceUrlVariables('/hey/ron', {});
+      expect(url).toBe('/hey/ron');
+
+      // Trailing slash
+      url = replaceUrlVariables('/hey/ron/', {});
+      expect(url).toBe('/hey/ron/');
+    });
+
+    it('should replace variables in strings', () => {
+      // No trailing slash
+      let url = replaceUrlVariables('/hey/:name', { name: 'billy' });
+      expect(url).toBe('/hey/billy');
+
+      // Trailing slash
+      url = replaceUrlVariables('/hey/:name/', { name: 'billy' });
+      expect(url).toBe('/hey/billy/');
+    });
+
+    it('should replace multiple variables', () => {
+      // No trailing slash
+      let url = replaceUrlVariables('/:one/:two', {
+        one: 'that',
+        two: 'hurt',
+      });
+      expect(url).toBe('/that/hurt');
+
+      // Trailing slash
+      url = replaceUrlVariables('/:one/:two/', {
+        one: 'that',
+        two: 'hurt',
+      });
+      expect(url).toBe('/that/hurt/');
+    });
+  });
+});
+


### PR DESCRIPTION
- Fixes #1054  - duplicate recipes in sidebar
- Fixes #1055 - duplicate React key warning

- ~Adds a check to snip `/edit`, `/clone`, and `/approval_request` from 'session views', ensuring that links in the 'recent recipes' section are to the `view recipe` page and never `edit recipe`, etc.~ 
Adds `slug` and `sessionSlug` properties to routes. If a route has a `sessionSlug`, that is the path used for session purposes (i.e. recently viewed nav list).
- Adds `getNamedPath` router util, which returns a URL given an internal route slug
- Adds shield identicons to menu nav since they were not implemented when landed
- Adds tests

Ready for review!