### PR TITLE
Remove redundant "Add-on" label for ExtensionSelect.

### DIFF
--- a/recipe-server/client/control/components/recipes/OptOutStudyFields.js
+++ b/recipe-server/client/control/components/recipes/OptOutStudyFields.js
@@ -49,7 +49,7 @@ export default class OptOutStudyFields extends React.PureComponent {
 
           <Col xs={24} md={12}>
             <FormItem
-              label="Add-on Extension"
+              label="Extension"
               name="arguments.addonUrl"
               initialValue={recipeArguments.get('addonUrl', '')}
             >


### PR DESCRIPTION
An extension is a type of add-on, so putting both words as the label is redundant.