### PR TITLE
Add add-on test directory to lint, upgrade eslint-plugin-mozilla to 0.4.9 and fix raised errors

### DIFF
--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -105,7 +105,7 @@ this.Bootstrap = {
             log.error(`Error getting startup pref ${prefName}; unknown value type ${experimentPrefType}.`);
         }
       } catch (e) {
-        if (e.result == Cr.NS_ERROR_UNEXPECTED) {
+        if (e.result === Cr.NS_ERROR_UNEXPECTED) {
           // There is a value for the pref on the user branch but not on the default branch. This is ok.
           studyPrefsChanged[prefName] = null;
         } else {

--- a/recipe-client-addon/package.json
+++ b/recipe-client-addon/package.json
@@ -10,14 +10,14 @@
     "watch": "webpack --config ./webpack.config.js --watch",
     "build": "webpack --config ./webpack.config.js",
     "lint": "npm run lint-js; npm run lint-css;",
-    "lint-js": "eslint lib content bootstrap.js webpack.config.js || true",
+    "lint-js": "eslint lib content bootstrap.js webpack.config.js test || true",
     "lint-css": "stylelint '**/*.css' --config .stylelintrc || true"
   },
   "devDependencies": {
     "babili-webpack-plugin": "0.1.2",
     "eslint": "4.10.0",
     "eslint-config-normandy": "1.0.0",
-    "eslint-plugin-mozilla": "0.4.6",
+    "eslint-plugin-mozilla": "0.4.9",
     "eslint-plugin-no-unsanitized": "2.0.1",
     "eslint-plugin-react": "^7.1.0",
     "license-webpack-plugin": "0.5.1",

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -12,9 +12,8 @@ Cu.import("resource://shield-recipe-client/lib/Utils.jsm", this);
 
 // Load mocking/stubbing library, sinon
 // docs: http://sinonjs.org/docs/
-const loader = Cc["@mozilla.org/moz/jssubscript-loader;1"].getService(Ci.mozIJSSubScriptLoader);
 /* global sinon */
-loader.loadSubScript("resource://testing-common/sinon-2.3.2.js");
+Services.scriptloader.loadSubScript("resource://testing-common/sinon-2.3.2.js");
 
 // Make sinon assertions fail in a way that mochitest understands
 sinon.assert.fail = function(message) {


### PR DESCRIPTION
I'm starting to spread mozilla/use-services around mozilla-central, whilst doing that I noticed that the test/ directory of the add-on wasn't being linted. Hence, I'm adding that here, and fixing issues arising.

Also for good measure is an upgrade of the plugin to the latest.