### PR TITLE
#1111: Paused enrollment indicator

### DIFF
--- a/recipe-server/client/control/components/common/EnrollmentStatus.js
+++ b/recipe-server/client/control/components/common/EnrollmentStatus.js
@@ -51,7 +51,7 @@ export default class EnrollmentSatus extends React.Component {
     } = this.props;
 
     return (
-      <Link href={`/recipe/${recipe.id}/`} className={cx(!recipe.enabled && 'is-lowkey')}>
+      <Link href={`/recipe/${recipe.id}/`} className={cx('status-link', !recipe.enabled && 'is-lowkey')}>
         <Icon
           className={cx('status-icon', this.getColor())}
           type={this.getIcon()}

--- a/recipe-server/client/control/components/common/EnrollmentStatus.js
+++ b/recipe-server/client/control/components/common/EnrollmentStatus.js
@@ -1,0 +1,83 @@
+import { Icon } from 'antd';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'redux-little-router';
+import { connect } from 'react-redux';
+
+@connect((state, { record }) => {
+  const isEnabled = record.enabled;
+  const isPaused = !isEnabled || !!record.arguments.isEnrollmentPaused;
+
+  return {
+    record,
+    isEnabled,
+    isPaused,
+  };
+})
+export default class EnrollmentSatus extends React.PureComponent {
+  static propTypes = {
+    // Ideally this would be an Immutable Map, but Ant's table works with POJO's.
+    record: PropTypes.object.isRequired,
+    isEnabled: PropTypes.bool.isRequired,
+    isPaused: PropTypes.bool.isRequired,
+  };
+
+  getLabel() {
+    const {
+      isEnabled,
+      isPaused,
+    } = this.props;
+    let label = 'Disabled';
+
+    if (isEnabled) {
+      label = isPaused ? 'Paused' : 'Active';
+    }
+
+    return label;
+  }
+
+  getIcon() {
+    const {
+      isEnabled,
+      isPaused,
+    } = this.props;
+    let label = 'minus';
+
+    if (isEnabled) {
+      label = isPaused ? 'pause' : 'check';
+    }
+
+    return label;
+  }
+
+  getColor() {
+    const {
+      isEnabled,
+      isPaused,
+    } = this.props;
+
+    let colorClass;
+    if (isEnabled) {
+      colorClass = isPaused ? 'is-false' : 'is-true';
+    }
+
+    return colorClass;
+  }
+
+  render() {
+    const {
+      record,
+      isEnabled,
+    } = this.props;
+
+    return (
+      <Link href={`/recipe/${record.id}/`} className={isEnabled ? '' : 'is-lowkey'}>
+        <Icon
+          className={this.getColor()}
+          type={this.getIcon()}
+        />
+        <span className="enrollment-label">{this.getLabel()}</span>
+      </Link>
+    );
+  }
+}

--- a/recipe-server/client/control/components/common/EnrollmentStatus.js
+++ b/recipe-server/client/control/components/common/EnrollmentStatus.js
@@ -1,79 +1,59 @@
 import { Icon } from 'antd';
+import cx from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'redux-little-router';
-import { connect } from 'react-redux';
 
-@connect((state, { record }) => {
-  const isEnabled = record.enabled;
-  const isPaused = !isEnabled || !!record.arguments.isEnrollmentPaused;
-
-  return {
-    record,
-    isEnabled,
-    isPaused,
-  };
-})
-export default class EnrollmentSatus extends React.PureComponent {
+// Ideally the prop.recipe would be an Immutable Map, but Ant's Table works with
+// plain JS objects, which means this component can not be Pure.
+export default class EnrollmentSatus extends React.Component {
   static propTypes = {
-    // Ideally this would be an Immutable Map, but Ant's table works with POJO's.
-    record: PropTypes.object.isRequired,
-    isEnabled: PropTypes.bool.isRequired,
-    isPaused: PropTypes.bool.isRequired,
+    recipe: PropTypes.object.isRequired,
   };
 
   getLabel() {
-    const {
-      isEnabled,
-      isPaused,
-    } = this.props;
     let label = 'Disabled';
-
-    if (isEnabled) {
-      label = isPaused ? 'Paused' : 'Active';
+    if (this.isRecipeEnabled()) {
+      label = this.isRecipePaused() ? 'Paused' : 'Active';
     }
-
     return label;
   }
 
   getIcon() {
-    const {
-      isEnabled,
-      isPaused,
-    } = this.props;
-    let label = 'minus';
-
-    if (isEnabled) {
-      label = isPaused ? 'pause' : 'check';
+    let iconType = 'minus';
+    if (this.isRecipeEnabled()) {
+      iconType = this.isRecipePaused() ? 'pause' : 'check';
     }
-
-    return label;
+    return iconType;
   }
 
   getColor() {
-    const {
-      isEnabled,
-      isPaused,
-    } = this.props;
-
     let colorClass;
-    if (isEnabled) {
-      colorClass = isPaused ? 'is-false' : 'is-true';
+    if (this.isRecipeEnabled()) {
+      colorClass = this.isRecipePaused() ? 'is-false' : 'is-true';
     }
-
     return colorClass;
+  }
+
+  isRecipePaused() {
+    const { recipe } = this.props;
+    return !recipe.enabled || !!recipe.arguments.isEnrollmentPaused;
+  }
+
+  isRecipeEnabled() {
+    const { recipe } = this.props;
+    return recipe.enabled;
   }
 
   render() {
     const {
-      record,
-      isEnabled,
+      recipe,
     } = this.props;
 
     return (
-      <Link href={`/recipe/${record.id}/`} className={isEnabled ? '' : 'is-lowkey'}>
+      <Link href={`/recipe/${recipe.id}/`} className={cx(!recipe.enabled && 'is-lowkey')}>
         <Icon
-          className={this.getColor()}
+          className={cx('status-icon', this.getColor())}
           type={this.getIcon()}
         />
         <span className="enrollment-label">{this.getLabel()}</span>

--- a/recipe-server/client/control/components/recipes/ListingActionBar.js
+++ b/recipe-server/client/control/components/recipes/ListingActionBar.js
@@ -71,6 +71,7 @@ export default class ListingActionBar extends React.PureComponent {
               { label: 'Action', value: 'action' },
               { label: 'Enabled', value: 'enabled' },
               { label: 'Last Updated', value: 'lastUpdated' },
+              { label: 'Enrollment Active', value: 'paused' },
             ]}
           />
         </Col>

--- a/recipe-server/client/control/components/recipes/RecipeListing.js
+++ b/recipe-server/client/control/components/recipes/RecipeListing.js
@@ -40,7 +40,6 @@ import {
     ordering: getQueryParam(state, 'ordering', '-last_updated'),
     pageNumber: getQueryParamAsInt(state, 'page', 1),
     recipes: getRecipeListingFlattenedAction(state),
-    paused: getQueryParam(state, 'paused'),
     searchText: getQueryParam(state, 'searchText'),
     status: getQueryParam(state, 'status'),
   }),
@@ -60,7 +59,6 @@ export default class RecipeListing extends React.PureComponent {
     openNewWindow: PropTypes.func.isRequired,
     ordering: PropTypes.string,
     pageNumber: PropTypes.number,
-    paused: PropTypes.bool,
     push: PropTypes.func.isRequired,
     recipes: PropTypes.instanceOf(List).isRequired,
     searchText: PropTypes.string,
@@ -70,7 +68,6 @@ export default class RecipeListing extends React.PureComponent {
   static defaultProps = {
     count: null,
     ordering: null,
-    paused: false,
     pageNumber: null,
     searchText: null,
     status: null,
@@ -133,17 +130,7 @@ export default class RecipeListing extends React.PureComponent {
         <Table.Column
           title="Enrollment Active"
           key="paused"
-          render={(text, record) => <EnrollmentStatus record={record} />}
-          filters={[
-            { text: 'Paused', value: true },
-            { text: 'Active', value: false },
-          ]}
-          onFilter={(value, record) => {
-            const isPaused = (record.arguments && !!record.arguments.isEnrollmentPaused) || false;
-            // `value` is a string when passed into this function.
-            return isPaused === (value === 'true');
-          }}
-          filterMultiple={false}
+          render={(text, record) => <EnrollmentStatus recipe={record} />}
         />
       );
     },
@@ -178,14 +165,12 @@ export default class RecipeListing extends React.PureComponent {
       ordering,
       searchText,
       status,
-      paused,
     } = this.props;
 
     const filters = {
       text: searchText,
       ordering,
       status,
-      paused,
     };
 
     Object.keys(filters).forEach(key => {

--- a/recipe-server/client/control/components/recipes/RecipeListing.js
+++ b/recipe-server/client/control/components/recipes/RecipeListing.js
@@ -1,4 +1,4 @@
-import { Icon, Pagination, Table } from 'antd';
+import { Pagination, Table } from 'antd';
 import autobind from 'autobind-decorator';
 import { List } from 'immutable';
 import moment from 'moment';
@@ -9,6 +9,7 @@ import { push as pushAction, Link } from 'redux-little-router';
 
 
 import BooleanIcon from 'control/components/common/BooleanIcon';
+import EnrollmentStatus from 'control/components/common/EnrollmentStatus';
 import LoadingOverlay from 'control/components/common/LoadingOverlay';
 import QueryFilteredRecipes from 'control/components/data/QueryFilteredRecipes';
 import QueryRecipeListingColumns from 'control/components/data/QueryRecipeListingColumns';
@@ -132,18 +133,7 @@ export default class RecipeListing extends React.PureComponent {
         <Table.Column
           title="Enrollment Active"
           key="paused"
-          render={(text, record) => {
-            const isPaused = (record.arguments && !!record.arguments.isEnrollmentPaused) || false;
-            return (
-              <Link href={`/recipe/${record.id}/`}>
-                <Icon
-                  className={isPaused ? 'is-false' : 'is-true'}
-                  type={isPaused ? 'pause' : 'check'}
-                />
-                {isPaused ? 'Paused' : 'Active'}
-              </Link>
-            );
-          }}
+          render={(text, record) => <EnrollmentStatus record={record} />}
           filters={[
             { text: 'Paused', value: true },
             { text: 'Active', value: false },

--- a/recipe-server/client/control/less/components/boolean-icon.less
+++ b/recipe-server/client/control/less/components/boolean-icon.less
@@ -1,6 +1,10 @@
+.ant-table .anticon,
 .boolean-icon {
   font-size: 16px;
   font-weight: bold;
+  margin-right: 0.25em;
+  position: relative;
+  top: 2px;
 
   &.is-true {
     color: #0C0;

--- a/recipe-server/client/control/less/components/listing.less
+++ b/recipe-server/client/control/less/components/listing.less
@@ -13,4 +13,8 @@
   .shieldicon {
     margin-right: 0.5em;
   }
+
+  .is-lowkey {
+    opacity: 0.4;
+  }
 }

--- a/recipe-server/client/control/state/constants.js
+++ b/recipe-server/client/control/state/constants.js
@@ -10,6 +10,7 @@ export const DEFAULT_RECIPE_LISTING_COLUMNS = new List([
   'action',
   'enabled',
   'lastUpdated',
+  'paused',
 ]);
 
 export const DEFAULT_REQUEST = new Map({
@@ -22,6 +23,7 @@ export const RECIPE_LISTING_COLUMNS = new List([
   'action',
   'enabled',
   'lastUpdated',
+  'paused',
 ]);
 
 export const REVISION_APPROVED = 'REVISION_APPROVED';

--- a/recipe-server/client/control/tests/components/common/test_EnrollmentStatus.js
+++ b/recipe-server/client/control/tests/components/common/test_EnrollmentStatus.js
@@ -1,0 +1,42 @@
+import { Icon } from 'antd';
+import React from 'react';
+import { mount } from 'enzyme';
+import { Map } from 'immutable';
+
+import { wrapMockStore } from 'control/tests/mockStore';
+import TestComponent from 'control/components/common/EnrollmentStatus';
+
+const { WrappedComponent: EnrollmentStatus } = TestComponent;
+
+describe('<EnrollmentStatus>', () => {
+  const props = {
+    isEnabled: false,
+    isPaused: false,
+    record: new Map(),
+  };
+
+  it('should work', () => {
+    const wrapper = () => mount(wrapMockStore(<EnrollmentStatus {...props} />));
+    expect(wrapper).not.toThrow();
+  });
+
+  it('should print `disabled` if the recipe is not enabled', () => {
+    const wrapper = mount(wrapMockStore(<EnrollmentStatus {...props} isEnabled={false} />));
+    expect(wrapper.text()).toContain('Disabled');
+    expect(wrapper.find(Icon).props().type).toBe('minus');
+  });
+
+  it('should print `active` if the recipe is enabled and NOT paused', () => {
+    const wrapper = mount(wrapMockStore(
+      <EnrollmentStatus {...props} isEnabled isPaused={false} />
+    ));
+    expect(wrapper.text()).toContain('Active');
+    expect(wrapper.find(Icon).props().type).toBe('check');
+  });
+
+  it('should print `paused` if the recipe is enabled and paused', () => {
+    const wrapper = mount(wrapMockStore(<EnrollmentStatus {...props} isEnabled isPaused />));
+    expect(wrapper.text()).toContain('Paused');
+    expect(wrapper.find(Icon).props().type).toBe('pause');
+  });
+});

--- a/recipe-server/client/control/tests/components/common/test_EnrollmentStatus.js
+++ b/recipe-server/client/control/tests/components/common/test_EnrollmentStatus.js
@@ -1,39 +1,40 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Link } from 'redux-little-router';
+import { mount } from 'enzyme';
 
 import EnrollmentStatus from 'control/components/common/EnrollmentStatus';
+import { wrapMockStore } from 'control/tests/mockStore';
+
 
 describe('<EnrollmentStatus>', () => {
   it('should work', () => {
-    const wrapper = () => shallow(<EnrollmentStatus recipe={{}} />);
+    const wrapper = () => mount(wrapMockStore(<EnrollmentStatus recipe={{}} />));
     expect(wrapper).not.toThrow();
   });
 
   it('should print `disabled` if the recipe is not enabled', () => {
     const recipe = { enabled: false };
-    const wrapper = shallow(<EnrollmentStatus recipe={recipe} />);
+    const wrapper = mount(wrapMockStore(<EnrollmentStatus recipe={recipe} />));
     expect(wrapper.text()).toContain('Disabled');
-    expect(wrapper.find('.status-icon').props().type).toBe('minus');
+    expect(wrapper.find('.status-icon').props().className).toContain('anticon-minus');
   });
 
   it('should print `active` if the recipe is enabled and NOT paused', () => {
     const recipe = { enabled: true, arguments: { isEnrollmentPaused: false } };
-    const wrapper = shallow(<EnrollmentStatus recipe={recipe} />);
+    const wrapper = mount(wrapMockStore(<EnrollmentStatus recipe={recipe} />));
     expect(wrapper.text()).toContain('Active');
-    expect(wrapper.find('.status-icon').props().type).toBe('check');
+    expect(wrapper.find('.status-icon').props().className).toContain('anticon-check');
   });
 
   it('should print `paused` if the recipe is enabled and paused', () => {
     const recipe = { enabled: true, arguments: { isEnrollmentPaused: true } };
-    const wrapper = shallow(<EnrollmentStatus recipe={recipe} />);
+    const wrapper = mount(wrapMockStore(<EnrollmentStatus recipe={recipe} />));
     expect(wrapper.text()).toContain('Paused');
-    expect(wrapper.find('.status-icon').props().type).toBe('pause');
+    expect(wrapper.find('.status-icon').props().className).toContain('anticon-pause');
   });
 
   it('should add a "lowkey" class when the recipe is disabled', () => {
     const recipe = { enabled: false };
-    const wrapper = shallow(<EnrollmentStatus recipe={recipe} />);
-    expect(wrapper.find(Link).props().className).toContain('is-lowkey');
+    const wrapper = mount(wrapMockStore(<EnrollmentStatus recipe={recipe} />));
+    expect(wrapper.find('.status-link').props().className).toContain('is-lowkey');
   });
 });

--- a/recipe-server/client/control/tests/components/common/test_EnrollmentStatus.js
+++ b/recipe-server/client/control/tests/components/common/test_EnrollmentStatus.js
@@ -1,42 +1,39 @@
-import { Icon } from 'antd';
 import React from 'react';
-import { mount } from 'enzyme';
-import { Map } from 'immutable';
+import { shallow } from 'enzyme';
+import { Link } from 'redux-little-router';
 
-import { wrapMockStore } from 'control/tests/mockStore';
-import TestComponent from 'control/components/common/EnrollmentStatus';
-
-const { WrappedComponent: EnrollmentStatus } = TestComponent;
+import EnrollmentStatus from 'control/components/common/EnrollmentStatus';
 
 describe('<EnrollmentStatus>', () => {
-  const props = {
-    isEnabled: false,
-    isPaused: false,
-    record: new Map(),
-  };
-
   it('should work', () => {
-    const wrapper = () => mount(wrapMockStore(<EnrollmentStatus {...props} />));
+    const wrapper = () => shallow(<EnrollmentStatus recipe={{}} />);
     expect(wrapper).not.toThrow();
   });
 
   it('should print `disabled` if the recipe is not enabled', () => {
-    const wrapper = mount(wrapMockStore(<EnrollmentStatus {...props} isEnabled={false} />));
+    const recipe = { enabled: false };
+    const wrapper = shallow(<EnrollmentStatus recipe={recipe} />);
     expect(wrapper.text()).toContain('Disabled');
-    expect(wrapper.find(Icon).props().type).toBe('minus');
+    expect(wrapper.find('.status-icon').props().type).toBe('minus');
   });
 
   it('should print `active` if the recipe is enabled and NOT paused', () => {
-    const wrapper = mount(wrapMockStore(
-      <EnrollmentStatus {...props} isEnabled isPaused={false} />
-    ));
+    const recipe = { enabled: true, arguments: { isEnrollmentPaused: false } };
+    const wrapper = shallow(<EnrollmentStatus recipe={recipe} />);
     expect(wrapper.text()).toContain('Active');
-    expect(wrapper.find(Icon).props().type).toBe('check');
+    expect(wrapper.find('.status-icon').props().type).toBe('check');
   });
 
   it('should print `paused` if the recipe is enabled and paused', () => {
-    const wrapper = mount(wrapMockStore(<EnrollmentStatus {...props} isEnabled isPaused />));
+    const recipe = { enabled: true, arguments: { isEnrollmentPaused: true } };
+    const wrapper = shallow(<EnrollmentStatus recipe={recipe} />);
     expect(wrapper.text()).toContain('Paused');
-    expect(wrapper.find(Icon).props().type).toBe('pause');
+    expect(wrapper.find('.status-icon').props().type).toBe('pause');
+  });
+
+  it('should add a "lowkey" class when the recipe is disabled', () => {
+    const recipe = { enabled: false };
+    const wrapper = shallow(<EnrollmentStatus recipe={recipe} />);
+    expect(wrapper.find(Link).props().className).toContain('is-lowkey');
   });
 });


### PR DESCRIPTION
Fixes #1111 (mostly)

Ticket #1111 requests an indicator on the recipe details page for 'paused enrollment', however this data already exists on the page: 
![screen shot 2017-12-18 at 12 41 15 pm](https://user-images.githubusercontent.com/2767162/34127993-699be8c0-e3fc-11e7-90b8-0b530dd5f3b9.png)

The ticket requested adding this info to the listing page, which this PR does:
![screen shot 2017-12-18 at 2 03 39 pm](https://user-images.githubusercontent.com/2767162/34128020-7d573e6e-e3fc-11e7-81b0-dde2c0233b59.png)

This should, for the most part, close #1111, as the 'paused' status is now available on the `listing`, `details`, and `edit` pages.