### PR TITLE
Improved UI error handling

### DIFF
--- a/recipe-server/client/control/components/extensions/CreateExtensionPage.js
+++ b/recipe-server/client/control/components/extensions/CreateExtensionPage.js
@@ -19,7 +19,7 @@ import {
   },
 )
 @autobind
-export default class CreateExtensionPage extends React.PureComponent {
+export default class CreateExtensionPage extends React.Component {
   static propTypes = {
     createExtension: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired,

--- a/recipe-server/client/control/components/extensions/CreateExtensionPage.js
+++ b/recipe-server/client/control/components/extensions/CreateExtensionPage.js
@@ -37,7 +37,7 @@ export default class CreateExtensionPage extends React.PureComponent {
   async handleSubmit(values) {
     const { createExtension, push } = this.props;
 
-    this.setState({ formErrors: undefined, });
+    this.setState({ formErrors: undefined });
 
     try {
       const extensionId = await createExtension(values);

--- a/recipe-server/client/control/components/extensions/CreateExtensionPage.js
+++ b/recipe-server/client/control/components/extensions/CreateExtensionPage.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { push as pushAction } from 'redux-little-router';
 
+import handleError from 'control/utils/handleError';
 import ExtensionForm from 'control/components/extensions/ExtensionForm';
 import {
   createExtension as createExtensionAction,
@@ -40,12 +41,9 @@ export default class CreateExtensionPage extends React.Component {
       message.success('Extension saved');
       push(`/extension/${extensionId}/`);
     } catch (error) {
-      message.error(
-        'Extension cannot be saved. Please correct any errors listed in the form below.',
-      );
-      if (error.data) {
-        this.setState({ formErrors: error.data });
-      }
+      handleError('Extension cannot be saved.', error);
+
+      this.setState({ formErrors: error.data });
     }
   }
 

--- a/recipe-server/client/control/components/extensions/CreateExtensionPage.js
+++ b/recipe-server/client/control/components/extensions/CreateExtensionPage.js
@@ -20,7 +20,7 @@ import {
   },
 )
 @autobind
-export default class CreateExtensionPage extends React.Component {
+export default class CreateExtensionPage extends React.PureComponent {
   static propTypes = {
     createExtension: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired,
@@ -36,6 +36,9 @@ export default class CreateExtensionPage extends React.Component {
    */
   async handleSubmit(values) {
     const { createExtension, push } = this.props;
+
+    this.setState({ formErrors: undefined, });
+
     try {
       const extensionId = await createExtension(values);
       message.success('Extension saved');
@@ -43,7 +46,7 @@ export default class CreateExtensionPage extends React.Component {
     } catch (error) {
       handleError('Extension cannot be saved.', error);
 
-      this.setState({ formErrors: error.data });
+      this.setState({ formErrors: error.data || error });
     }
   }
 

--- a/recipe-server/client/control/components/extensions/EditExtensionPage.js
+++ b/recipe-server/client/control/components/extensions/EditExtensionPage.js
@@ -30,7 +30,7 @@ import { addSessionView as addSessionViewAction } from 'control/state/app/sessio
   },
 )
 @autobind
-export default class EditExtensionPage extends React.PureComponent {
+export default class EditExtensionPage extends React.Component {
   static propTypes = {
     extension: PropTypes.instanceOf(Map).isRequired,
     extensionId: PropTypes.number.isRequired,

--- a/recipe-server/client/control/components/extensions/EditExtensionPage.js
+++ b/recipe-server/client/control/components/extensions/EditExtensionPage.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import handleError from 'control/utils/handleError';
 import LoadingOverlay from 'control/components/common/LoadingOverlay';
 import QueryExtension from 'control/components/data/QueryExtension';
 import ExtensionForm from 'control/components/extensions/ExtensionForm';
@@ -30,7 +31,7 @@ import { addSessionView as addSessionViewAction } from 'control/state/app/sessio
   },
 )
 @autobind
-export default class EditExtensionPage extends React.Component {
+export default class EditExtensionPage extends React.PureComponent {
   static propTypes = {
     extension: PropTypes.instanceOf(Map).isRequired,
     extensionId: PropTypes.number.isRequired,
@@ -64,15 +65,16 @@ export default class EditExtensionPage extends React.Component {
    */
   async handleSubmit(values) {
     const { extensionId, updateExtension } = this.props;
+    this.setState({ formErrors: undefined, });
+
     try {
       await updateExtension(extensionId, values);
-      message.success('Extension saved');
+      message.success('Extension saved!');
     } catch (error) {
-      message.error(
-        'Extension cannot be saved. Please correct any errors listed in the form below.',
-      );
+      handleError('Extension cannot be updated.', error)
+
       if (error.data) {
-        this.setState({ formErrors: error.data });
+        this.setState({ formErrors: error.data || error });
       }
     }
   }

--- a/recipe-server/client/control/components/extensions/EditExtensionPage.js
+++ b/recipe-server/client/control/components/extensions/EditExtensionPage.js
@@ -65,13 +65,13 @@ export default class EditExtensionPage extends React.PureComponent {
    */
   async handleSubmit(values) {
     const { extensionId, updateExtension } = this.props;
-    this.setState({ formErrors: undefined, });
+    this.setState({ formErrors: undefined });
 
     try {
       await updateExtension(extensionId, values);
       message.success('Extension saved!');
     } catch (error) {
-      handleError('Extension cannot be updated.', error)
+      handleError('Extension cannot be updated.', error);
 
       if (error.data) {
         this.setState({ formErrors: error.data || error });

--- a/recipe-server/client/control/components/forms/FormItem.js
+++ b/recipe-server/client/control/components/forms/FormItem.js
@@ -54,7 +54,7 @@ export default class FormItem extends React.PureComponent {
     connectToForm: true,
     initialValue: null,
     name: null,
-    rules: null,
+    rules: [{ required: true, message: 'This field is required.' }],
     trimWhitespace: false,
   };
 

--- a/recipe-server/client/control/components/recipes/ApprovalForm.js
+++ b/recipe-server/client/control/components/recipes/ApprovalForm.js
@@ -12,8 +12,7 @@ import FormItem from 'control/components/forms/FormItem';
 import {
   closeApprovalRequest as closeApprovalRequestAction,
 } from 'control/state/app/approvalRequests/actions';
-import { createForm } from 'control/utils/forms';
-
+import { createForm, ValidationError } from 'control/utils/forms';
 
 @connect(
   null,
@@ -39,7 +38,7 @@ export default class ApprovalForm extends React.PureComponent {
   handleApproveClick(event) {
     this.props.form.validateFields(error => {
       if (error) {
-        handleError('Unable to approve request.', error);
+        handleError('Unable to approve request.', new ValidationError(error));
       } else {
         this.props.onSubmit(event, { approved: true });
       }
@@ -49,7 +48,7 @@ export default class ApprovalForm extends React.PureComponent {
   handleRejectClick(event) {
     this.props.form.validateFields(error => {
       if (error) {
-        handleError('Unable to reject request.', error);
+        handleError('Unable to reject request.', new ValidationError(error));
       } else {
         this.props.onSubmit(event, { approved: false });
       }

--- a/recipe-server/client/control/components/recipes/ApprovalRequest.js
+++ b/recipe-server/client/control/components/recipes/ApprovalRequest.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import handleError from 'control/utils/handleError';
 import ApprovalForm from 'control/components/recipes/ApprovalForm';
 import ApprovalDetails from 'control/components/recipes/ApprovalDetails';
 import RecipeDetails from 'control/components/recipes/RecipeDetails';
@@ -72,16 +73,10 @@ export default class ApprovalRequest extends React.PureComponent {
       await action(approvalRequest.get('id'), values);
       message.success(successMessage);
     } catch (error) {
+      handleError(`Unable to ${context.approved ? 'approve' : 'reject'} request.`, error);
+
       if (error.data) {
         this.setState({ formErrors: error.data });
-
-        // `error.data` is an object of invalid fields and the corresponding error
-        // message. `join`ing them here will produce a single error for the toast.
-        message.error(Object.values(error.data).join(' '));
-      } else {
-        message.error(
-          'Approval could not be submitted. Please correct any errors listed in the form below.',
-        );
       }
     } finally {
       this.setState({

--- a/recipe-server/client/control/components/recipes/CloneRecipePage.js
+++ b/recipe-server/client/control/components/recipes/CloneRecipePage.js
@@ -6,6 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link, push as pushAction } from 'redux-little-router';
 
+import handleError from 'control/utils/handleError';
 import LoadingOverlay from 'control/components/common/LoadingOverlay';
 import RecipeForm from 'control/components/recipes/RecipeForm';
 import QueryRecipe from 'control/components/data/QueryRecipe';
@@ -68,9 +69,7 @@ export default class CloneRecipePage extends React.PureComponent {
 
       push(`/recipe/${newId}/`);
     } catch (error) {
-      message.error(
-        'Recipe cannot be saved. Please correct any errors listed in the form below.',
-      );
+      handleError('Recipe cannot be cloned.', error);
 
       this.setState({
         formErrors: error.data || error,

--- a/recipe-server/client/control/components/recipes/ConsoleLogFields.js
+++ b/recipe-server/client/control/components/recipes/ConsoleLogFields.js
@@ -6,7 +6,7 @@ import React from 'react';
 import FormItem from 'control/components/forms/FormItem';
 
 
-export default class ConsoleLogFields extends React.PureComponent {
+export default class ConsoleLogFields extends React.Component {
   static propTypes = {
     disabled: PropTypes.bool,
     recipeArguments: PropTypes.instanceOf(Map),

--- a/recipe-server/client/control/components/recipes/CreateRecipePage.js
+++ b/recipe-server/client/control/components/recipes/CreateRecipePage.js
@@ -18,7 +18,7 @@ import { createRecipe as createAction } from 'control/state/app/recipes/actions'
   },
 )
 @autobind
-export default class CreateRecipePage extends React.Component {
+export default class CreateRecipePage extends React.PureComponent {
   static propTypes = {
     createRecipe: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired,
@@ -37,13 +37,13 @@ export default class CreateRecipePage extends React.Component {
       push,
     } = this.props;
 
+    this.setState({
+      formErrors: undefined,
+    });
 
     try {
       const newId = await createRecipe(values);
       message.success('Recipe created');
-      this.setState({
-        formErrors: undefined,
-      });
       push(`/recipe/${newId}/`);
     } catch (error) {
       handleError('Recipe cannot be created.', error);

--- a/recipe-server/client/control/components/recipes/CreateRecipePage.js
+++ b/recipe-server/client/control/components/recipes/CreateRecipePage.js
@@ -17,7 +17,7 @@ import { createRecipe as createAction } from 'control/state/app/recipes/actions'
   },
 )
 @autobind
-export default class CreateRecipePage extends React.PureComponent {
+export default class CreateRecipePage extends React.Component {
   static propTypes = {
     createRecipe: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired,

--- a/recipe-server/client/control/components/recipes/CreateRecipePage.js
+++ b/recipe-server/client/control/components/recipes/CreateRecipePage.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { push as pushAction } from 'redux-little-router';
 
+import handleError from 'control/utils/handleError';
 import RecipeForm from 'control/components/recipes/RecipeForm';
 import { createRecipe as createAction } from 'control/state/app/recipes/actions';
 
@@ -45,15 +46,11 @@ export default class CreateRecipePage extends React.Component {
       });
       push(`/recipe/${newId}/`);
     } catch (error) {
-      message.error(
-        'Recipe cannot be created. Please correct any errors listed in the form below.',
-      );
+      handleError('Recipe cannot be created.', error);
 
-      if (error) {
-        this.setState({
-          formErrors: error.data || error,
-        });
-      }
+      this.setState({
+        formErrors: error.data || error,
+      });
     }
   }
 

--- a/recipe-server/client/control/components/recipes/EditRecipePage.js
+++ b/recipe-server/client/control/components/recipes/EditRecipePage.js
@@ -33,7 +33,7 @@ import { getUrlParamAsInt } from 'control/state/router/selectors';
   },
 )
 @autobind
-export default class EditRecipePage extends React.PureComponent {
+export default class EditRecipePage extends React.Component {
   static propTypes = {
     addSessionView: PropTypes.func.isRequired,
     updateRecipe: PropTypes.func.isRequired,

--- a/recipe-server/client/control/components/recipes/EditRecipePage.js
+++ b/recipe-server/client/control/components/recipes/EditRecipePage.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import handleError from 'control/utils/handleError';
 import LoadingOverlay from 'control/components/common/LoadingOverlay';
 import RecipeForm from 'control/components/recipes/RecipeForm';
 import QueryRecipe from 'control/components/data/QueryRecipe';
@@ -74,20 +75,16 @@ export default class EditRecipePage extends React.Component {
 
     try {
       await this.props.updateRecipe(recipeId, values);
-      message.success('Recipe saved');
+      message.success('Recipe updated!');
       this.setState({
         formErrors: undefined,
       });
     } catch (error) {
-      message.error(
-        'Recipe cannot be saved. Please correct any errors listed in the form below.',
-      );
+      handleError('Recipe cannot be updated.', error);
 
-      if (error) {
-        this.setState({
-          formErrors: error.data || error,
-        });
-      }
+      this.setState({
+        formErrors: error.data,
+      });
     }
   }
 

--- a/recipe-server/client/control/components/recipes/EditRecipePage.js
+++ b/recipe-server/client/control/components/recipes/EditRecipePage.js
@@ -34,7 +34,7 @@ import { getUrlParamAsInt } from 'control/state/router/selectors';
   },
 )
 @autobind
-export default class EditRecipePage extends React.Component {
+export default class EditRecipePage extends React.PureComponent {
   static propTypes = {
     addSessionView: PropTypes.func.isRequired,
     updateRecipe: PropTypes.func.isRequired,
@@ -73,17 +73,18 @@ export default class EditRecipePage extends React.Component {
   async handleSubmit(values) {
     const { recipeId } = this.props;
 
+    this.setState({
+      formErrors: undefined,
+    });
+
     try {
       await this.props.updateRecipe(recipeId, values);
       message.success('Recipe updated!');
-      this.setState({
-        formErrors: undefined,
-      });
     } catch (error) {
       handleError('Recipe cannot be updated.', error);
 
       this.setState({
-        formErrors: error.data,
+        formErrors: error.data || error,
       });
     }
   }

--- a/recipe-server/client/control/components/recipes/OptOutStudyFields.js
+++ b/recipe-server/client/control/components/recipes/OptOutStudyFields.js
@@ -10,7 +10,7 @@ import ExtensionSelect from 'control/components/extensions/ExtensionSelect';
 import { connectFormProps } from 'control/utils/forms';
 
 @connectFormProps
-export default class OptOutStudyFields extends React.PureComponent {
+export default class OptOutStudyFields extends React.Component {
   static propTypes = {
     disabled: PropTypes.bool,
     recipeArguments: PropTypes.instanceOf(Map).isRequired,

--- a/recipe-server/client/control/components/recipes/PreferenceExperimentFields.js
+++ b/recipe-server/client/control/components/recipes/PreferenceExperimentFields.js
@@ -11,7 +11,7 @@ import { connectFormProps } from 'control/utils/forms';
 
 
 @connectFormProps
-export default class PreferenceExperimentFields extends React.PureComponent {
+export default class PreferenceExperimentFields extends React.Component {
   static propTypes = {
     disabled: PropTypes.bool,
     form: PropTypes.object.isRequired,

--- a/recipe-server/client/control/components/recipes/ShowHeartbeatFields.js
+++ b/recipe-server/client/control/components/recipes/ShowHeartbeatFields.js
@@ -11,7 +11,7 @@ import { connectFormProps } from 'control/utils/forms';
 
 
 @connectFormProps
-export default class ShowHeartbeatFields extends React.PureComponent {
+export default class ShowHeartbeatFields extends React.Component {
   static propTypes = {
     disabled: PropTypes.bool,
     form: PropTypes.object.isRequired,

--- a/recipe-server/client/control/tests/utils/test_handleError.js
+++ b/recipe-server/client/control/tests/utils/test_handleError.js
@@ -1,5 +1,6 @@
-import handleError, { ERR_MESSAGES } from 'control/utils/handleError';
 import APIClient from 'control/utils/api';
+import { ValidationError } from 'control/utils/forms';
+import handleError, { ERR_MESSAGES } from 'control/utils/handleError';
 
 describe('handleError util', () => {
   it('should work', () => {
@@ -22,7 +23,9 @@ describe('handleError util', () => {
   });
 
   it('should detect form validation errors', () => {
-    const { context, message, reason } = handleError('Test.', { field: 'Validation message.' });
+    const err = new ValidationError({ field: 'Validation message.' });
+    const { context, message, reason } = handleError('Test.', err);
+
     expect(context).toBe('Test.');
     expect(message).toBe(`Test. ${ERR_MESSAGES.FORM_VALIDATION}`);
     expect(reason).toBe(ERR_MESSAGES.FORM_VALIDATION);

--- a/recipe-server/client/control/tests/utils/test_handleError.js
+++ b/recipe-server/client/control/tests/utils/test_handleError.js
@@ -1,0 +1,59 @@
+import handleError, { ERR_MESSAGES } from 'control/utils/handleError';
+import APIClient from 'control/utils/api';
+
+describe('handleError util', () => {
+  it('should work', () => {
+    const wrapper = () => handleError();
+    expect(wrapper).not.toThrow();
+  });
+
+  it('should return the context', () => {
+    const { context, message, reason } = handleError('Test error');
+    expect(context).toBe('Test error');
+    expect(message).toBe('Test error');
+    expect(reason).toBe('');
+  });
+
+  it('should determine a message based on the error given', () => {
+    const { context, message, reason } = handleError('Test.', new Error('Error Message.'));
+    expect(context).toBe('Test.');
+    expect(message).toBe('Test. Error Message.');
+    expect(reason).toBe('Error Message.');
+  });
+
+  it('should detect form validation errors', () => {
+    const err = new APIClient.APIError('Server Error.', { field: 'Validation message. ' });
+
+    const { context, message, reason } = handleError('Test.', err);
+    expect(context).toBe('Test.');
+    expect(message).toBe(`Test. ${ERR_MESSAGES.FORM_VALIDATION}`);
+    expect(reason).toBe(ERR_MESSAGES.FORM_VALIDATION);
+  });
+
+  it('should fall back to server messages if no form validation errors', () => {
+    const err = new APIClient.APIError('Something from the server.');
+
+    const { context, message, reason } = handleError('Test.', err);
+    expect(context).toBe('Test.');
+    expect(message).toBe('Test. Something from the server.');
+    expect(reason).toBe('Something from the server.');
+  });
+
+  it('should detect when a user is offline', () => {
+    const { context, message, reason } = handleError('Test.', new Error(), {
+      checkUserOnline: () => false,
+    });
+    expect(context).toBe('Test.');
+    expect(message).toBe(`Test. ${ERR_MESSAGES.NO_INTERNET}`);
+    expect(reason).toBe(ERR_MESSAGES.NO_INTERNET);
+  });
+
+  it('should notify the user somehow', () => {
+    let called = false;
+    handleError('Test.', new Error(), {
+      notifyUser: () => { called = true; },
+    });
+
+    expect(called).toBe(true);
+  });
+});

--- a/recipe-server/client/control/utils/api.js
+++ b/recipe-server/client/control/utils/api.js
@@ -54,7 +54,7 @@ export default class APIClient {
     // Throw if we get a non-200 response.
     if (!response.ok) {
       let message;
-      let data;
+      let data = {};
       let err;
 
       try {
@@ -64,6 +64,8 @@ export default class APIClient {
         message = error.message;
         err = error;
       }
+
+      data = { ...data, status: response.status };
 
       throw new APIClient.APIError(message, data, err);
     }

--- a/recipe-server/client/control/utils/api.js
+++ b/recipe-server/client/control/utils/api.js
@@ -55,15 +55,17 @@ export default class APIClient {
     if (!response.ok) {
       let message;
       let data;
+      let err;
 
       try {
         data = await response.json();
         message = data.detail || response.statusText;
       } catch (error) {
         message = error.message;
+        err = error;
       }
 
-      throw new APIClient.APIError(message, data);
+      throw new APIClient.APIError(message, data, err);
     }
 
     if (response.status !== 204) {

--- a/recipe-server/client/control/utils/forms.js
+++ b/recipe-server/client/control/utils/forms.js
@@ -1,9 +1,17 @@
-import { Form, message } from 'antd';
+import { Form } from 'antd';
 import autobind from 'autobind-decorator';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import handleError from 'control/utils/handleError';
+
+// Simple error class used when a form fails to validate.
+export class ValidationError extends Error {
+  constructor(data) {
+    super();
+    this.fields = data;
+  }
+}
 
 
 /**
@@ -99,7 +107,7 @@ export function createForm({ validateFields, ...formConfig }) {
           const defaultValues = await this.defaultValidateFields();
           values = await customValidateFields.call(this.formComponent, defaultValues);
         } catch (error) {
-          handleError('Could not validate form. Please correct the errors below.');
+          handleError('Could not validate form.', new ValidationError(error));
 
           return;
         }

--- a/recipe-server/client/control/utils/forms.js
+++ b/recipe-server/client/control/utils/forms.js
@@ -3,6 +3,8 @@ import autobind from 'autobind-decorator';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import handleError from 'control/utils/handleError';
+
 
 /**
  * Decorator used to wrap forms for collecting and validating user input.
@@ -92,13 +94,17 @@ export function createForm({ validateFields, ...formConfig }) {
        */
       async triggerSubmit(context) {
         const customValidateFields = validateFields || (values => values);
+        let values;
         try {
           const defaultValues = await this.defaultValidateFields();
-          const values = await customValidateFields.call(this.formComponent, defaultValues);
-          this.props.onSubmit(values, context);
+          values = await customValidateFields.call(this.formComponent, defaultValues);
         } catch (error) {
-          message.error('Could not validate form. Please correct the errors below.');
+          handleError('Could not validate form. Please correct the errors below.');
+
+          return;
         }
+
+        this.props.onSubmit(values, context);
       }
 
       async defaultValidateFields() {

--- a/recipe-server/client/control/utils/handleError.js
+++ b/recipe-server/client/control/utils/handleError.js
@@ -1,4 +1,4 @@
-import { message } from 'antd';
+import { message as AntMessage } from 'antd';
 
 import APIClient from 'control/utils/api';
 
@@ -7,29 +7,65 @@ export const ERR_MESSAGES = {
   FORM_VALIDATION: 'Please correct the form items highlighted below.',
   NO_INTERNET: 'Check your internet connection and try again.',
   SERVER_FAILED: 'The server failed to respond. Please try again.',
+  NOT_LOGGED_IN: 'No active user session found, try logging in again.',
+  NO_PERMISSION: 'You do not have permission to perform that action.',
 };
 
-// String to search for to determine if a fetch failed. Unlikely to change.
-const fetchFailureMessage = 'Failed to fetch';
+// Search strings used to determine various types responses.
+const checkFetchFailure = ({ message = '' }) =>
+  message.indexOf('Failed to fetch') !== -1 || message.indexOf('NetworkError') !== -1;
+
+const checkLoginFailure = ({ message = '' }) => message.indexOf('credentials were not provided') > -1;
+const checkAPIFailure = error => error instanceof APIClient.APIError;
+
 
 const defaultMethods = {
   checkUserOnline: () => navigator.onLine,
-  notifyUser: errMsg => message.error(errMsg),
+  notifyUser: errMsg => AntMessage.error(errMsg, 10),
+};
+
+const handleAPIError = error => {
+  let message = '';
+
+  switch (error.data.status) {
+    case 400: // Bad Request
+      message = ERR_MESSAGES.FORM_VALIDATION;
+      break;
+
+    case 403: // Forbidden
+      message = checkLoginFailure(error) ? ERR_MESSAGES.NOT_LOGGED_IN : ERR_MESSAGES.NO_PERMISSION;
+      break;
+
+    case 500: // Internal Server Error
+      message = `${ERR_MESSAGES.SERVER_FAILED} (${error.message})`;
+      break;
+
+    // If it's a status we aren't expecting, simply pass the server error
+    // forward to the client.
+    default:
+      message = error.message;
+      break;
+  }
+
+  return message;
 };
 
 export default function handleError(context = 'Error!', error, methodOverrides = {}) {
   const methods = { ...defaultMethods, ...methodOverrides };
   let errMsg = '';
 
+  // This function can be used to trigger an error message without an actual Error
+  // object. If an Error is given, though, we can extract a more meaningful error message.
   if (error) {
+    errMsg = error.message || '';
     if (!methods.checkUserOnline()) {
       errMsg = ERR_MESSAGES.NO_INTERNET;
-    } else if (error.message.indexOf(fetchFailureMessage) > -1) {
+    } else if (checkFetchFailure(error)) {
       errMsg = ERR_MESSAGES.SERVER_FAILED;
-    } else if (error instanceof APIClient.APIError && error.data) {
+    } else if (checkAPIFailure(error)) {
+      errMsg = handleAPIError(error);
+    } else if (!(error instanceof Error)) {
       errMsg = ERR_MESSAGES.FORM_VALIDATION;
-    } else {
-      errMsg = error.message;
     }
   }
 

--- a/recipe-server/client/control/utils/handleError.js
+++ b/recipe-server/client/control/utils/handleError.js
@@ -1,6 +1,7 @@
 import { message as AntMessage } from 'antd';
 
 import APIClient from 'control/utils/api';
+import { ValidationError } from 'control/utils/forms';
 
 
 export const ERR_MESSAGES = {
@@ -17,6 +18,7 @@ const checkFetchFailure = ({ message = '' }) =>
 
 const checkLoginFailure = ({ message = '' }) => message.indexOf('credentials were not provided') > -1;
 const checkAPIFailure = error => error instanceof APIClient.APIError;
+const checkValidationFailure = error => error instanceof ValidationError;
 
 const msgDisplayTime = 8; // seconds
 
@@ -65,7 +67,7 @@ export default function handleError(context = 'Error!', error, methodOverrides =
       errMsg = ERR_MESSAGES.SERVER_FAILED;
     } else if (checkAPIFailure(error)) {
       errMsg = handleAPIError(error);
-    } else if (!(error instanceof Error)) {
+    } else if (checkValidationFailure(error)) {
       errMsg = ERR_MESSAGES.FORM_VALIDATION;
     }
   }

--- a/recipe-server/client/control/utils/handleError.js
+++ b/recipe-server/client/control/utils/handleError.js
@@ -1,0 +1,45 @@
+import { message } from 'antd';
+
+import APIClient from 'control/utils/api';
+
+
+export const ERR_MESSAGES = {
+  FORM_VALIDATION: 'Please correct the form items highlighted below.',
+  NO_INTERNET: 'Check your internet connection and try again.',
+  SERVER_FAILED: 'The server failed to respond. Please try again.',
+};
+
+// String to search for to determine if a fetch failed. Unlikely to change.
+const fetchFailureMessage = 'Failed to fetch';
+
+const defaultMethods = {
+  checkUserOnline: () => navigator.onLine,
+  notifyUser: errMsg => message.error(errMsg),
+};
+
+export default function handleError(context = 'Error!', error, methodOverrides = {}) {
+  const methods = { ...defaultMethods, ...methodOverrides };
+  let errMsg = '';
+
+  if (error) {
+    if (!methods.checkUserOnline()) {
+      errMsg = ERR_MESSAGES.NO_INTERNET;
+    } else if (error.message.indexOf(fetchFailureMessage) > -1) {
+      errMsg = ERR_MESSAGES.SERVER_FAILED;
+    } else if (error instanceof APIClient.APIError && error.data) {
+      errMsg = ERR_MESSAGES.FORM_VALIDATION;
+    } else {
+      errMsg = error.message;
+    }
+  }
+
+  const userMessage = `${context}${errMsg ? ` ${errMsg}` : ''}`;
+
+  methods.notifyUser(userMessage);
+
+  return {
+    context,
+    message: userMessage,
+    reason: errMsg,
+  };
+}

--- a/recipe-server/client/control/utils/handleError.js
+++ b/recipe-server/client/control/utils/handleError.js
@@ -18,10 +18,11 @@ const checkFetchFailure = ({ message = '' }) =>
 const checkLoginFailure = ({ message = '' }) => message.indexOf('credentials were not provided') > -1;
 const checkAPIFailure = error => error instanceof APIClient.APIError;
 
+const msgDisplayTime = 8; // seconds
 
 const defaultMethods = {
   checkUserOnline: () => navigator.onLine,
-  notifyUser: errMsg => AntMessage.error(errMsg, 10),
+  notifyUser: errMsg => AntMessage.error(errMsg, msgDisplayTime),
 };
 
 const handleAPIError = error => {

--- a/recipe-server/client/control/utils/handleError.js
+++ b/recipe-server/client/control/utils/handleError.js
@@ -35,6 +35,10 @@ const handleAPIError = error => {
       message = ERR_MESSAGES.FORM_VALIDATION;
       break;
 
+    case 401: // Not logged in
+      message = ERR_MESSAGES.NOT_LOGGED_IN;
+      break;
+
     case 403: // Forbidden
       message = checkLoginFailure(error) ? ERR_MESSAGES.NOT_LOGGED_IN : ERR_MESSAGES.NO_PERMISSION;
       break;


### PR DESCRIPTION
- Adds `handleError` util function
  - Given a `context` and an Error, determines an appropriate message to display to the user.
  Ex: `handleError('Recipe creation failed.', someError)` returns `'Recipe creation failed. Please correct the form errors below.'`
  - Checks if the server failed, if the user is not currently connected, or if there was a form validation error.
  - Falls back to displaying the plain error message given from the server response.
- Fixes issue where validation errors would not appear in recipe argument fields

This could use some more fleshing out, for instance mythmon had mentioned catching expired login sessions. I think we can implement those features in the future, but what's in this PR should be a good start.