### PR TITLE
Add OptGroup to ExtensionSelect to clarify what is being listed.

### DIFF
--- a/recipe-server/client/control/components/extensions/ExtensionSelect.js
+++ b/recipe-server/client/control/components/extensions/ExtensionSelect.js
@@ -9,7 +9,7 @@ import QueryMultipleExtensions from 'control/components/data/QueryMultipleExtens
 import { getExtensionListing } from 'control/state/app/extensions/selectors';
 import { isRequestInProgress } from 'control/state/app/requests/selectors';
 
-const { Option } = Select;
+const { OptGroup, Option } = Select;
 
 @connect(
   state => ({
@@ -75,6 +75,7 @@ export default class ExtensionSelect extends React.Component {
       size,
       value,
     } = this.props;
+    const optGroupLabel = search ? 'Search results' : 'Recently uploaded extensions';
 
     if (isLoadingSearch) {
       displayedList = new List();
@@ -94,12 +95,14 @@ export default class ExtensionSelect extends React.Component {
           onSearch={this.updateSearch}
           showSearch
         >
-          {displayedList.map(item => {
-            const xpi = item.get('xpi');
-            const name = item.get('name');
+          <OptGroup label={optGroupLabel}>
+            {displayedList.map(item => {
+              const xpi = item.get('xpi');
+              const name = item.get('name');
 
-            return (<Option key={xpi} value={xpi} title={name}>{name}</Option>);
-          })}
+              return (<Option key={xpi} value={xpi} title={name}>{name}</Option>);
+            })}
+          </OptGroup>
         </Select>
       </div>
     );


### PR DESCRIPTION
This makes it a bit clearer why only some options are shown in the dropdown.

Note that the "Recently uploaded" bit is a lie, because right now we're just fetching the first page of results, which is actually the oldest uploaded extensions. But IIRC the intention was to show recently-uploaded extensions, so that's the label I went with.

<img width="284" alt="screen shot 2017-10-03 at 6 24 53 pm" src="https://user-images.githubusercontent.com/193106/31156255-318dc7fc-a868-11e7-97da-cd47202cba98.png">

<img width="200" alt="screen shot 2017-10-03 at 6 25 00 pm" src="https://user-images.githubusercontent.com/193106/31156257-34fdd74c-a868-11e7-8365-adfae80c501c.png">
