### PR TITLE
Bug 1416153 - Part 0: Fix tests that uses BrowserTestUtils.waitForNew Tab to perform the registration of the next event handler instantly inside the new tab event handler. r=Gijs

### DIFF
--- a/recipe-client-addon/test/browser/browser_Heartbeat.js
+++ b/recipe-client-addon/test/browser/browser_Heartbeat.js
@@ -102,11 +102,18 @@ add_task(async function() {
   Assert.equal(messageEl.textContent, "test", "Message is correct");
 
   // Check that when clicking the learn more link, a tab opens with the right URL
-  const tabOpenPromise = BrowserTestUtils.waitForNewTab(targetWindow.gBrowser);
+  let loadedPromise;
+  const tabOpenPromise = new Promise(resolve => {
+    gBrowser.tabContainer.addEventListener("TabOpen", event => {
+      let tab = event.target;
+      loadedPromise = BrowserTestUtils.browserLoaded(
+        tab.linkedBrowser, true, url => url && url !== "about:blank");
+      resolve(tab);
+    }, { once: true });
+  });
   learnMoreEl.click();
   const tab = await tabOpenPromise;
-  const tabUrl = await BrowserTestUtils.browserLoaded(
-    tab.linkedBrowser, true, url => url && url !== "about:blank");
+  const tabUrl = await loadedPromise;
 
   Assert.equal(tabUrl, "https://example.org/learnmore", "Learn more link opened the right url");
 
@@ -138,11 +145,18 @@ add_task(async function() {
   Assert.equal(engagementButton.label, "Click me!", "Engagement button has correct label");
 
   const engagementEl = hb.notice.querySelector(".notification-button");
-  const tabOpenPromise = BrowserTestUtils.waitForNewTab(targetWindow.gBrowser);
+  let loadedPromise;
+  const tabOpenPromise = new Promise(resolve => {
+    gBrowser.tabContainer.addEventListener("TabOpen", event => {
+      let tab = event.target;
+      loadedPromise = BrowserTestUtils.browserLoaded(
+        tab.linkedBrowser, true, url => url && url !== "about:blank");
+      resolve(tab);
+    }, { once: true });
+  });
   engagementEl.click();
   const tab = await tabOpenPromise;
-  const tabUrl = await BrowserTestUtils.browserLoaded(
-        tab.linkedBrowser, true, url => url && url !== "about:blank");
+  const tabUrl = await loadedPromise;
   // the postAnswer url gets query parameters appended onto the end, so use Assert.startsWith instead of Assert.equal
   Assert.ok(tabUrl.startsWith("https://example.org/postAnswer"), "Engagement button opened the right url");
 


### PR DESCRIPTION
This is a backport from [Bug 1416153](https://bugzilla.mozilla.org/show_bug.cgi?id=1416153). It helps with race conditions in tests that we hit when trying to sync v80.