### PR TITLE
1088: ExtensionSelect losing focus

### DIFF
--- a/recipe-server/client/control/components/common/LoadingOverlay.js
+++ b/recipe-server/client/control/components/common/LoadingOverlay.js
@@ -65,7 +65,9 @@ export class SimpleLoadingOverlay extends React.PureComponent {
 export default class LoadingOverlay extends React.PureComponent {
   static propTypes = {
     isLoading: PropTypes.bool.isRequired,
-    requestIds: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]),
+    requestIds: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.string), PropTypes.string
+    ]).isRequired,
   };
 
   static defaultProps = {

--- a/recipe-server/client/control/components/extensions/EditExtensionPage.js
+++ b/recipe-server/client/control/components/extensions/EditExtensionPage.js
@@ -86,7 +86,7 @@ export default class EditExtensionPage extends React.PureComponent {
 
         <h2>Edit Extension</h2>
 
-        <LoadingOverlay>
+        <LoadingOverlay requestIds={`fetch-extension-${extensionId}`}>
           <ExtensionForm
             extension={extension}
             onSubmit={this.handleSubmit}


### PR DESCRIPTION
- Fixes #1088 
- Fixes issue where typing into the `ExtensionSelect` component would result in the field losing focus to a `LoadingOverlay` taking over the page.
- This is also the only `LoadingOverlay` that did not specify the `requestIds` to listen for, so this issue should not come up anywhere else on the site.