### PR TITLE
Fix #1139 - Log study enrollment events via Telemetry Events

### DIFF
--- a/docs/user/data_collection.rst
+++ b/docs/user/data_collection.rst
@@ -83,3 +83,110 @@ reported under the key ``shield-recipe-client/recipe/<recipe id>``:
 .. js:data:: RECIPE_SUCCESS
 
    The recipe was executed successfully.
+
+
+Enrollment
+-----------
+Shield records enrollment and unenrollment of users into studies, and
+records that data using `Telemetry Events`_. All data is stored in the
+``normandy`` category.
+
+.. _Telemetry Events: https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html
+
+Preference Studies
+^^^^^^^^^^^^^^^^^^
+Enrollment
+   method
+      The string ``"enroll"``
+   object
+      The string ``"preference_study"``
+   value
+      The name of the study (``recipe.arguments.slug``).
+   extra
+      branch
+         The name of the branch the user was assigned to (example:
+         ``"control"`` or ``"experiment"``).
+      experimentType
+         The type of preference experiment. Currently this can take
+         values "exp" and "exp-highpop", the latter being for
+         experiments targetting large numbers of users.
+
+Unenrollment
+   method
+      The string ``"unenroll"``.
+   object
+      The string ``"preference_study"``.
+   value
+      The name of the study (``recipe.arguments.slug``).
+   extra
+      didResetValue
+         The string ``"true"`` if the preference was set back to its
+         original value, ``"false"`` if it was left as its current
+         value. This can happen when, for example, the user changes a
+         preference that was involved in a user-branch study.
+      reason
+         The reason for unenrollment. Possible values are:
+
+         * ``"recipe-not-seen"``: The recipe was no longer
+           applicable to this client This can be because the recipe
+           was disabled, or the user no longer matches the recipe's
+           filter.
+         * ``"user-preference-changed"``: The study preference was
+           changed on the user branch. This could mean the user
+           changed the preference, or that some other mechanism set a
+           non-default value for the preference.
+         * ``"user-preference-changed-sideload"``: The study
+           preference was changed on the user branch while Shield was
+           inactive. This could mean that the value was manually
+           changed in a profile while Firefox was not running.
+         * ``"unknown"``: A reason was not specificied. This should be
+           considered a bug.
+
+Add-on Studies
+^^^^^^^^^^^^^^
+Enrollment
+   method
+      The string ``"enroll"``
+   object
+      The string ``"addon_study"``
+   value
+      The name of the study (``recipe.arguments.slug``).
+   extra
+      addonId
+         The add-on's ID (example: ``"feature-study@shield.mozilla.com"``).
+      addonVersion
+         The add-on's version (example: ``"1.2.3"``).
+
+Unenrollment
+   method
+      The string ``"unenroll"``.
+   object
+      The string ``"addon_study"``.
+   value
+      The name of the study (``recipe.arguments.name``).
+   extra
+      addonId
+         The add-on's ID (example: ``"feature-study@shield.mozilla.com"``).
+      addonVersion
+         The add-on's version (example: ``"1.2.3"``).
+      reason
+         The reason for unenrollment. Possible values are:
+
+         * ``"install-failure"``: The add-on failed to install.
+         * ``"individual-opt-out"``: The user opted-out of this
+           particular study.
+         * ``"general-opt-out"``: The user opted-out of studies in
+           general.
+         * ``"recipe-not-seen"``: The recipe was no longer applicable
+           to this client. This can be because the recipe was
+           disabled, or the user no longer matches the recipe's
+           filter.
+         * ``"uninstalled"``: The study's add-on as uninstalled by some
+           mechanism. For example, this could be a user action or the
+           add-on self-uninstalling.
+         * ``"uninstalled-sideload"``: The study's add-on was
+           uninstalled while Shield was inactive. This could be that
+           the add-on is no longer compatible, or was manually removed
+           from a profile.
+         * ``"unknown"``: A reason was not specificied. This should be
+           considered a bug.

--- a/recipe-client-addon/bootstrap.js
+++ b/recipe-client-addon/bootstrap.js
@@ -202,6 +202,7 @@ this.Bootstrap = {
       "lib/ShieldPreferences.jsm",
       "lib/ShieldRecipeClient.jsm",
       "lib/Storage.jsm",
+      "lib/TelemetryEvents.jsm",
       "lib/Uptake.jsm",
       "lib/Utils.jsm",
     ].map(m => `resource://shield-recipe-client/${m}`);

--- a/recipe-client-addon/content/AboutPages.jsm
+++ b/recipe-client-addon/content/AboutPages.jsm
@@ -165,7 +165,7 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
           this.sendStudyList(message.target);
           break;
         case "Shield:RemoveStudy":
-          this.removeStudy(message.data);
+          this.removeStudy(message.data.recipeId, message.data.reason);
           break;
         case "Shield:OpenDataPreferences":
           this.openDataPreferences();
@@ -195,8 +195,8 @@ XPCOMUtils.defineLazyGetter(this.AboutPages, "aboutStudies", () => {
      * Disable an active study and remove its add-on.
      * @param {String} studyName
      */
-    async removeStudy(recipeId) {
-      await AddonStudies.stop(recipeId);
+    async removeStudy(recipeId, reason) {
+      await AddonStudies.stop(recipeId, reason);
 
       // Update any open tabs with the new study list now that it has changed.
       Services.mm.broadcastAsyncMessage("Shield:ReceiveStudyList", {

--- a/recipe-client-addon/content/about-studies/shield-studies.js
+++ b/recipe-client-addon/content/about-studies/shield-studies.js
@@ -109,7 +109,7 @@ class StudyListItem extends React.Component {
   }
 
   handleClickRemove() {
-    sendPageEvent("RemoveStudy", this.props.study.recipeId);
+    sendPageEvent("RemoveStudy", {recipeId: this.props.study.recipeId, reason: "individual-opt-out"});
   }
 
   render() {

--- a/recipe-client-addon/lib/AddonStudies.jsm
+++ b/recipe-client-addon/lib/AddonStudies.jsm
@@ -91,8 +91,9 @@ function getStore(db) {
  * Mark a study object as having ended. Modifies the study in-place.
  * @param {IDBDatabase} db
  * @param {Study} study
+ * @param {String} reason Why the study is ending.
  */
-async function markAsEnded(db, study, reason = "unknown") {
+async function markAsEnded(db, study, reason) {
   if (reason === "unknown") {
     log.warn(`Study ${study.name} ending for unknown reason.`);
   }
@@ -321,11 +322,12 @@ this.AddonStudies = {
   /**
    * Stop an active study, uninstalling the associated add-on.
    * @param {Number} recipeId
+   * @param {String} reason Why the study is ending. Optional, defaults to "unknown".
    * @throws
    *   If no study is found with the given recipeId.
    *   If the study is already inactive.
    */
-  async stop(recipeId, reason) {
+  async stop(recipeId, reason = "unknown") {
     const db = await getDatabase();
     const study = await getStore(db).get(recipeId);
     if (!study) {

--- a/recipe-client-addon/lib/AddonStudies.jsm
+++ b/recipe-client-addon/lib/AddonStudies.jsm
@@ -35,10 +35,9 @@ XPCOMUtils.defineLazyModuleGetter(this, "FileUtils", "resource://gre/modules/Fil
 XPCOMUtils.defineLazyModuleGetter(this, "IndexedDB", "resource://gre/modules/IndexedDB.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "AddonManager", "resource://gre/modules/AddonManager.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Addons", "resource://shield-recipe-client/lib/Addons.jsm");
-XPCOMUtils.defineLazyModuleGetter(
-  this, "CleanupManager", "resource://shield-recipe-client/lib/CleanupManager.jsm"
-);
+XPCOMUtils.defineLazyModuleGetter(this, "CleanupManager", "resource://shield-recipe-client/lib/CleanupManager.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "LogManager", "resource://shield-recipe-client/lib/LogManager.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "TelemetryEvents", "resource://shield-recipe-client/lib/TelemetryEvents.jsm");
 
 Cu.importGlobalProperties(["fetch"]); /* globals fetch */
 
@@ -93,11 +92,21 @@ function getStore(db) {
  * @param {IDBDatabase} db
  * @param {Study} study
  */
-async function markAsEnded(db, study) {
+async function markAsEnded(db, study, reason = "unknown") {
+  if (reason === "unknown") {
+    log.warn(`Study ${study.name} ending for unknown reason.`);
+  }
+
   study.active = false;
   study.studyEndDate = new Date();
   await getStore(db).put(study);
+
   Services.obs.notifyObservers(study, STUDY_ENDED_TOPIC, `${study.recipeId}`);
+  TelemetryEvents.sendEvent("unenroll", "addon_study", study.name, {
+    addonId: study.addonId,
+    addonVersion: study.addonVersion,
+    reason,
+  });
 }
 
 this.AddonStudies = {
@@ -145,7 +154,7 @@ this.AddonStudies = {
     for (const study of activeStudies) {
       const addon = await AddonManager.getAddonByID(study.addonId);
       if (!addon) {
-        await markAsEnded(db, study);
+        await markAsEnded(db, study, "uninstalled-sideload");
       }
     }
     await this.close();
@@ -168,7 +177,7 @@ this.AddonStudies = {
       // Use a dedicated DB connection instead of the shared one so that we can
       // close it without fear of affecting other users of the shared connection.
       const db = await openDatabase();
-      await markAsEnded(db, matchingStudy);
+      await markAsEnded(db, matchingStudy, "uninstalled");
       await db.close();
     }
   },
@@ -258,12 +267,24 @@ this.AddonStudies = {
       studyStartDate: new Date(),
     };
 
+    TelemetryEvents.sendEvent("enroll", "addon_study", name, {
+      addonId: install.addon.id,
+      addonVersion: install.addon.version,
+    });
+
     try {
       await getStore(db).add(study);
       await Addons.applyInstall(install, false);
       return study;
     } catch (err) {
       await getStore(db).delete(recipeId);
+
+      TelemetryEvents.sendEvent("unenroll", "addon_study", name, {
+        reason: "install-failure",
+        addonId: install.addon.id,
+        addonVersion: install.addon.version,
+      });
+
       throw err;
     } finally {
       Services.obs.notifyObservers(addonFile, "flush-cache-entry");
@@ -304,17 +325,17 @@ this.AddonStudies = {
    *   If no study is found with the given recipeId.
    *   If the study is already inactive.
    */
-  async stop(recipeId) {
+  async stop(recipeId, reason) {
     const db = await getDatabase();
     const study = await getStore(db).get(recipeId);
     if (!study) {
-      throw new Error(`No study found for recipe ${recipeId}`);
+      throw new Error(`No study found for recipe ${recipeId}.`);
     }
     if (!study.active) {
       throw new Error(`Cannot stop study for recipe ${recipeId}; it is already inactive.`);
     }
 
-    await markAsEnded(db, study);
+    await markAsEnded(db, study, reason);
 
     try {
       await Addons.uninstall(study.addonId);

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -455,8 +455,13 @@ this.PreferenceExperiments = {
    * Stop an active experiment, deactivate preference watchers, and optionally
    * reset the associated preference to its previous value.
    * @param {string} experimentName
-   * @param {boolean} [resetValue=true]
-   *   If true, reset the preference to its original value.
+   * @param {Object} options
+   * @param {boolean} [options.resetValue = true]
+   *   If true, reset the preference to its original value prior to
+   *   the experiment. Optional, defauls to true.
+   * @param {String} [options.reason = "unknown"]
+   *   Reason that the experiment is ending. Optional, defaults to
+   *   "unknown".
    * @rejects {Error}
    *   If there is no stored experiment with the given name, or if the
    *   experiment has already expired.

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -61,6 +61,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "JSONFile", "resource://gre/modules/JSON
 XPCOMUtils.defineLazyModuleGetter(this, "OS", "resource://gre/modules/osfile.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "LogManager", "resource://shield-recipe-client/lib/LogManager.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "TelemetryEnvironment", "resource://gre/modules/TelemetryEnvironment.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "TelemetryEvents", "resource://shield-recipe-client/lib/TelemetryEvents.jsm");
 
 this.EXPORTED_SYMBOLS = ["PreferenceExperiments"];
 
@@ -186,7 +187,10 @@ this.PreferenceExperiments = {
       if (getPref(UserPreferences, experiment.preferenceName, experiment.preferenceType) !== experiment.preferenceValue) {
         // if not, stop the experiment, and skip the remaining steps
         log.info(`Stopping experiment "${experiment.name}" because its value changed`);
-        await this.stop(experiment.name, false);
+        await this.stop(experiment.name, {
+          didResetValue: false,
+          reason: "user-preference-changed-sideload"
+        });
         continue;
       }
 
@@ -351,6 +355,7 @@ this.PreferenceExperiments = {
     store.saveSoon();
 
     TelemetryEnvironment.setExperimentActive(name, branch, {type: EXPERIMENT_TYPE_PREFIX + experimentType});
+    TelemetryEvents.sendEvent("enroll", "preference_study", name, {experimentType, branch});
     await this.saveStartupPrefs();
   },
 
@@ -377,8 +382,10 @@ this.PreferenceExperiments = {
       observer() {
         const newValue = getPref(UserPreferences, preferenceName, preferenceType);
         if (newValue !== preferenceValue) {
-          PreferenceExperiments.stop(experimentName, false)
-                               .catch(Cu.reportError);
+          PreferenceExperiments.stop(experimentName, {
+            didResetValue: false,
+            reason: "user-preference-changed",
+          }).catch(Cu.reportError);
         }
       },
     };
@@ -454,8 +461,11 @@ this.PreferenceExperiments = {
    *   If there is no stored experiment with the given name, or if the
    *   experiment has already expired.
    */
-  async stop(experimentName, resetValue = true) {
+  async stop(experimentName, {resetValue = true, reason = "unknown"} = {}) {
     log.debug(`PreferenceExperiments.stop(${experimentName})`);
+    if (reason === "unknown") {
+      log.warn(`experiment ${experimentName} ending for unknown reason`);
+    }
 
     const store = await ensureStorage();
     if (!(experimentName in store.data)) {
@@ -496,6 +506,10 @@ this.PreferenceExperiments = {
     store.saveSoon();
 
     TelemetryEnvironment.setExperimentInactive(experimentName, experiment.branch);
+    TelemetryEvents.sendEvent("unenroll", "preference_study", experimentName, {
+      didResetValue: resetValue ? "true" : "false",
+      reason,
+    });
     await this.saveStartupPrefs();
   },
 

--- a/recipe-client-addon/lib/ShieldPreferences.jsm
+++ b/recipe-client-addon/lib/ShieldPreferences.jsm
@@ -73,22 +73,24 @@ this.ShieldPreferences = {
     let prefValue;
     switch (prefName) {
       // If the FHR pref changes, set the opt-out-study pref to the value it is changing to.
-      case FHR_UPLOAD_ENABLED_PREF:
+      case FHR_UPLOAD_ENABLED_PREF: {
         prefValue = Services.prefs.getBoolPref(FHR_UPLOAD_ENABLED_PREF);
         Services.prefs.setBoolPref(OPT_OUT_STUDIES_ENABLED_PREF, prefValue);
         break;
+      }
 
       // If the opt-out pref changes to be false, disable all current studies.
-      case OPT_OUT_STUDIES_ENABLED_PREF:
+      case OPT_OUT_STUDIES_ENABLED_PREF: {
         prefValue = Services.prefs.getBoolPref(OPT_OUT_STUDIES_ENABLED_PREF);
         if (!prefValue) {
           for (const study of await AddonStudies.getAll()) {
             if (study.active) {
-              await AddonStudies.stop(study.recipeId);
+              await AddonStudies.stop(study.recipeId, "general-opt-out");
             }
           }
         }
         break;
+      }
     }
   },
 

--- a/recipe-client-addon/lib/ShieldRecipeClient.jsm
+++ b/recipe-client-addon/lib/ShieldRecipeClient.jsm
@@ -22,6 +22,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "ShieldPreferences",
   "resource://shield-recipe-client/lib/ShieldPreferences.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "AddonStudies",
   "resource://shield-recipe-client/lib/AddonStudies.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "TelemetryEvents",
+  "resource://shield-recipe-client/lib/TelemetryEvents.jsm");
 
 this.EXPORTED_SYMBOLS = ["ShieldRecipeClient"];
 
@@ -80,6 +82,12 @@ this.ShieldRecipeClient = {
       ShieldPreferences.init();
     } catch (err) {
       log.error("Failed to initialize preferences UI:", err);
+    }
+
+    try {
+      TelemetryEvents.init();
+    } catch (err) {
+      log.error("Failed to initialize telemetry events:", err);
     }
 
     await RecipeRunner.init();

--- a/recipe-client-addon/lib/TelemetryEvents.jsm
+++ b/recipe-client-addon/lib/TelemetryEvents.jsm
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const {utils: Cu, interfaces: Ci} = Components;
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+
+this.EXPORTED_SYMBOLS = ["TelemetryEvents"];
+
+const TELEMETRY_CATEGORY = "normandy";
+
+const TelemetryEvents = {
+  startup() {
+    Services.telemetry.registerEvents(TELEMETRY_CATEGORY, {
+      enroll: {
+        methods: ["enroll"],
+        objects: ["preference_study", "addon_study"],
+        extra_keys: ["experimentType", "branch", "addonId", "addonVersion"],
+        record_on_release: true,
+      },
+
+      unenroll: {
+        methods: ["unenroll"],
+        objects: ["preference_study", "addon_study"],
+        extra_keys: ["reason", "didResetValue", "addonId", "addonVersion"],
+        record_on_release: true,
+      },
+    });
+  },
+
+  sendEvent(method, object, value, extra) {
+    Services.telemetry.recordEvent(TELEMETRY_CATEGORY, method, object, value, extra);
+  },
+};

--- a/recipe-client-addon/test/browser/browser_AddonStudies.js
+++ b/recipe-client-addon/test/browser/browser_AddonStudies.js
@@ -5,6 +5,7 @@ Cu.import("resource://testing-common/TestUtils.jsm", this);
 Cu.import("resource://testing-common/AddonTestUtils.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/Addons.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/AddonStudies.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/TelemetryEvents.jsm", this);
 
 // Initialize test utils
 AddonTestUtils.initMochitest(this);
@@ -175,8 +176,9 @@ decorate_task(
 
 decorate_task(
   withWebExtension({version: "2.0"}),
+  withStub(TelemetryEvents, "sendEvent"),
   AddonStudies.withStudies(),
-  async function testStart([addonId, addonFile]) {
+  async function testStart([addonId, addonFile], sendEventStub) {
     const startupPromise = AddonTestUtils.promiseWebExtensionStartup(addonId);
     const addonUrl = Services.io.newFileURI(addonFile).spec;
 
@@ -210,6 +212,12 @@ decorate_task(
       "start saves study data to storage",
     );
     ok(study.studyStartDate, "start assigns a value to the study start date.");
+
+    Assert.deepEqual(
+      sendEventStub.getCall(0).args,
+      ["enroll", "addon_study", args.name, {addonId, addonVersion: "2.0"}],
+      "AddonStudies.start() should send the correct telemetry event"
+    );
 
     await AddonStudies.stop(args.recipeId);
   }
@@ -245,14 +253,25 @@ decorate_task(
     studyFactory({active: true, addonId: testStopId, studyEndDate: null}),
   ]),
   withInstalledWebExtension({id: testStopId}),
-  async function testStop([study], [addonId, addonFile]) {
-    await AddonStudies.stop(study.recipeId);
+  withStub(TelemetryEvents, "sendEvent"),
+  async function testStop([study], [addonId, addonFile], sendEventStub) {
+    await AddonStudies.stop(study.recipeId, "test-reason");
     const newStudy = await AddonStudies.get(study.recipeId);
     ok(!newStudy.active, "stop marks the study as inactive.");
     ok(newStudy.studyEndDate, "stop saves the study end date.");
 
     const addon = await Addons.get(addonId);
     is(addon, null, "stop uninstalls the study add-on.");
+
+    Assert.deepEqual(
+      sendEventStub.getCall(0).args,
+      ["unenroll", "addon_study", study.name, {
+        addonId,
+        addonVersion: study.addonVersion,
+        reason: "test-reason"
+      }],
+      "stop should send the correct telemetry event"
+    );
   }
 );
 
@@ -280,15 +299,25 @@ decorate_task(
     studyFactory({active: true, addonId: "installed@example.com"}),
     studyFactory({active: false, addonId: "already.gone@example.com", studyEndDate: new Date(2012, 1)}),
   ]),
+  withStub(TelemetryEvents, "sendEvent"),
   withInstalledWebExtension({id: "installed@example.com"}),
-  async function testInit([activeStudy, activeInstalledStudy, inactiveStudy]) {
+  async function testInit([activeUninstalledStudy, activeInstalledStudy, inactiveStudy], sendEventStub) {
     await AddonStudies.init();
 
-    const newActiveStudy = await AddonStudies.get(activeStudy.recipeId);
+    const newActiveStudy = await AddonStudies.get(activeUninstalledStudy.recipeId);
     ok(!newActiveStudy.active, "init marks studies as inactive if their add-on is not installed.");
     ok(
       newActiveStudy.studyEndDate,
       "init sets the study end date if a study's add-on is not installed."
+    );
+    Assert.deepEqual(
+      sendEventStub.getCall(0).args,
+      ["unenroll", "addon_study", activeUninstalledStudy.name, {
+        addonId: activeUninstalledStudy.addonId,
+        addonVersion: activeUninstalledStudy.addonVersion,
+        reason: "uninstalled-sideload",
+      }],
+      "AddonStudies.init() should send the correct telemetry event"
     );
 
     const newInactiveStudy = await AddonStudies.get(inactiveStudy.recipeId);
@@ -304,6 +333,9 @@ decorate_task(
       newActiveInstalledStudy,
       "init does not modify studies whose add-on is still installed."
     );
+
+    // Only activeUninstalledStudy should have generated any events
+    ok(sendEventStub.calledOnce);
   }
 );
 
@@ -321,6 +353,21 @@ decorate_task(
     ok(
       newStudy.studyEndDate,
       "The study end date is set when the add-on for the study is uninstalled."
+    );
+  }
+);
+
+// stop should pass "unknown" to TelemetryEvents for `reason` if none specified
+decorate_task(
+  AddonStudies.withStudies([studyFactory({ active: true })]),
+  withStub(TelemetryEvents, "sendEvent"),
+  async function testStopUnknownReason([study], sendEventStub) {
+    await AddonStudies.stop(study.recipeId);
+    is(
+      sendEventStub.getCall(0).args[3].reason,
+      "unknown",
+      "stop should send the correct telemetry event",
+      "AddonStudies.stop() should use unknown as the default reason",
     );
   }
 );

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -805,7 +805,7 @@ decorate_task(
     mockPreferences.set("fake.preference", "changed value");
     await PreferenceExperiments.init();
     ok(stopStub.calledWith("test"), "Experiment is stopped because value changed");
-    ok(Preferences.get("fake.preference"), "changed value", "Preference value was not changed");
+    is(Preferences.get("fake.preference"), "changed value", "Preference value was not changed");
   },
 );
 

--- a/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
+++ b/recipe-client-addon/test/browser/browser_PreferenceExperiments.js
@@ -4,6 +4,7 @@ Cu.import("resource://gre/modules/Preferences.jsm", this);
 Cu.import("resource://gre/modules/TelemetryEnvironment.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/CleanupManager.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/TelemetryEvents.jsm", this);
 
 // Save ourselves some typing
 const {withMockExperiments} = PreferenceExperiments;
@@ -101,7 +102,8 @@ decorate_task(
   withMockExperiments,
   withMockPreferences,
   withStub(PreferenceExperiments, "startObserver"),
-  async function testStart(experiments, mockPreferences, startObserverStub) {
+  withStub(TelemetryEvents, "sendEvent"),
+  async function testStart(experiments, mockPreferences, startObserverStub, sendEventStub) {
     mockPreferences.set("fake.preference", "oldvalue", "default");
     mockPreferences.set("fake.preference", "uservalue", "user");
 
@@ -407,8 +409,12 @@ decorate_task(
   withMockExperiments,
   withMockPreferences,
   withSpy(PreferenceExperiments, "stopObserver"),
-  async function testStop(experiments, mockPreferences, stopObserverSpy) {
+  withStub(TelemetryEvents, "sendEvent"),
+  async function testStop(experiments, mockPreferences, stopObserverSpy, sendEventStub) {
+    // this assertion is mostly useful for --verify test runs, to make
+    // sure that tests clean up correctly.
     is(Preferences.get("fake.preference"), null, "preference should start unset");
+
     mockPreferences.set(`${startupPrefs}.fake.preference`, "experimentvalue", "user");
     mockPreferences.set("fake.preference", "experimentvalue", "default");
     experiments.test = experimentFactory({
@@ -422,7 +428,7 @@ decorate_task(
     });
     PreferenceExperiments.startObserver("test", "fake.preference", "string", "experimentvalue");
 
-    await PreferenceExperiments.stop("test");
+    await PreferenceExperiments.stop("test", {reason: "test-reason"});
     ok(stopObserverSpy.calledWith("test"), "stop removed an observer");
     is(experiments.test.expired, true, "stop marked the experiment as expired");
     is(
@@ -433,6 +439,15 @@ decorate_task(
     ok(
       !Services.prefs.prefHasUserValue(`${startupPrefs}.fake.preference`),
       "stop cleared the startup preference for fake.preference.",
+    );
+
+    Assert.deepEqual(
+      sendEventStub.getCall(0).args,
+      ["unenroll", "preference_study", experiments.test.name, {
+        didResetValue: "true",
+        reason: "test-reason",
+      }],
+      "stop should send the correct telemetry event"
     );
 
     PreferenceExperiments.stopAllObservers();
@@ -505,8 +520,8 @@ decorate_task(
   withMockExperiments,
   withMockPreferences,
   withStub(PreferenceExperiments, "stopObserver"),
-
-  async function(experiments, mockPreferences, stopObserver) {
+  withStub(TelemetryEvents, "sendEvent"),
+  async function testStopReset(experiments, mockPreferences, stopObserverStub, sendEventStub) {
     mockPreferences.set("fake.preference", "customvalue", "default");
     experiments.test = experimentFactory({
       name: "test",
@@ -518,11 +533,19 @@ decorate_task(
       peferenceBranchType: "default",
     });
 
-    await PreferenceExperiments.stop("test", false);
+    await PreferenceExperiments.stop("test", {reason: "test-reason", resetValue: false});
     is(
       DefaultPreferences.get("fake.preference"),
       "customvalue",
       "stop did not modify the preference",
+    );
+    Assert.deepEqual(
+      sendEventStub.getCall(0).args,
+      ["unenroll", "preference_study", experiments.test.name, {
+        didResetValue: "false",
+        reason: "test-reason",
+      }],
+      "stop should send the correct telemetry event"
     );
   }
 );
@@ -678,7 +701,8 @@ decorate_task(
   withMockExperiments,
   withStub(TelemetryEnvironment, "setExperimentActive"),
   withStub(TelemetryEnvironment, "setExperimentInactive"),
-  async function testInitTelemetry(experiments, setActiveStub, setInactiveStub) {
+  withStub(TelemetryEvents, "sendEvent"),
+  async function testStartAndStopTelemetry(experiments, setActiveStub, setInactiveStub, sendEventStub) {
     await PreferenceExperiments.start({
       name: "test",
       branch: "branch",
@@ -691,10 +715,28 @@ decorate_task(
     Assert.deepEqual(
       setActiveStub.getCall(0).args,
       ["test", "branch", {type: "normandy-exp"}],
-      "Experiment is registerd by start()",
+      "Experiment is registered by start()",
     );
-    await PreferenceExperiments.stop("test");
+    await PreferenceExperiments.stop("test", {reason: "test-reason"});
     ok(setInactiveStub.calledWith("test", "branch"), "Experiment is unregistered by stop()");
+
+    Assert.deepEqual(
+      sendEventStub.getCall(0).args,
+      ["enroll", "preference_study", "test", {
+        experimentType: "exp",
+        branch: "branch",
+      }],
+      "PreferenceExperiments.start() should send the correct telemetry event"
+    );
+
+    Assert.deepEqual(
+      sendEventStub.getCall(1).args,
+      ["unenroll", "preference_study", "test", {
+        reason: "test-reason",
+        didResetValue: "true",
+      }],
+      "PreferenceExperiments.stop() should send the correct telemetry event"
+    );
   },
 );
 
@@ -703,7 +745,8 @@ decorate_task(
   withMockExperiments,
   withStub(TelemetryEnvironment, "setExperimentActive"),
   withStub(TelemetryEnvironment, "setExperimentInactive"),
-  async function testInitTelemetry(experiments, setActiveStub, setInactiveStub) {
+  withStub(TelemetryEvents, "sendEvent"),
+  async function testInitTelemetryExperimentType(experiments, setActiveStub, setInactiveStub, sendEventStub) {
     await PreferenceExperiments.start({
       name: "test",
       branch: "branch",
@@ -718,6 +761,15 @@ decorate_task(
       setActiveStub.getCall(0).args,
       ["test", "branch", {type: "normandy-pref-test"}],
       "start() should register the experiment with the provided type",
+    );
+
+    Assert.deepEqual(
+      sendEventStub.getCall(0).args,
+      ["enroll", "preference_study", "test", {
+        experimentType: "pref-test",
+        branch: "branch",
+      }],
+      "start should include the passed reason in the telemetry event"
     );
 
     // start sets the passed preference in a way that is hard to mock.
@@ -742,7 +794,8 @@ decorate_task(
   withMockExperiments,
   withMockPreferences,
   withStub(PreferenceExperiments, "stop"),
-  async function testInitChanges(experiments, mockPreferences, stopStub) {
+  withStub(TelemetryEvents, "sendEvent"),
+  async function testInitChanges(experiments, mockPreferences, stopStub, sendEventStub) {
     mockPreferences.set("fake.preference", "experiment value", "default");
     experiments.test = experimentFactory({
       name: "test",
@@ -752,8 +805,8 @@ decorate_task(
     mockPreferences.set("fake.preference", "changed value");
     await PreferenceExperiments.init();
     ok(stopStub.calledWith("test"), "Experiment is stopped because value changed");
-    is(Preferences.get("fake.preference"), "changed value", "Preference value was not changed");
-  }
+    ok(Preferences.get("fake.preference"), "changed value", "Preference value was not changed");
+  },
 );
 
 // init should register an observer for experiments
@@ -934,4 +987,22 @@ decorate_task(
       "Preference should be absent",
     );
   },
+);
+
+// stop should pass "unknown" to telemetry event for `reason` if none is specified
+decorate_task(
+  withMockExperiments,
+  withMockPreferences,
+  withStub(PreferenceExperiments, "stopObserver"),
+  withStub(TelemetryEvents, "sendEvent"),
+  async function testStopUnknownReason(experiments, mockPreferences, stopObserverStub, sendEventStub) {
+    mockPreferences.set("fake.preference", "default value", "default");
+    experiments.test = experimentFactory({ name: "test", preferenceName: "fake.preference" });
+    await PreferenceExperiments.stop("test");
+    is(
+      sendEventStub.getCall(0).args[3].reason,
+      "unknown",
+      "PreferenceExperiments.stop() should use unknown as the default reason",
+    );
+  }
 );

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -8,6 +8,7 @@ Cu.import("resource://shield-recipe-client/lib/Addons.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/SandboxManager.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/NormandyDriver.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/TelemetryEvents.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/Utils.jsm", this);
 
 // Load mocking/stubbing library, sinon
@@ -25,6 +26,8 @@ registerCleanupFunction(async function() {
   delete window.sinon;
 });
 
+// Prep Telemetry to receive events from tests
+TelemetryEvents.startup();
 
 this.UUID_REGEX = /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/;
 

--- a/recipe-server/client/actions/opt-out-study/index.js
+++ b/recipe-server/client/actions/opt-out-study/index.js
@@ -74,7 +74,7 @@ export async function postExecutionHook(normandy) {
       normandy.log(`Stopping study for recipe ${study.recipeId}.`, 'debug');
       try {
         // eslint-disable-next-line no-await-in-loop
-        await studies.stop(study.recipeId);
+        await studies.stop(study.recipeId, 'recipe-not-seen');
       } catch (err) {
         normandy.log(`Error while stopping study for recipe ${study.recipeId}: ${err}`, 'error');
       }

--- a/recipe-server/client/actions/tests/test_opt-out-study.js
+++ b/recipe-server/client/actions/tests/test_opt-out-study.js
@@ -173,8 +173,8 @@ describe('OptOutStudyAction', () => {
         await action.execute();
         await postExecutionHook(normandy);
 
-        expect(normandy.studies.stop).not.toHaveBeenCalledWith(seen.id);
-        expect(normandy.studies.stop).toHaveBeenCalledWith(unseen.id);
+        expect(normandy.studies.stop).not.toHaveBeenCalledWith(seen.id, 'recipe-not-seen');
+        expect(normandy.studies.stop).toHaveBeenCalledWith(unseen.id, 'recipe-not-seen');
       },
     );
   });


### PR DESCRIPTION
This add documentation and implementation for enrollment events when studies start and stop. This includes both preferences and add-on studies.

@georgf Can you review this? The changes in `recipe-client-addon/` should be treated like Firefox code, and will eventually make its way into mozilla-central.