### PR TITLE
Fixes #1100 Reset pref studies to the correct value when stopping.

### DIFF
--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -82,17 +82,29 @@ this.Bootstrap = {
 
       switch (experimentPrefType) {
         case Services.prefs.PREF_STRING:
-          studyPrefsChanged[prefName] = defaultBranch.getCharPref(prefName, undefined);
+          try {  // eslint-disable-line mozilla/use-default-preference-values
+            studyPrefsChanged[prefName] = defaultBranch.getCharPref(prefName);
+          } catch (e) {
+            Cu.reportError(e);
+          }
           defaultBranch.setCharPref(prefName, experimentBranch.getCharPref(prefName));
           break;
 
         case Services.prefs.PREF_INT:
-          studyPrefsChanged[prefName] = defaultBranch.getIntPref(prefName, undefined);
+          try {  // eslint-disable-line mozilla/use-default-preference-values
+            studyPrefsChanged[prefName] = defaultBranch.getIntPref(prefName);
+          } catch (e) {
+            Cu.reportError(e);
+          }
           defaultBranch.setIntPref(prefName, experimentBranch.getIntPref(prefName));
           break;
 
         case Services.prefs.PREF_BOOL:
-          studyPrefsChanged[prefName] = defaultBranch.getBoolPref(prefName, undefined);
+          try {  // eslint-disable-line mozilla/use-default-preference-values
+            studyPrefsChanged[prefName] = defaultBranch.getBoolPref(prefName);
+          } catch (e) {
+            Cu.reportError(e);
+          }
           defaultBranch.setBoolPref(prefName, experimentBranch.getBoolPref(prefName));
           break;
 

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -13,6 +13,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "LogManager",
   "resource://shield-recipe-client/lib/LogManager.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "ShieldRecipeClient",
   "resource://shield-recipe-client/lib/ShieldRecipeClient.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PreferenceExperiments",
+  "resource://shield-recipe-client/lib/PreferenceExperiments.jsm");
 
 // Act as both a normal bootstrap.js and a JS module so that we can test
 // startup methods without having to install/uninstall the add-on.
@@ -42,6 +44,8 @@ const DEFAULT_PREFS = {
 const log = Log.repository.getLogger(BOOTSTRAP_LOGGER_NAME);
 log.addAppender(new Log.ConsoleAppender(new Log.BasicFormatter()));
 log.level = Services.prefs.getIntPref(PREF_LOGGING_LEVEL, Log.Level.Warn);
+
+let studyPrefsChanged = {};
 
 this.Bootstrap = {
   initShieldPrefs(defaultPrefs) {
@@ -78,14 +82,17 @@ this.Bootstrap = {
 
       switch (experimentPrefType) {
         case Services.prefs.PREF_STRING:
+          studyPrefsChanged[prefName] = defaultBranch.getCharPref(prefName, undefined);
           defaultBranch.setCharPref(prefName, experimentBranch.getCharPref(prefName));
           break;
 
         case Services.prefs.PREF_INT:
+          studyPrefsChanged[prefName] = defaultBranch.getIntPref(prefName, undefined);
           defaultBranch.setIntPref(prefName, experimentBranch.getIntPref(prefName));
           break;
 
         case Services.prefs.PREF_BOOL:
+          studyPrefsChanged[prefName] = defaultBranch.getBoolPref(prefName, undefined);
           defaultBranch.setBoolPref(prefName, experimentBranch.getBoolPref(prefName));
           break;
 
@@ -104,7 +111,7 @@ this.Bootstrap = {
   observe(subject, topic, data) {
     if (topic === UI_AVAILABLE_NOTIFICATION) {
       Services.obs.removeObserver(this, UI_AVAILABLE_NOTIFICATION);
-      ShieldRecipeClient.startup();
+      this.finishStartup();
     }
   },
 
@@ -122,8 +129,13 @@ this.Bootstrap = {
     if (reason === REASON_APP_STARTUP) {
       Services.obs.addObserver(this, UI_AVAILABLE_NOTIFICATION);
     } else {
-      ShieldRecipeClient.startup();
+      this.finishStartup();
     }
+  },
+
+  async finishStartup() {
+    await PreferenceExperiments.recordOriginalValues(studyPrefsChanged);
+    ShieldRecipeClient.startup();
   },
 
   async shutdown(data, reason) {

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -45,7 +45,7 @@ const log = Log.repository.getLogger(BOOTSTRAP_LOGGER_NAME);
 log.addAppender(new Log.ConsoleAppender(new Log.BasicFormatter()));
 log.level = Services.prefs.getIntPref(PREF_LOGGING_LEVEL, Log.Level.Warn);
 
-let studyPrefsChanged = {};
+const studyPrefsChanged = {};
 
 this.Bootstrap = {
   initShieldPrefs(defaultPrefs) {

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -146,7 +146,7 @@ this.PreferenceExperiments = {
     const store = await ensureStorage();
 
     for (const experiment of Object.values(store.data)) {
-      if (experiment.preferenceName in studyPrefsChanged) {
+      if (studyPrefsChanged.hasOwnProperty(experiment.preferenceName)) {
         if (experiment.expired) {
           log.warn("Expired preference experiment changed value during startup");
         }

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -139,6 +139,30 @@ function setPref(prefBranch, prefName, prefType, prefValue) {
 
 this.PreferenceExperiments = {
   /**
+   * Update the the experiment storage with changes that happened during early startup.
+   * @param {object} studyPrefsChanged Map from pref name to previous pref value
+   */
+  async recordOriginalValues(studyPrefsChanged) {
+    const store = await ensureStorage();
+
+    for (const experiment of Object.values(store.data)) {
+      if (experiment.preferenceName in studyPrefsChanged) {
+        if (experiment.expired) {
+          log.warn("Expired preference experiment changed value during startup");
+        }
+        if (experiment.branch !== "default") {
+          log.warn("Non-default branch preference experiment changed value during startup");
+        }
+        experiment.previousPreferenceValue = studyPrefsChanged[experiment.preferenceName];
+      }
+    }
+
+    // not calling store.saveSoon() because if the data doesn't get
+    // written, it will get updated with fresher data next time the
+    // browser starts.
+  },
+
+  /**
    * Set the default preference value for active experiments that use the
    * default preference branch.
    */

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -693,3 +693,51 @@ decorate_task(
     );
   },
 );
+
+// test that default branch prefs restore to the right value
+decorate_task(
+  withMockExperiments,
+  withMockPreferences,
+  withStub(PreferenceExperiments, "startObserver"),
+  withStub(PreferenceExperiments, "stopObserver"),
+  async function testDefaultBranchStop(mockExperiments, mockPreferences, stopObserverStub) {
+    const prefName = "fake.preference";
+    mockPreferences.set(prefName, "old version's value", "default");
+
+    // start an experiment
+    await PreferenceExperiments.start({
+      name: "test",
+      branch: "branch",
+      preferenceName: prefName,
+      preferenceValue: "experiment value",
+      preferenceBranchType: "default",
+      preferenceType: "string",
+    });
+
+    is(
+      Services.prefs.getCharPref(prefName),
+      "experiment value",
+      "Starting an experiment should change the pref",
+    );
+
+    // Now pretend that firefox has updated and restarted to a version
+    // where the built-default value of fake.preference is something
+    // else. Bootstrap has run and changed the pref to the
+    // experimental value, and produced the call to
+    // recordOriginalValues below.
+    PreferenceExperiments.recordOriginalValues({ [prefName]: "new version's value" });
+    is(
+      Services.prefs.getCharPref(prefName),
+      "experiment value",
+      "Recording original values shouldn't affect the preference."
+    );
+
+    // Now stop the experiment. It should revert to the new version's default, not the old.
+    await PreferenceExperiments.stop("test");
+    is(
+      Services.prefs.getCharPref(prefName),
+      "new version's value",
+      "Preference should revert to new default",
+    );
+  },
+);

--- a/recipe-client-addon/test/browser/browser_bootstrap.js
+++ b/recipe-client-addon/test/browser/browser_bootstrap.js
@@ -169,30 +169,38 @@ decorate_task(
 
 decorate_task(
   withBootstrap,
-  withStub(ShieldRecipeClient, "startup"),
-  async function testStartupDelayed(Bootstrap, startupStub) {
-    Bootstrap.startup(undefined, 1); // 1 == APP_STARTUP
-    ok(
-      !startupStub.called,
-      "When started at app startup, do not call ShieldRecipeClient.startup immediately.",
-    );
+  async function testStartupDelayed(Bootstrap) {
+    const finishStartupStub = sinon.stub(Bootstrap, "finishStartup");
+    try {
+      Bootstrap.startup(undefined, 1); // 1 == APP_STARTUP
+      ok(
+        !finishStartupStub.called,
+        "When started at app startup, do not call ShieldRecipeClient.startup immediately.",
+      );
 
-    Bootstrap.observe(null, "sessionstore-windows-restored");
-    ok(
-      startupStub.called,
-      "Once the sessionstore-windows-restored event is observed, call ShieldRecipeClient.startup.",
-    );
+      Bootstrap.observe(null, "sessionstore-windows-restored");
+      ok(
+        finishStartupStub.called,
+        "Once the sessionstore-windows-restored event is observed, call ShieldRecipeClient.startup.",
+      );
+    } finally {
+      finishStartupStub.restore();
+    }
   },
 );
 
 decorate_task(
   withBootstrap,
-  withStub(ShieldRecipeClient, "startup"),
-  async function testStartupDelayed(Bootstrap, startupStub) {
-    Bootstrap.startup(undefined, 3); // 1 == ADDON_ENABLED
-    ok(
-      startupStub.called,
-      "When the add-on is enabled outside app startup, call ShieldRecipeClient.startup immediately.",
-    );
+  async function testStartupDelayed(Bootstrap) {
+    const finishStartupStub = sinon.stub(Bootstrap, "finishStartup");
+    try {
+      Bootstrap.startup(undefined, 3); // 3 == ADDON_ENABLED
+      ok(
+        finishStartupStub.called,
+        "When the add-on is enabled outside app startup, call ShieldRecipeClient.startup immediately.",
+      );
+    } finally {
+      finishStartupStub.restore();
+    }
   },
 );


### PR DESCRIPTION
This would have avoided [the bug we had with Screenshots](https://mail.mozilla.org/pipermail/dev-shield/2017-September/000302.html), by resetting back to the new default instead of the old default when the study ended.