### PR TITLE
Improve checks in response to 2017-11-07 outage

### DIFF
--- a/recipe-server/normandy/recipes/management/commands/update_action_signatures.py
+++ b/recipe-server/normandy/recipes/management/commands/update_action_signatures.py
@@ -11,6 +11,7 @@ from normandy.recipes.models import Action
 class Command(BaseCommand):
     """Update signatures for Actions that have no signature or an old signature."""
     help = 'Update Action signatures'
+    requires_system_checks = False
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/recipe-server/normandy/recipes/management/commands/update_recipe_signatures.py
+++ b/recipe-server/normandy/recipes/management/commands/update_recipe_signatures.py
@@ -13,6 +13,7 @@ class Command(BaseCommand):
     Update signatures for enabled Recipes that have no signature or an old signature
     """
     help = 'Update Recipe signatures'
+    requires_system_checks = False
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/recipe-server/normandy/recipes/management/commands/update_signatures.py
+++ b/recipe-server/normandy/recipes/management/commands/update_signatures.py
@@ -7,6 +7,7 @@ class Command(BaseCommand):
     Meta command to call all update_*_signatures management commands.
     """
     help = 'Update all signatures'
+    requires_system_checks = False
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/recipe-server/normandy/recipes/tests/test_checks.py
+++ b/recipe-server/normandy/recipes/tests/test_checks.py
@@ -5,6 +5,7 @@ import pytest
 from normandy.recipes import checks, signing
 from normandy.recipes.tests import RecipeFactory, SignatureFactory
 
+
 @pytest.mark.django_db
 class TestSignaturesUseGoodCertificates(object):
 
@@ -25,7 +26,7 @@ class TestSignaturesUseGoodCertificates(object):
     def test_it_ignores_signatures_not_in_use(self, mocker, settings):
         settings.CERTIFICATES_EXPIRE_EARLY_DAYS = None
         recipe = RecipeFactory(signed=True)
-        unused_signature = SignatureFactory(x5u='https://example.com/bad_x5u')
+        SignatureFactory(x5u='https://example.com/bad_x5u')  # unused signature
         mock_verify_x5u = mocker.patch('normandy.recipes.checks.signing.verify_x5u')
 
         def side_effect(x5u, *args):

--- a/recipe-server/normandy/recipes/tests/test_checks.py
+++ b/recipe-server/normandy/recipes/tests/test_checks.py
@@ -36,7 +36,7 @@ class TestSignaturesUseGoodCertificates(object):
         mock_verify_x5u.side_effect = side_effect
 
         errors = checks.signatures_use_good_certificates(None)
-        assert not mock_verify_x5u.assert_called_once_with(recipe.signature.x5u, None)
+        mock_verify_x5u.assert_called_once_with(recipe.signature.x5u, None)
         assert errors == []
 
     def test_it_passes_expire_early_setting(self, mocker, settings):
@@ -45,5 +45,5 @@ class TestSignaturesUseGoodCertificates(object):
         mock_verify_x5u = mocker.patch('normandy.recipes.checks.signing.verify_x5u')
 
         errors = checks.signatures_use_good_certificates(None)
-        assert not mock_verify_x5u.assert_called_once_with(recipe.signature.x5u, timedelta(7))
+        mock_verify_x5u.assert_called_once_with(recipe.signature.x5u, timedelta(7))
         assert errors == []

--- a/recipe-server/normandy/recipes/tests/test_checks.py
+++ b/recipe-server/normandy/recipes/tests/test_checks.py
@@ -1,0 +1,48 @@
+from datetime import timedelta
+
+import pytest
+
+from normandy.recipes import checks, signing
+from normandy.recipes.tests import RecipeFactory, SignatureFactory
+
+@pytest.mark.django_db
+class TestSignaturesUseGoodCertificates(object):
+
+    def test_it_works(self):
+        assert checks.signatures_use_good_certificates(None) == []
+
+    def test_it_fails_if_a_signature_does_not_verify(self, mocker, settings):
+        settings.CERTIFICATES_EXPIRE_EARLY_DAYS = None
+        recipe = RecipeFactory(signed=True)
+        mock_verify_x5u = mocker.patch('normandy.recipes.checks.signing.verify_x5u')
+        mock_verify_x5u.side_effect = signing.BadCertificate('testing exception')
+
+        errors = checks.signatures_use_good_certificates(None)
+        mock_verify_x5u.assert_called_once_with(recipe.signature.x5u, None)
+        assert len(errors) == 1
+        assert errors[0].id == checks.WARNING_BAD_SIGNING_CERTIFICATE
+
+    def test_it_ignores_signatures_not_in_use(self, mocker, settings):
+        settings.CERTIFICATES_EXPIRE_EARLY_DAYS = None
+        recipe = RecipeFactory(signed=True)
+        unused_signature = SignatureFactory(x5u='https://example.com/bad_x5u')
+        mock_verify_x5u = mocker.patch('normandy.recipes.checks.signing.verify_x5u')
+
+        def side_effect(x5u, *args):
+            if 'bad' in x5u:
+                raise signing.BadCertificate('testing exception')
+            return True
+        mock_verify_x5u.side_effect = side_effect
+
+        errors = checks.signatures_use_good_certificates(None)
+        assert not mock_verify_x5u.assert_called_once_with(recipe.signature.x5u, None)
+        assert errors == []
+
+    def test_it_passes_expire_early_setting(self, mocker, settings):
+        settings.CERTIFICATES_EXPIRE_EARLY_DAYS = 7
+        recipe = RecipeFactory(signed=True)
+        mock_verify_x5u = mocker.patch('normandy.recipes.checks.signing.verify_x5u')
+
+        errors = checks.signatures_use_good_certificates(None)
+        assert not mock_verify_x5u.assert_called_once_with(recipe.signature.x5u, timedelta(7))
+        assert errors == []


### PR DESCRIPTION
These code changes were made during the outage to alleviate problems found during recovery. None of them would have fixed the bug.

Currently hearbeat is disabled on production because it lacks these code changes. This leaves us very vulnerable to problems. These changes are high priority because of that. We'd like to deploy these changes today if possible.

@Osmose Rehan is busy with other high priority Pioneer things. Can you review this?