### PR TITLE
No need to specify Cc/Ci/Cu as global in head_xpc.js

### DIFF
--- a/recipe-client-addon/test/unit/head_xpc.js
+++ b/recipe-client-addon/test/unit/head_xpc.js
@@ -1,7 +1,5 @@
 "use strict";
 
-// List these manually due to bug 1366719.
-/* global Cc, Ci, Cu */
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 
 Cu.import("resource://gre/modules/Services.jsm");


### PR DESCRIPTION
We don't need this global definition, I'm not quite sure why I thought it was necessary previously. Lint seems to work fine without it.