### PR TITLE
UI: Abstract Labeled Input from SwitchBox

### DIFF
--- a/recipe-server/client/control/components/forms/CheckBox.js
+++ b/recipe-server/client/control/components/forms/CheckBox.js
@@ -10,19 +10,13 @@ export default class LabeledCheckbox extends LabeledInput {
   }
 
   getElementProps() {
-    const { value } = this.props;
-
-    return {
-      checked: value,
-    };
+    return { checked: this.props.value };
   }
 
   getLabelProps() {
-    const { value } = this.props;
-
     return {
       role: 'checkbox',
-      'aria-checked': value,
+      'aria-checked': this.props.value,
     };
   }
 }

--- a/recipe-server/client/control/components/forms/CheckBox.js
+++ b/recipe-server/client/control/components/forms/CheckBox.js
@@ -1,10 +1,10 @@
-import { Switch } from 'antd';
+import { Checkbox as AntCheckbox } from 'antd';
 import autobind from 'autobind-decorator';
 
 import LabeledInput from './LabeledInput';
 
 @autobind
-export default class SwitchBox extends LabeledInput {
+export default class CheckBox extends LabeledInput {
   handleLabelClick() {
     const newValue = !this.props.value;
 
@@ -12,7 +12,7 @@ export default class SwitchBox extends LabeledInput {
   }
 
   getElement() {
-    return Switch;
+    return AntCheckbox;
   }
 
   getElementProps() {

--- a/recipe-server/client/control/components/forms/CheckBox.js
+++ b/recipe-server/client/control/components/forms/CheckBox.js
@@ -1,18 +1,12 @@
-import { Checkbox as AntCheckbox } from 'antd';
+import { Checkbox } from 'antd';
 import autobind from 'autobind-decorator';
 
 import LabeledInput from './LabeledInput';
 
 @autobind
-export default class CheckBox extends LabeledInput {
-  handleLabelClick() {
-    const newValue = !this.props.value;
-
-    this.props.onChange(newValue);
-  }
-
+export default class LabeledCheckbox extends LabeledInput {
   getElement() {
-    return AntCheckbox;
+    return Checkbox;
   }
 
   getElementProps() {

--- a/recipe-server/client/control/components/forms/LabeledInput.js
+++ b/recipe-server/client/control/components/forms/LabeledInput.js
@@ -1,6 +1,6 @@
 // eslint does not detect that aria roles come from `getLabelProps`,
 // ignoring the rule here to disable lint errors.
-/* eslint-disable jsx-a11y/interactive-supports-focus */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 
 import autobind from 'autobind-decorator';
 import PropTypes from 'prop-types';
@@ -12,14 +12,12 @@ export default class LabeledInput extends React.Component {
     children: PropTypes.node,
     element: PropTypes.node,
     onChange: PropTypes.func,
-    value: PropTypes.any,
   };
 
   static defaultProps = {
     children: null,
     element: undefined,
     onChange: () => {},
-    value: undefined,
   }
 
   getElement() { throw new Error('LabeledInput#getElement must be overridden.'); }
@@ -33,7 +31,6 @@ export default class LabeledInput extends React.Component {
   render() {
     const {
       children,
-      value,
       onChange,
     } = this.props;
 

--- a/recipe-server/client/control/components/forms/LabeledInput.js
+++ b/recipe-server/client/control/components/forms/LabeledInput.js
@@ -1,0 +1,62 @@
+// eslint does not detect that aria roles come from `getLabelProps`,
+// ignoring the rule here to disable lint errors.
+/* eslint-disable jsx-a11y/interactive-supports-focus */
+
+import autobind from 'autobind-decorator';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+@autobind
+export default class LabeledInput extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    element: PropTypes.node,
+    onChange: PropTypes.func,
+    value: PropTypes.any,
+  };
+
+  static defaultProps = {
+    children: null,
+    element: undefined,
+    onChange: () => {},
+    value: undefined,
+  }
+
+  getElement() { throw new Error('LabeledInput#getElement must be overridden.'); }
+
+  getLabelProps() { return { role: 'input' }; }
+
+  getElementProps() { return {}; }
+
+  handleLabelClick() {}
+
+  render() {
+    const {
+      children,
+      value,
+      onChange,
+    } = this.props;
+
+    const Element = this.getElement();
+
+    return (
+      <label className="labeled-input">
+        <Element
+          onChange={onChange}
+          {...this.getElementProps()}
+        />
+
+        {
+          children &&
+            <span
+              className="label"
+              onClick={this.handleLabelClick}
+              {...this.getLabelProps()}
+            >
+              { children }
+            </span>
+        }
+      </label>
+    );
+  }
+}

--- a/recipe-server/client/control/components/forms/LabeledInput.js
+++ b/recipe-server/client/control/components/forms/LabeledInput.js
@@ -10,13 +10,11 @@ import React from 'react';
 export default class LabeledInput extends React.Component {
   static propTypes = {
     children: PropTypes.node,
-    element: PropTypes.node,
     onChange: PropTypes.func,
   };
 
   static defaultProps = {
     children: null,
-    element: undefined,
     onChange: () => {},
   }
 

--- a/recipe-server/client/control/components/recipes/ShowHeartbeatFields.js
+++ b/recipe-server/client/control/components/recipes/ShowHeartbeatFields.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import DocumentUrlInput from 'control/components/forms/DocumentUrlInput';
-import SwitchBox from 'control/components/forms/SwitchBox';
+import CheckBox from 'control/components/forms/CheckBox';
 import FormItem from 'control/components/forms/FormItem';
 import { connectFormProps } from 'control/utils/forms';
 
@@ -91,11 +91,12 @@ export default class ShowHeartbeatFields extends React.PureComponent {
           </FormItem>
           <FormItem
             name="arguments.includeTelemetryUUID"
+            label="Include Telemetry UUID?"
             initialValue={recipeArguments.get('includeTelemetryUUID', false)}
           >
-            <SwitchBox disabled={disabled}>
+            <CheckBox disabled={disabled}>
               Include UUID in Post-Answer URL and Telemetry
-            </SwitchBox>
+            </CheckBox>
           </FormItem>
         </Col>
         <Col sm={24}>

--- a/recipe-server/client/control/less/components/switchbox.less
+++ b/recipe-server/client/control/less/components/switchbox.less
@@ -1,4 +1,4 @@
-.switchbox {
+.labeled-input {
   align-items: center;
   display: flex;
 

--- a/recipe-server/client/control/less/pages/recipe-form.less
+++ b/recipe-server/client/control/less/pages/recipe-form.less
@@ -63,20 +63,6 @@
   }
 }
 
-.recipe-form {
-  .ant-form .ant-checkbox-wrapper {
-    line-height: 1em;
-  }
-
-  .post-answer-url {
-    margin-bottom: 0;
-  }
-
-  .post-answer-url-checkbox {
-    margin-bottom: 1em;
-  }
-}
-
 fieldset {
   border: none;
 

--- a/recipe-server/client/control/tests/components/recipes/test_LabeledInput.js
+++ b/recipe-server/client/control/tests/components/recipes/test_LabeledInput.js
@@ -1,17 +1,25 @@
 import { Switch } from 'antd';
+import autobind from 'autobind-decorator';
 import React from 'react';
 import { mount } from 'enzyme';
 
-import SwitchBox from 'control/components/forms/SwitchBox';
+import LabeledInput from 'control/components/forms/LabeledInput';
 
-describe('<SwitchBox>', () => {
+@autobind
+class TestInput extends LabeledInput {
+  getElement() { return Switch; }
+  getElementProps() { return { checked: this.props.value, testProp: 123 }; }
+  handleLabelClick() { this.props.onChange(); }
+}
+
+describe('<LabeledInput>', () => {
   const props = {
     children: null,
     onChange: () => {},
     value: null,
   };
 
-  const factory = (customProps = {}) => mount(<SwitchBox {...props} {...customProps} />);
+  const factory = (customProps = {}) => mount(<TestInput {...props} {...customProps} />);
 
   it('should work', () => {
     expect(factory).not.toThrow();
@@ -43,8 +51,14 @@ describe('<SwitchBox>', () => {
     });
   });
 
-  describe('the Switch', () => {
-    it('should inherit the `value` as a `checked` prop', () => {
+  describe('getElementProps', () => {
+    it('should pass properties into the internal component', () => {
+      const wrapper = factory();
+      expect(wrapper.find(Switch).length).toBe(1);
+      expect(wrapper.find(Switch).props().testProp).toBe(123);
+    });
+
+    it('should pass dynamic props (`value` as a `checked` prop)', () => {
       const wrapper = factory({ value: true });
       expect(wrapper.find(Switch).length).toBe(1);
       expect(wrapper.find(Switch).props().checked).toBe(true);


### PR DESCRIPTION
- Abstracts common `SwitchBox`/`CheckBox` code into a shared class, `LabeledInput`
- `LabeledInput` lets us wrap Ant's form components with the same label classes/styles we've established in the `SwitchBox`
- This allows us to more easily create input controls that fit within the conventions of our forms. For example, to make a labelled `Rating` input control, the code is simply:

```
import { Rate } from 'antd';
import autobind from 'autobind-decorator';

import LabeledInput from './LabeledInput';

@autobind
export default class Rating extends LabeledInput {
  static MAX_RATING = 5;

  getElement() {
    return Rate;
  }

  getElementProps() {
    return { value: this.props.value };
  }

  handleLabelClick() {
    let nextValue = (this.props.value || 0) + 1;
    nextValue = nextValue % (Rating.MAX_RATING + 1);

    this.props.onChange(nextValue);
  }
}
```

Currently, the `LabeledInput` component needs tests, but this is ready for feedback.