### PR TITLE
#1141: Highlight current selected revision

### DIFF
--- a/recipe-server/client/control/components/recipes/HistoryTimeline.js
+++ b/recipe-server/client/control/components/recipes/HistoryTimeline.js
@@ -30,6 +30,7 @@ export default class HistoryTimeline extends React.PureComponent {
     const {
       history,
       recipeId,
+      selectedRevisionId,
     } = this.props;
 
     return (
@@ -41,6 +42,7 @@ export default class HistoryTimeline extends React.PureComponent {
               history.map((revision, index) =>
                 (<HistoryItem
                   key={revision.get('id')}
+                  selectedRevisionId={selectedRevisionId}
                   revisionNo={history.size - index}
                   recipeId={recipeId}
                   revision={revision}

--- a/recipe-server/client/control/tests/components/recipes/test_HistoryItem.js
+++ b/recipe-server/client/control/tests/components/recipes/test_HistoryItem.js
@@ -1,3 +1,4 @@
+import { Timeline } from 'antd';
 import { fromJS, Map } from 'immutable';
 import React from 'react';
 import { mount } from 'enzyme';
@@ -27,6 +28,41 @@ describe('<HistoryItem>', () => {
     const wrapper = () => mount(wrapMockStore(<HistoryItem {...props} />));
 
     expect(wrapper).not.toThrow();
+  });
+
+  describe('selected revisions', () => {
+    const props = {
+      isLatestRevision: () => {},
+      revision: new Map({
+        id: 'abc123',
+      }),
+      status: new Map(),
+      recipeId: 'def234',
+      revisionNo: 6,
+    };
+
+    it('should highlight when it is the selected revision', () => {
+      const wrapper = mount(wrapMockStore(<HistoryItem {...props} selectedRevisionId="abc123" />));
+
+      // We can test against the Timeline.Item inheritting proper visual styles.
+      const el = wrapper.find(Timeline.Item);
+      expect(el.length).toBe(1);
+      expect(el.props().color).toBe('blue');
+
+      // `dot` is an Icon which should be highlighted with the appropriate icon.
+      expect(el.props().dot).toBeTruthy();
+      expect(el.props().dot.props.type).toBe('circle-left');
+      expect(el.props().dot.props.color).toBe('blue');
+    });
+
+    it('should NOT highlight when it is NOT the selected revision', () => {
+      const wrapper = mount(wrapMockStore(<HistoryItem {...props} selectedRevisionId="aeiou" />));
+
+      const el = wrapper.find(Timeline.Item);
+      expect(el.length).toBe(1);
+      expect(el.props().color).not.toBe('blue');
+      expect(el.props().dot).toBe(null);
+    });
   });
 
   describe('<HistoryItemPopover>', () => {


### PR DESCRIPTION
Fixes #1141 

The history timeline component was not highlighting the revision the user was currently viewing, due to a prop not being passed into `Timeline.Item`s.

This passes the `selectedRevisionId` prop to `Item`s, and adds appropriate tests.