### PR TITLE
Ignore NSP-532, since a fix is not currently available.

### DIFF
--- a/recipe-server/.nsprc
+++ b/recipe-server/.nsprc
@@ -1,0 +1,5 @@
+{
+  "exceptions": [
+    "https://nodesecurity.io/advisories/532"
+  ]
+}


### PR DESCRIPTION
This is a security problem in the moment js library. I don't believe we are vulnerable to this problem, since we only use in client side. There is not fix available yet. I'm tracking this issue, and will file a PR to include a fix once it is published.

In the meantime, this is breaking the build, so ignoring it until there is a fix available seems to me the best way forwards.