### PR TITLE
PR #1100 - Revert study preferences to empty when appropriate.

### DIFF
--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -457,18 +457,16 @@ this.PreferenceExperiments = {
 
       if (previousPreferenceValue !== null) {
         setPref(preferences, preferenceName, preferenceType, previousPreferenceValue);
+      } else if (preferenceBranchType === "user") {
+        // Remove the "user set" value (which Shield set), but leave the default intact.
+        preferences.clearUserPref(preferenceName);
       } else {
-        if (preferenceBranchType === 'user') {
-          // Remove the "user set" value (which Shield set), but leave the default intact.
-          preferences.clearUserPref(preferenceName);
-        } else {
-          // Remove both the user and default branch preference. This
-          // is ok because we only do this when studies expire, not
-          // when users actively leave a study by changing the
-          // preference, so there should not be a user branch value at
-          // this point.
-          Services.prefs.getDefaultBranch('').deleteBranch(preferenceName)
-        }
+        // Remove both the user and default branch preference. This
+        // is ok because we only do this when studies expire, not
+        // when users actively leave a study by changing the
+        // preference, so there should not be a user branch value at
+        // this point.
+        Services.prefs.getDefaultBranch("").deleteBranch(preferenceName);
       }
     }
 

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -102,16 +102,22 @@ const log = LogManager.getLogger("preference-experiments");
 let experimentObservers = new Map();
 CleanupManager.addCleanupHandler(() => PreferenceExperiments.stopAllObservers());
 
-function getPref(prefBranch, prefName, prefType, defaultVal) {
+function getPref(prefBranch, prefName, prefType) {
+  if (prefBranch.getPrefType(prefName) === 0) {
+    // pref doesn't exist
+    return null;
+  }
+
   switch (prefType) {
-    case "boolean":
-      return prefBranch.getBoolPref(prefName, defaultVal);
+    case "boolean": {
+      return prefBranch.getBoolPref(prefName);
+    }
 
     case "string":
-      return prefBranch.getStringPref(prefName, defaultVal);
+      return prefBranch.getStringPref(prefName);
 
     case "integer":
-      return prefBranch.getIntPref(prefName, defaultVal);
+      return prefBranch.getIntPref(prefName);
 
     default:
       throw new TypeError(`Unexpected preference type (${prefType}) for ${prefName}.`);
@@ -171,7 +177,7 @@ this.PreferenceExperiments = {
 
     for (const experiment of await this.getAllActive()) {
       // Check that the current value of the preference is still what we set it to
-      if (getPref(UserPreferences, experiment.preferenceName, experiment.preferenceType, undefined) !== experiment.preferenceValue) {
+      if (getPref(UserPreferences, experiment.preferenceName, experiment.preferenceType) !== experiment.preferenceValue) {
         // if not, stop the experiment, and skip the remaining steps
         log.info(`Stopping experiment "${experiment.name}" because its value changed`);
         await this.stop(experiment.name, false);
@@ -299,7 +305,7 @@ this.PreferenceExperiments = {
       preferenceName,
       preferenceValue,
       preferenceType,
-      previousPreferenceValue: getPref(preferences, preferenceName, preferenceType, undefined),
+      previousPreferenceValue: getPref(preferences, preferenceName, preferenceType),
       preferenceBranchType,
     };
 
@@ -347,7 +353,7 @@ this.PreferenceExperiments = {
     const observerInfo = {
       preferenceName,
       observer() {
-        const newValue = getPref(UserPreferences, preferenceName, preferenceType, undefined);
+        const newValue = getPref(UserPreferences, preferenceName, preferenceType);
         if (newValue !== preferenceValue) {
           PreferenceExperiments.stop(experimentName, false)
                                .catch(Cu.reportError);
@@ -448,13 +454,21 @@ this.PreferenceExperiments = {
     if (resetValue) {
       const {preferenceName, preferenceType, previousPreferenceValue, preferenceBranchType} = experiment;
       const preferences = PreferenceBranchType[preferenceBranchType];
-      if (previousPreferenceValue !== undefined) {
+
+      if (previousPreferenceValue !== null) {
         setPref(preferences, preferenceName, preferenceType, previousPreferenceValue);
       } else {
-        // This does nothing if we're on the default branch, which is fine. The
-        // preference will be reset on next restart, and most preferences should
-        // have had a default value set before the experiment anyway.
-        preferences.clearUserPref(preferenceName);
+        if (preferenceBranchType === 'user') {
+          // Remove the "user set" value (which Shield set), but leave the default intact.
+          preferences.clearUserPref(preferenceName);
+        } else {
+          // Remove both the user and default branch preference. This
+          // is ok because we only do this when studies expire, not
+          // when users actively leave a study by changing the
+          // preference, so there should not be a user branch value at
+          // this point.
+          Services.prefs.getDefaultBranch('').deleteBranch(preferenceName)
+        }
       }
     }
 

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -427,7 +427,7 @@ add_task(withMockExperiments(withMockPreferences(async function(experiments, moc
     preferenceName: "fake.preference",
     preferenceValue: "experimentvalue",
     preferenceType: "string",
-    previousPreferenceValue: undefined,
+    previousPreferenceValue: null,
     preferenceBranchType: "user",
   });
 
@@ -694,7 +694,7 @@ decorate_task(
   },
 );
 
-// test that default branch prefs restore to the right value
+// test that default branch prefs restore to the right value if the default pref changes
 decorate_task(
   withMockExperiments,
   withMockPreferences,
@@ -738,6 +738,53 @@ decorate_task(
       Services.prefs.getCharPref(prefName),
       "new version's value",
       "Preference should revert to new default",
+    );
+  },
+);
+
+// test that default branch prefs restore to the right value if the preference is removed
+decorate_task(
+  withMockExperiments,
+  withMockPreferences,
+  withStub(PreferenceExperiments, "startObserver"),
+  withStub(PreferenceExperiments, "stopObserver"),
+  async function testDefaultBranchStop(mockExperiments, mockPreferences, stopObserverStub) {
+    const prefName = "fake.preference";
+    mockPreferences.set(prefName, "old version's value", "default");
+
+    // start an experiment
+    await PreferenceExperiments.start({
+      name: "test",
+      branch: "branch",
+      preferenceName: prefName,
+      preferenceValue: "experiment value",
+      preferenceBranchType: "default",
+      preferenceType: "string",
+    });
+
+    is(
+      Services.prefs.getCharPref(prefName),
+      "experiment value",
+      "Starting an experiment should change the pref",
+    );
+
+    // Now pretend that firefox has updated and restarted to a version
+    // where fake.preference has been removed in the default pref set.
+    // Bootstrap has run and changed the pref to the experimental
+    // value, and produced the call to recordOriginalValues below.
+    PreferenceExperiments.recordOriginalValues({ [prefName]: null });
+    is(
+      Services.prefs.getCharPref(prefName),
+      "experiment value",
+      "Recording original values shouldn't affect the preference."
+    );
+
+    // Now stop the experiment. It should remove the preference
+    await PreferenceExperiments.stop("test");
+    is(
+      Services.prefs.getCharPref(prefName, "DEFAULT"),
+      "DEFAULT",
+      "Preference should be absent",
     );
   },
 );

--- a/recipe-client-addon/test/browser/browser_bootstrap.js
+++ b/recipe-client-addon/test/browser/browser_bootstrap.js
@@ -1,6 +1,7 @@
 "use strict";
 
 Cu.import("resource://shield-recipe-client/lib/ShieldRecipeClient.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm", this);
 
 // We can't import bootstrap.js directly since it isn't in the jar manifest, but
 // we can use Addon.getResourceURI to get a path to the file and import using
@@ -23,6 +24,12 @@ function withBootstrap(testFunction) {
 const initPref1 = "test.initShieldPrefs1";
 const initPref2 = "test.initShieldPrefs2";
 const initPref3 = "test.initShieldPrefs3";
+
+const experimentPref1 = "test.initExperimentPrefs1";
+const experimentPref2 = "test.initExperimentPrefs2";
+const experimentPref3 = "test.initExperimentPrefs3";
+const experimentPref4 = "test.initExperimentPrefs4";
+
 decorate_task(
   withPrefEnv({
     clear: [[initPref1], [initPref2], [initPref3]],
@@ -80,9 +87,6 @@ decorate_task(
   },
 );
 
-const experimentPref1 = "test.initExperimentPrefs1";
-const experimentPref2 = "test.initExperimentPrefs2";
-const experimentPref3 = "test.initExperimentPrefs3";
 decorate_task(
   withPrefEnv({
     set: [
@@ -202,5 +206,49 @@ decorate_task(
     } finally {
       finishStartupStub.restore();
     }
+  },
+);
+
+// During startup, preferences that are changed for experiments should
+// be record by calling PreferenceExperiments.recordOriginalValues.
+decorate_task(
+  withPrefEnv({
+    set: [
+      [`extensions.shield-recipe-client.startupExperimentPrefs.${experimentPref1}`, true],
+      [`extensions.shield-recipe-client.startupExperimentPrefs.${experimentPref2}`, 2],
+      [`extensions.shield-recipe-client.startupExperimentPrefs.${experimentPref3}`, "string"],
+      [`extensions.shield-recipe-client.startupExperimentPrefs.${experimentPref4}`, "another string"],
+    ],
+    clear: [
+      [experimentPref1],
+      [experimentPref2],
+      [experimentPref3],
+      [experimentPref4],
+      ["extensions.shield-recipe-client.startupExperimentPrefs.existingPref"],
+    ],
+  }),
+  withBootstrap,
+  withStub(PreferenceExperiments, "recordOriginalValues"),
+  async function testInitExperimentPrefs(Bootstrap, recordOriginalValuesStub) {
+    const defaultBranch = Services.prefs.getDefaultBranch("");
+
+    defaultBranch.setBoolPref(experimentPref1, false);
+    defaultBranch.setIntPref(experimentPref2, 1);
+    defaultBranch.setCharPref(experimentPref3, "original string");
+    // experimentPref4 is left unset
+
+    Bootstrap.initExperimentPrefs();
+    await Bootstrap.finishStartup();
+
+    Assert.deepEqual(
+      recordOriginalValuesStub.getCall(0).args,
+      [{
+        [experimentPref1]: false,
+        [experimentPref2]: 1,
+        [experimentPref3]: "original string",
+        [experimentPref4]: null,  // null because it was not initially set.
+      }],
+      "finishStartup should record original values of the prefs initExperimentPrefs changed",
+    );
   },
 );


### PR DESCRIPTION
This fixes an issue that came up in the QA of #1100. When the default value has changed during the experiment to an empty value (which happened for screenshots), this causes it to revert correctly.