### PR TITLE
Fix TelemetryEvent initialization and tests

### DIFF
--- a/recipe-client-addon/lib/TelemetryEvents.jsm
+++ b/recipe-client-addon/lib/TelemetryEvents.jsm
@@ -12,7 +12,7 @@ this.EXPORTED_SYMBOLS = ["TelemetryEvents"];
 const TELEMETRY_CATEGORY = "normandy";
 
 const TelemetryEvents = {
-  startup() {
+  init() {
     Services.telemetry.registerEvents(TELEMETRY_CATEGORY, {
       enroll: {
         methods: ["enroll"],

--- a/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
+++ b/recipe-client-addon/test/browser/browser_ShieldRecipeClient.js
@@ -5,6 +5,7 @@ Cu.import("resource://shield-recipe-client/lib/RecipeRunner.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/PreferenceExperiments.jsm", this);
 Cu.import("resource://shield-recipe-client-content/AboutPages.jsm", this);
 Cu.import("resource://shield-recipe-client/lib/AddonStudies.jsm", this);
+Cu.import("resource://shield-recipe-client/lib/TelemetryEvents.jsm", this);
 
 function withStubInits(testFunction) {
   return decorate(
@@ -12,6 +13,7 @@ function withStubInits(testFunction) {
     withStub(AddonStudies, "init"),
     withStub(PreferenceExperiments, "init"),
     withStub(RecipeRunner, "init"),
+    withStub(TelemetryEvents, "init"),
     testFunction
   );
 }
@@ -39,6 +41,7 @@ decorate_task(
     ok(AddonStudies.init.called, "startup calls AddonStudies.init");
     ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
     ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+    ok(TelemetryEvents.init.called, "startup calls TelemetryEvents.init");
   }
 );
 
@@ -52,6 +55,7 @@ decorate_task(
     ok(AddonStudies.init.called, "startup calls AddonStudies.init");
     ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
     ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+    ok(TelemetryEvents.init.called, "startup calls TelemetryEvents.init");
   }
 );
 
@@ -65,5 +69,21 @@ decorate_task(
     ok(AddonStudies.init.called, "startup calls AddonStudies.init");
     ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
     ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+    ok(TelemetryEvents.init.called, "startup calls TelemetryEvents.init");
+  }
+);
+
+
+decorate_task(
+  withStubInits,
+  async function testStartupTelemetryEventsInitFail() {
+    TelemetryEvents.init.returns(Promise.reject(new Error("oh no")));
+
+    await ShieldRecipeClient.startup();
+    ok(AboutPages.init.called, "startup calls AboutPages.init");
+    ok(AddonStudies.init.called, "startup calls AddonStudies.init");
+    ok(PreferenceExperiments.init.called, "startup calls PreferenceExperiments.init");
+    ok(RecipeRunner.init.called, "startup calls RecipeRunner.init");
+    ok(TelemetryEvents.init.called, "startup calls TelemetryEvents.init");
   }
 );

--- a/recipe-client-addon/test/browser/head.js
+++ b/recipe-client-addon/test/browser/head.js
@@ -27,7 +27,7 @@ registerCleanupFunction(async function() {
 });
 
 // Prep Telemetry to receive events from tests
-TelemetryEvents.startup();
+TelemetryEvents.init();
 
 this.UUID_REGEX = /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/;
 


### PR DESCRIPTION
Adrian pointed out that this feature doesn't even start up, since I used the wrong method name in the add-on startup.

bors delegate= @gijsk 

---

As an aside, a quick tutorial on bors. After someone with permission says `bors r+` alone on a line (which includes you for this PR, because of the `delegate` line above), bors will try to merge this PR. Bors will make a merge commit with master, run the tests on that merge commit, and then if it passes actually merge the PR into master. There are other commands, which can be seen [in the bors docs](https://bors.tech/documentation/). You can use these commands from Github review approvals as well, if you want.

It is safe to trigger bors even if the tests haven't yet passed in this PR, or even if they failed for unrelated reasons. Bors won't merge to master unless the tests pass.