### PR TITLE
Cachebust Taskcluster docker image.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -22,7 +22,7 @@ tasks:
     payload:
       env:
       maxRunTime: 300 # 5 minutes
-      image: mozilla/normandy-taskcluster:2017-06-12
+      image: mozilla/normandy-taskcluster:2017-10-16
       features:
         taskclusterProxy: true
       command:

--- a/addon-builder/Dockerfile
+++ b/addon-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:zesty
 WORKDIR /root
-ENV CACHEBUST=2017-07-26
+ENV CACHEBUST=2017-10-16
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-transport-https \
         curl \

--- a/ci/taskcluster/bin/decision.py
+++ b/ci/taskcluster/bin/decision.py
@@ -70,7 +70,7 @@ def main():
                 'deadline': fromNow('1 day'),
                 'expires': fromNow('365 days'),
                 'payload': {
-                    'image': 'mozilla/normandy-taskcluster:2017-07-26',
+                    'image': 'mozilla/normandy-taskcluster:2017-10-16',
                     'command': [
                         '/bin/bash',
                         '-c',


### PR DESCRIPTION
This should fix our TC issues, since the Docker image is always built with the latest version of Rust.

I've built and pushed this updated version of the image already.