### PR TITLE
#1151: "High Volume" toggle validation broken

### DIFF
--- a/recipe-server/client/control/components/recipes/PreferenceExperimentFields.js
+++ b/recipe-server/client/control/components/recipes/PreferenceExperimentFields.js
@@ -54,7 +54,7 @@ export default class PreferenceExperimentFields extends React.Component {
           <FormItem
             label="High volume recipe"
             name="arguments.isHighVolume"
-            initialValue={recipeArguments.get('isHighVolume')}
+            initialValue={recipeArguments.get('isHighVolume', false)}
           >
             <SwitchBox disabled={disabled}>
               Affects the experiment type reported to telemetry, and


### PR DESCRIPTION
Fixes #1151 

Initially thought this was an issue with one of the custom input components we made, turns out we were simply a missing a `false` Immutable fallback value.

Not totally sure how to write tests against this. It seemed a little excessive to write tests to specifically check if a form item has a certain default value, though maybe that's fine? Open to thoughts.