### PR TITLE
#1157: Store approval requests on load

### DIFF
--- a/recipe-server/client/control/state/app/approvalRequests/reducers.js
+++ b/recipe-server/client/control/state/app/approvalRequests/reducers.js
@@ -4,8 +4,8 @@ import { combineReducers } from 'redux';
 import {
   APPROVAL_REQUEST_DELETE,
   APPROVAL_REQUEST_RECEIVE,
+  RECIPE_HISTORY_RECEIVE,
 } from 'control/state/action-types';
-
 
 function items(state = new Map(), action) {
   let approvalRequest;
@@ -21,6 +21,19 @@ function items(state = new Map(), action) {
         .remove('approver');
 
       return state.set(action.approvalRequest.id, approvalRequest);
+
+    case RECIPE_HISTORY_RECEIVE: {
+      const revisions = fromJS(action.revisions);
+
+      return state.withMutations(mutState => {
+        revisions.forEach(revision => {
+          const approvalId = revision.getIn(['approval_request', 'id'], null);
+          if (approvalId) {
+            mutState.set(approvalId, revision.get('approval_request'));
+          }
+        });
+      });
+    }
 
     case APPROVAL_REQUEST_DELETE:
       return state.remove(action.approvalRequestId);

--- a/recipe-server/client/control/tests/state/approvalRequests/test_reducers.js
+++ b/recipe-server/client/control/tests/state/approvalRequests/test_reducers.js
@@ -1,9 +1,10 @@
-import { fromJS } from 'immutable';
+import { fromJS, Map } from 'immutable';
 import * as matchers from 'jasmine-immutable-matchers';
 
 import {
   APPROVAL_REQUEST_DELETE,
   APPROVAL_REQUEST_RECEIVE,
+  RECIPE_HISTORY_RECEIVE,
 } from 'control/state/action-types';
 import approvalRequestsReducer from 'control/state/app/approvalRequests/reducers';
 import {
@@ -55,5 +56,21 @@ describe('Approval requests reducer', () => {
     });
 
     expect(updatedState).toEqual(INITIAL_STATE);
+  });
+
+  it('should handle RECIPE_HISTORY_RECEIVE', () => {
+    const appRequest = {
+      id: 'test',
+      arbitrary_data: 123,
+    };
+
+    const state = approvalRequestsReducer(undefined, {
+      type: RECIPE_HISTORY_RECEIVE,
+      revisions: [{
+        approval_request: appRequest,
+      }],
+    });
+
+    expect(state.items.get(appRequest.id)).toEqual(new Map(appRequest));
   });
 });


### PR DESCRIPTION
Fixes #1157 

- Corrects issue where approval requests were not stored in redux on page load
- Adds appropriate test

Ready for review.