### PR TITLE
Fix #1162 - Allow filtering recipes by action name

### DIFF
--- a/recipe-server/normandy/recipes/api/v1/views.py
+++ b/recipe-server/normandy/recipes/api/v1/views.py
@@ -75,10 +75,15 @@ class ActionImplementationView(generics.RetrieveAPIView):
 
 class RecipeFilters(django_filters.FilterSet):
     enabled = CaseInsensitiveBooleanFilter(name='enabled', lookup_expr='eq')
+    action = django_filters.CharFilter(name='latest_revision__action__name')
 
     class Meta:
         model = Recipe
-        fields = ['latest_revision__action', 'enabled']
+        fields = [
+            'action',
+            'enabled',
+            'latest_revision__action',
+        ]
 
 
 class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):

--- a/recipe-server/normandy/recipes/api/v2/views.py
+++ b/recipe-server/normandy/recipes/api/v2/views.py
@@ -37,10 +37,15 @@ class ActionViewSet(CachingViewsetMixin, viewsets.ReadOnlyModelViewSet):
 
 class RecipeFilters(django_filters.FilterSet):
     enabled = CaseInsensitiveBooleanFilter(name='enabled', lookup_expr='eq')
+    action = django_filters.CharFilter(name='latest_revision__action__name')
 
     class Meta:
         model = Recipe
-        fields = ['latest_revision__action', 'enabled']
+        fields = [
+            'action',
+            'enabled',
+            'latest_revision__action',
+        ]
 
 
 class RecipeOrderingFilter(AliasedOrderingFilter):

--- a/recipe-server/normandy/recipes/tests/api/v1/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v1/test_api.py
@@ -530,6 +530,48 @@ class TestRecipeAPI(object):
             for recipe in res.data:
                 assert recipe['id'] in [r1.id, r2.id]
 
+        def test_list_filter_action_legacy(self, api_client):
+            a1 = ActionFactory()
+            a2 = ActionFactory()
+            r1 = RecipeFactory(action=a1)
+            r2 = RecipeFactory(action=a2)
+
+            assert a1.id != a2.id
+
+            res = api_client.get(f'/api/v1/recipe/?latest_revision__action={a1.id}')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data] == [r1.id]
+
+            res = api_client.get(f'/api/v1/recipe/?latest_revision__action={a2.id}')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data] == [r2.id]
+
+            assert a1.id != -1 and a2.id != -1
+            res = api_client.get(f'/api/v1/recipe/?latest_revision__action=-1')
+            assert res.status_code == 200
+            assert res.data == []
+
+        def test_list_filter_action(self, api_client):
+            a1 = ActionFactory()
+            a2 = ActionFactory()
+            r1 = RecipeFactory(action=a1)
+            r2 = RecipeFactory(action=a2)
+
+            assert a1.name != a2.name
+
+            res = api_client.get(f'/api/v1/recipe/?action={a1.name}')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data] == [r1.id]
+
+            res = api_client.get(f'/api/v1/recipe/?action={a2.name}')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data] == [r2.id]
+
+            assert a1.name != "nonexistant" and a2.name != "nonexistant"
+            res = api_client.get(f'/api/v1/recipe/?action=nonexistant')
+            assert res.status_code == 200
+            assert res.data == []
+
     @pytest.mark.django_db
     class TestSigned(object):
         def test_signed_listing_works(self, api_client):

--- a/recipe-server/normandy/recipes/tests/api/v1/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v1/test_api.py
@@ -163,401 +163,418 @@ class TestImplementationAPI(object):
 
 @pytest.mark.django_db
 class TestRecipeAPI(object):
-    def test_it_works(self, api_client):
-        res = api_client.get('/api/v1/recipe/')
-        assert res.status_code == 200
-        assert res.data == []
 
-    def test_it_serves_recipes(self, api_client):
-        recipe = RecipeFactory()
+    @pytest.mark.django_db
+    class TestListing(object):
+        def test_it_works(self, api_client):
+            res = api_client.get('/api/v1/recipe/')
+            assert res.status_code == 200
+            assert res.data == []
 
-        res = api_client.get('/api/v1/recipe/')
-        assert res.status_code == 200
-        assert res.data[0]['name'] == recipe.name
+        def test_it_serves_recipes(self, api_client):
+            recipe = RecipeFactory()
 
-    def test_it_can_create_recipes(self, api_client):
-        action = ActionFactory()
+            res = api_client.get('/api/v1/recipe/')
+            assert res.status_code == 200
+            assert res.data[0]['name'] == recipe.name
 
-        # Enabled recipe
-        res = api_client.post('/api/v1/recipe/', {
-            'name': 'Test Recipe',
-            'action': action.name,
-            'arguments': {},
-            'extra_filter_expression': 'whatever',
-            'enabled': True
-        })
-        assert res.status_code == 201
+        def test_available_if_admin_enabled(self, api_client, settings):
+            settings.ADMIN_ENABLED = True
+            res = api_client.get('/api/v1/recipe/')
+            assert res.status_code == 200
+            assert res.data == []
 
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 1
+        def test_readonly_if_admin_disabled(self, api_client, settings):
+            settings.ADMIN_ENABLED = False
+            res = api_client.get('/api/v1/recipe/')
+            assert res.status_code == 200
 
-    def test_it_can_create_disabled_recipes(self, api_client):
-        action = ActionFactory()
+            recipe = RecipeFactory(name='unchanged')
+            res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {'name': 'changed'})
+            assert res.status_code == 403
+            assert res.data['detail'] == AdminEnabledOrReadOnly.message
 
-        # Disabled recipe
-        res = api_client.post('/api/v1/recipe/', {
-            'name': 'Test Recipe',
-            'action': action.name,
-            'arguments': {},
-            'extra_filter_expression': 'whatever',
-            'enabled': False
-        })
-        assert res.status_code == 201
+        def test_list_view_includes_cache_headers(self, api_client):
+            res = api_client.get('/api/v1/recipe/')
+            assert res.status_code == 200
+            # It isn't important to assert a particular value for max_age
+            assert 'max-age=' in res['Cache-Control']
+            assert 'public' in res['Cache-Control']
 
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 1
+        def test_list_sets_no_cookies(self, api_client):
+            res = api_client.get('/api/v1/recipe/')
+            assert res.status_code == 200
+            assert 'Cookies' not in res
 
-    def test_it_can_edit_recipes(self, api_client):
-        recipe = RecipeFactory(name='unchanged', extra_filter_expression='true')
-        old_revision_id = recipe.revision_id
+    @pytest.mark.django_db
+    class TestCreation(object):
+        def test_it_can_create_recipes(self, api_client):
+            action = ActionFactory()
 
-        res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {
-            'name': 'changed',
-            'extra_filter_expression': 'false',
-        })
-        assert res.status_code == 200
+            # Enabled recipe
+            res = api_client.post('/api/v1/recipe/', {
+                'name': 'Test Recipe',
+                'action': action.name,
+                'arguments': {},
+                'extra_filter_expression': 'whatever',
+                'enabled': True
+            })
+            assert res.status_code == 201
 
-        recipe = Recipe.objects.all()[0]
-        assert recipe.name == 'changed'
-        assert recipe.filter_expression == 'false'
-        assert recipe.revision_id != old_revision_id
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 1
 
-    def test_creation_when_action_does_not_exist(self, api_client):
-        res = api_client.post('/api/v1/recipe/', {'name': 'Test Recipe',
-                                                  'action': 'fake-action',
-                                                  'arguments': '{}'})
-        assert res.status_code == 400
+        def test_it_can_create_disabled_recipes(self, api_client):
+            action = ActionFactory()
 
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 0
+            # Disabled recipe
+            res = api_client.post('/api/v1/recipe/', {
+                'name': 'Test Recipe',
+                'action': action.name,
+                'arguments': {},
+                'extra_filter_expression': 'whatever',
+                'enabled': False
+            })
+            assert res.status_code == 201
 
-    def test_creation_when_arguments_are_invalid(self, api_client):
-        ActionFactory(
-            name='foobarbaz',
-            arguments_schema={
-                'type': 'object',
-                'properties': {'message': {'type': 'string'}},
-                'required': ['message']
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 1
+
+        def test_creation_when_action_does_not_exist(self, api_client):
+            res = api_client.post('/api/v1/recipe/', {'name': 'Test Recipe',
+                                                      'action': 'fake-action',
+                                                      'arguments': '{}'})
+            assert res.status_code == 400
+
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 0
+
+        def test_creation_when_arguments_are_invalid(self, api_client):
+            ActionFactory(
+                name='foobarbaz',
+                arguments_schema={
+                    'type': 'object',
+                    'properties': {'message': {'type': 'string'}},
+                    'required': ['message']
+                }
+            )
+            res = api_client.post('/api/v1/recipe/', {'name': 'Test Recipe',
+                                                      'enabled': True,
+                                                      'extra_filter_expression': 'true',
+                                                      'action': 'foobarbaz',
+                                                      'arguments': {'message': ''}})
+            assert res.status_code == 400
+
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 0
+
+    @pytest.mark.django_db
+    class TestUpdates(object):
+        def test_it_can_edit_recipes(self, api_client):
+            recipe = RecipeFactory(name='unchanged', extra_filter_expression='true')
+            old_revision_id = recipe.revision_id
+
+            res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {
+                'name': 'changed',
+                'extra_filter_expression': 'false',
+            })
+            assert res.status_code == 200
+
+            recipe = Recipe.objects.all()[0]
+            assert recipe.name == 'changed'
+            assert recipe.filter_expression == 'false'
+            assert recipe.revision_id != old_revision_id
+
+        def test_it_can_change_action_for_recipes(self, api_client):
+            recipe = RecipeFactory()
+            action = ActionFactory()
+
+            res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {'action': action.name})
+            assert res.status_code == 200
+
+            recipe = Recipe.objects.get(pk=recipe.id)
+            assert recipe.action == action
+
+        def test_it_can_change_arguments_for_recipes(self, api_client):
+            recipe = RecipeFactory(arguments_json='{}')
+            action = ActionFactory(
+                name='foobarbaz',
+                arguments_schema={
+                    'type': 'object',
+                    'properties': {'message': {'type': 'string'}},
+                    'required': ['message']
+                }
+            )
+
+            arguments = {'message': 'test message'}
+
+            res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {
+                'action': action.name, 'arguments': arguments})
+            assert res.status_code == 200
+
+            recipe = Recipe.objects.get(pk=recipe.id)
+            assert recipe.arguments == arguments
+
+        def test_it_can_delete_recipes(self, api_client):
+            recipe = RecipeFactory()
+
+            res = api_client.delete('/api/v1/recipe/%s/' % recipe.id)
+            assert res.status_code == 204
+
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 0
+
+        def test_update_recipe_action(self, api_client):
+            r = RecipeFactory()
+            a = ActionFactory(name='test')
+
+            res = api_client.patch(f'/api/v1/recipe/{r.pk}/', {'action': 'test'})
+            assert res.status_code == 200
+
+            r.refresh_from_db()
+            assert r.action == a
+
+        def test_update_recipe_locale(self, api_client):
+            l1 = LocaleFactory(code='fr-FR')
+            l2 = LocaleFactory(code='en-US')
+            r = RecipeFactory(locales=[l1])
+
+            res = api_client.patch(f'/api/v1/recipe/{r.pk}/', {'locales': ['en-US']})
+            assert res.status_code == 200
+
+            r.refresh_from_db()
+            assert list(r.locales.all()) == [l2]
+
+        def test_update_recipe_country(self, api_client):
+            c1 = CountryFactory(code='US')
+            c2 = CountryFactory(code='CA')
+            r = RecipeFactory(countries=[c1])
+
+            res = api_client.patch(f'/api/v1/recipe/{r.pk}/', {'countries': ['CA']})
+            assert res.status_code == 200
+
+            r.refresh_from_db()
+            assert list(r.countries.all()) == [c2]
+
+        def test_update_recipe_channel(self, api_client):
+            c1 = ChannelFactory(slug='release')
+            c2 = ChannelFactory(slug='beta')
+            r = RecipeFactory(channels=[c1])
+
+            res = api_client.patch(f'/api/v1/recipe/{r.pk}/', {'channels': ['beta']})
+            assert res.status_code == 200
+
+            r.refresh_from_db()
+            assert list(r.channels.all()) == [c2]
+
+    @pytest.mark.django_db
+    class TestDetail(object):
+        def test_detail_view_includes_cache_headers(self, api_client):
+            recipe = RecipeFactory()
+            res = api_client.get(f'/api/v1/recipe/{recipe.id}/')
+            assert res.status_code == 200
+            # It isn't important to assert a particular value for max-age
+            assert 'max-age=' in res['Cache-Control']
+            assert 'public' in res['Cache-Control']
+
+        def test_history(self, api_client):
+            recipe = RecipeFactory(name='version 1')
+            recipe.revise(name='version 2')
+            recipe.revise(name='version 3')
+
+            res = api_client.get('/api/v1/recipe/%s/history/' % recipe.id)
+
+            assert res.data[0]['recipe']['name'] == 'version 3'
+            assert res.data[1]['recipe']['name'] == 'version 2'
+            assert res.data[2]['recipe']['name'] == 'version 1'
+
+        def test_it_can_enable_recipes(self, api_client):
+            recipe = RecipeFactory(enabled=False, approver=UserFactory())
+
+            res = api_client.post('/api/v1/recipe/%s/enable/' % recipe.id)
+            assert res.status_code == 200
+            assert res.data['enabled'] is True
+
+            recipe = Recipe.objects.all()[0]
+            assert recipe.enabled
+
+        def test_cannot_enable_unapproved_recipes(self, api_client):
+            recipe = RecipeFactory(enabled=False)
+
+            res = api_client.post('/api/v1/recipe/%s/enable/' % recipe.id)
+            assert res.status_code == 409
+            assert res.data['enabled'] == 'Cannot enable a recipe that is not approved.'
+
+        def test_it_can_disable_recipes(self, api_client):
+            recipe = RecipeFactory(approver=UserFactory(), enabled=True)
+
+            res = api_client.post('/api/v1/recipe/%s/disable/' % recipe.id)
+            assert res.status_code == 200
+            assert res.data['enabled'] is False
+
+            recipe = Recipe.objects.all()[0]
+            assert not recipe.is_approved
+            assert not recipe.enabled
+
+        def test_detail_sets_no_cookies(self, api_client):
+            recipe = RecipeFactory()
+            res = api_client.get('/api/v1/recipe/{id}/'.format(id=recipe.id))
+            assert res.status_code == 200
+            assert res.client.cookies == {}
+
+    @pytest.mark.django_db
+    class TestFiltering(object):
+        def test_filtering_by_enabled_lowercase(self, api_client):
+            r1 = RecipeFactory(approver=UserFactory(), enabled=True)
+            RecipeFactory(enabled=False)
+
+            res = api_client.get('/api/v1/recipe/?enabled=true')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data] == [r1.id]
+
+        def test_filtering_by_enabled_fuzz(self, api_client):
+            """
+            Test that we don't return 500 responses when we get unexpected boolean filters.
+
+            This was a real case that showed up in our error logging.
+            """
+            url = (
+                "/api/v1/recipe/?enabled=javascript%3a%2f*"
+                "<%2fscript><svg%2fonload%3d'%2b%2f'%2f%2b"
+            )
+            res = api_client.get(url)
+            assert res.status_code == 400
+            assert res.data == {
+                'messages': [
+                    "'javascript:/*</script><svg/onload='+/'/+' "
+                    "value must be either True or False.",
+                ],
             }
-        )
-        res = api_client.post('/api/v1/recipe/', {'name': 'Test Recipe',
-                                                  'enabled': True,
-                                                  'extra_filter_expression': 'true',
-                                                  'action': 'foobarbaz',
-                                                  'arguments': {'message': ''}})
-        assert res.status_code == 400
-
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 0
-
-    def test_it_can_change_action_for_recipes(self, api_client):
-        recipe = RecipeFactory()
-        action = ActionFactory()
-
-        res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {'action': action.name})
-        assert res.status_code == 200
-
-        recipe = Recipe.objects.get(pk=recipe.id)
-        assert recipe.action == action
-
-    def test_it_can_change_arguments_for_recipes(self, api_client):
-        recipe = RecipeFactory(arguments_json='{}')
-        action = ActionFactory(
-            name='foobarbaz',
-            arguments_schema={
-                'type': 'object',
-                'properties': {'message': {'type': 'string'}},
-                'required': ['message']
-            }
-        )
-
-        arguments = {'message': 'test message'}
-
-        res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {
-            'action': action.name, 'arguments': arguments})
-        assert res.status_code == 200
-
-        recipe = Recipe.objects.get(pk=recipe.id)
-        assert recipe.arguments == arguments
-
-    def test_it_can_delete_recipes(self, api_client):
-        recipe = RecipeFactory()
-
-        res = api_client.delete('/api/v1/recipe/%s/' % recipe.id)
-        assert res.status_code == 204
-
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 0
-
-    def test_available_if_admin_enabled(self, api_client, settings):
-        settings.ADMIN_ENABLED = True
-        res = api_client.get('/api/v1/recipe/')
-        assert res.status_code == 200
-        assert res.data == []
-
-    def test_readonly_if_admin_disabled(self, api_client, settings):
-        settings.ADMIN_ENABLED = False
-        res = api_client.get('/api/v1/recipe/')
-        assert res.status_code == 200
-
-        recipe = RecipeFactory(name='unchanged')
-        res = api_client.patch('/api/v1/recipe/%s/' % recipe.id, {'name': 'changed'})
-        assert res.status_code == 403
-        assert res.data['detail'] == AdminEnabledOrReadOnly.message
-
-    def test_history(self, api_client):
-        recipe = RecipeFactory(name='version 1')
-        recipe.revise(name='version 2')
-        recipe.revise(name='version 3')
-
-        res = api_client.get('/api/v1/recipe/%s/history/' % recipe.id)
-
-        assert res.data[0]['recipe']['name'] == 'version 3'
-        assert res.data[1]['recipe']['name'] == 'version 2'
-        assert res.data[2]['recipe']['name'] == 'version 1'
-
-    def test_it_can_enable_recipes(self, api_client):
-        recipe = RecipeFactory(enabled=False, approver=UserFactory())
-
-        res = api_client.post('/api/v1/recipe/%s/enable/' % recipe.id)
-        assert res.status_code == 200
-        assert res.data['enabled'] is True
-
-        recipe = Recipe.objects.all()[0]
-        assert recipe.enabled
-
-    def test_cannot_enable_unapproved_recipes(self, api_client):
-        recipe = RecipeFactory(enabled=False)
-
-        res = api_client.post('/api/v1/recipe/%s/enable/' % recipe.id)
-        assert res.status_code == 409
-        assert res.data['enabled'] == 'Cannot enable a recipe that is not approved.'
-
-    def test_it_can_disable_recipes(self, api_client):
-        recipe = RecipeFactory(approver=UserFactory(), enabled=True)
-
-        res = api_client.post('/api/v1/recipe/%s/disable/' % recipe.id)
-        assert res.status_code == 200
-        assert res.data['enabled'] is False
-
-        recipe = Recipe.objects.all()[0]
-        assert not recipe.is_approved
-        assert not recipe.enabled
-
-    def test_filtering_by_enabled_lowercase(self, api_client):
-        r1 = RecipeFactory(approver=UserFactory(), enabled=True)
-        RecipeFactory(enabled=False)
-
-        res = api_client.get('/api/v1/recipe/?enabled=true')
-        assert res.status_code == 200
-        assert [r['id'] for r in res.data] == [r1.id]
-
-    def test_filtering_by_enabled_fuzz(self, api_client):
-        """
-        Test that we don't return 500 responses when we get unexpected boolean filters.
-
-        This was a real case that showed up in our error logging.
-        """
-        url = "/api/v1/recipe/?enabled=javascript%3a%2f*<%2fscript><svg%2fonload%3d'%2b%2f'%2f%2b"
-        res = api_client.get(url)
-        assert res.status_code == 400
-        assert res.data == {
-            'messages': [
-                "'javascript:/*</script><svg/onload='+/'/+' value must be either True or False.",
-            ],
-        }
-
-    def test_list_view_includes_cache_headers(self, api_client):
-        res = api_client.get('/api/v1/recipe/')
-        assert res.status_code == 200
-        # It isn't important to assert a particular value for max_age
-        assert 'max-age=' in res['Cache-Control']
-        assert 'public' in res['Cache-Control']
-
-    def test_signed_view_includes_cache_headers(self, api_client):
-        res = api_client.get('/api/v1/recipe/signed/')
-        assert res.status_code == 200
-        # It isn't important to assert a particular value for max-age
-        assert 'max-age=' in res['Cache-Control']
-        assert 'public' in res['Cache-Control']
-
-    def test_detail_view_includes_cache_headers(self, api_client):
-        recipe = RecipeFactory()
-        res = api_client.get(f'/api/v1/recipe/{recipe.id}/')
-        assert res.status_code == 200
-        # It isn't important to assert a particular value for max-age
-        assert 'max-age=' in res['Cache-Control']
-        assert 'public' in res['Cache-Control']
-
-    def test_signed_listing_works(self, api_client):
-        r1 = RecipeFactory(signed=True)
-        res = api_client.get('/api/v1/recipe/signed/')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['recipe']['id'] == r1.id
-        assert res.data[0]['signature']['signature'] == r1.signature.signature
-
-    def test_signed_only_lists_signed_recipes(self, api_client):
-        r1 = RecipeFactory(signed=True)
-        r2 = RecipeFactory(signed=True)
-        RecipeFactory(signed=False)
-        res = api_client.get('/api/v1/recipe/signed/')
-        assert res.status_code == 200
-        assert len(res.data) == 2
-
-        res.data.sort(key=lambda r: r['recipe']['id'])
-
-        assert res.data[0]['recipe']['id'] == r1.id
-        assert res.data[0]['signature']['signature'] == r1.signature.signature
-        assert res.data[1]['recipe']['id'] == r2.id
-        assert res.data[1]['signature']['signature'] == r2.signature.signature
-
-    def test_signed_listing_filters_by_enabled(Self, api_client):
-        enabled_recipe = RecipeFactory(signed=True, approver=UserFactory(), enabled=True)
-        disabled_recipe = RecipeFactory(signed=True, enabled=False)
-
-        res = api_client.get('/api/v1/recipe/signed/?enabled=1')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['recipe']['id'] == enabled_recipe.id
-
-        res = api_client.get('/api/v1/recipe/signed/?enabled=0')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['recipe']['id'] == disabled_recipe.id
-
-    def test_list_sets_no_cookies(self, api_client):
-        res = api_client.get('/api/v1/recipe/')
-        assert res.status_code == 200
-        assert 'Cookies' not in res
-
-    def test_detail_sets_no_cookies(self, api_client):
-        recipe = RecipeFactory()
-        res = api_client.get('/api/v1/recipe/{id}/'.format(id=recipe.id))
-        assert res.status_code == 200
-        assert res.client.cookies == {}
-
-    def test_list_filter_status(self, api_client):
-        r1 = RecipeFactory(enabled=False)
-        r2 = RecipeFactory(approver=UserFactory(), enabled=True)
-
-        res = api_client.get('/api/v1/recipe/?status=enabled')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['id'] == r2.id
-
-        res = api_client.get('/api/v1/recipe/?status=disabled')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['id'] == r1.id
-
-    def test_list_filter_channels(self, api_client):
-        r1 = RecipeFactory(channels=[ChannelFactory(slug='beta')])
-        r2 = RecipeFactory(channels=[ChannelFactory(slug='release')])
-
-        res = api_client.get('/api/v1/recipe/?channels=beta')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['id'] == r1.id
-
-        res = api_client.get('/api/v1/recipe/?channels=beta,release')
-        assert res.status_code == 200
-        assert len(res.data) == 2
-        for recipe in res.data:
-            assert recipe['id'] in [r1.id, r2.id]
-
-    def test_list_filter_countries(self, api_client):
-        r1 = RecipeFactory(countries=[CountryFactory(code='US')])
-        r2 = RecipeFactory(countries=[CountryFactory(code='CA')])
-
-        res = api_client.get('/api/v1/recipe/?countries=US')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['id'] == r1.id
-
-        res = api_client.get('/api/v1/recipe/?countries=US,CA')
-        assert res.status_code == 200
-        assert len(res.data) == 2
-        for recipe in res.data:
-            assert recipe['id'] in [r1.id, r2.id]
-
-    def test_list_filter_locales(self, api_client):
-        r1 = RecipeFactory(locales=[LocaleFactory(code='en-US')])
-        r2 = RecipeFactory(locales=[LocaleFactory(code='fr-CA')])
-
-        res = api_client.get('/api/v1/recipe/?locales=en-US')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['id'] == r1.id
-
-        res = api_client.get('/api/v1/recipe/?locales=en-US,fr-CA')
-        assert res.status_code == 200
-        assert len(res.data) == 2
-        for recipe in res.data:
-            assert recipe['id'] in [r1.id, r2.id]
-
-    def test_list_filter_text(self, api_client):
-        r1 = RecipeFactory(name='first', extra_filter_expression='1 + 1 == 2')
-        r2 = RecipeFactory(name='second', extra_filter_expression='one + one == two')
-
-        res = api_client.get('/api/v1/recipe/?text=first')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['id'] == r1.id
-
-        res = api_client.get('/api/v1/recipe/?text=one')
-        assert res.status_code == 200
-        assert len(res.data) == 1
-        assert res.data[0]['id'] == r2.id
-
-        res = api_client.get('/api/v1/recipe/?text=t')
-        assert res.status_code == 200
-        assert len(res.data) == 2
-        for recipe in res.data:
-            assert recipe['id'] in [r1.id, r2.id]
-
-    def test_update_recipe_action(self, api_client):
-        r = RecipeFactory()
-        a = ActionFactory(name='test')
-
-        res = api_client.patch(f'/api/v1/recipe/{r.pk}/', {'action': 'test'})
-        assert res.status_code == 200
-
-        r.refresh_from_db()
-        assert r.action == a
-
-    def test_update_recipe_locale(self, api_client):
-        l1 = LocaleFactory(code='fr-FR')
-        l2 = LocaleFactory(code='en-US')
-        r = RecipeFactory(locales=[l1])
-
-        res = api_client.patch(f'/api/v1/recipe/{r.pk}/', {'locales': ['en-US']})
-        assert res.status_code == 200
-
-        r.refresh_from_db()
-        assert list(r.locales.all()) == [l2]
-
-    def test_update_recipe_country(self, api_client):
-        c1 = CountryFactory(code='US')
-        c2 = CountryFactory(code='CA')
-        r = RecipeFactory(countries=[c1])
-
-        res = api_client.patch(f'/api/v1/recipe/{r.pk}/', {'countries': ['CA']})
-        assert res.status_code == 200
-
-        r.refresh_from_db()
-        assert list(r.countries.all()) == [c2]
-
-    def test_update_recipe_channel(self, api_client):
-        c1 = ChannelFactory(slug='release')
-        c2 = ChannelFactory(slug='beta')
-        r = RecipeFactory(channels=[c1])
-
-        res = api_client.patch(f'/api/v1/recipe/{r.pk}/', {'channels': ['beta']})
-        assert res.status_code == 200
-
-        r.refresh_from_db()
-        assert list(r.channels.all()) == [c2]
+
+        def test_list_filter_status(self, api_client):
+            r1 = RecipeFactory(enabled=False)
+            r2 = RecipeFactory(approver=UserFactory(), enabled=True)
+
+            res = api_client.get('/api/v1/recipe/?status=enabled')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['id'] == r2.id
+
+            res = api_client.get('/api/v1/recipe/?status=disabled')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['id'] == r1.id
+
+        def test_list_filter_channels(self, api_client):
+            r1 = RecipeFactory(channels=[ChannelFactory(slug='beta')])
+            r2 = RecipeFactory(channels=[ChannelFactory(slug='release')])
+
+            res = api_client.get('/api/v1/recipe/?channels=beta')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['id'] == r1.id
+
+            res = api_client.get('/api/v1/recipe/?channels=beta,release')
+            assert res.status_code == 200
+            assert len(res.data) == 2
+            for recipe in res.data:
+                assert recipe['id'] in [r1.id, r2.id]
+
+        def test_list_filter_countries(self, api_client):
+            r1 = RecipeFactory(countries=[CountryFactory(code='US')])
+            r2 = RecipeFactory(countries=[CountryFactory(code='CA')])
+
+            res = api_client.get('/api/v1/recipe/?countries=US')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['id'] == r1.id
+
+            res = api_client.get('/api/v1/recipe/?countries=US,CA')
+            assert res.status_code == 200
+            assert len(res.data) == 2
+            for recipe in res.data:
+                assert recipe['id'] in [r1.id, r2.id]
+
+        def test_list_filter_locales(self, api_client):
+            r1 = RecipeFactory(locales=[LocaleFactory(code='en-US')])
+            r2 = RecipeFactory(locales=[LocaleFactory(code='fr-CA')])
+
+            res = api_client.get('/api/v1/recipe/?locales=en-US')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['id'] == r1.id
+
+            res = api_client.get('/api/v1/recipe/?locales=en-US,fr-CA')
+            assert res.status_code == 200
+            assert len(res.data) == 2
+            for recipe in res.data:
+                assert recipe['id'] in [r1.id, r2.id]
+
+        def test_list_filter_text(self, api_client):
+            r1 = RecipeFactory(name='first', extra_filter_expression='1 + 1 == 2')
+            r2 = RecipeFactory(name='second', extra_filter_expression='one + one == two')
+
+            res = api_client.get('/api/v1/recipe/?text=first')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['id'] == r1.id
+
+            res = api_client.get('/api/v1/recipe/?text=one')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['id'] == r2.id
+
+            res = api_client.get('/api/v1/recipe/?text=t')
+            assert res.status_code == 200
+            assert len(res.data) == 2
+            for recipe in res.data:
+                assert recipe['id'] in [r1.id, r2.id]
+
+    @pytest.mark.django_db
+    class TestSigned(object):
+        def test_signed_listing_works(self, api_client):
+            r1 = RecipeFactory(signed=True)
+            res = api_client.get('/api/v1/recipe/signed/')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['recipe']['id'] == r1.id
+            assert res.data[0]['signature']['signature'] == r1.signature.signature
+
+        def test_signed_view_includes_cache_headers(self, api_client):
+            res = api_client.get('/api/v1/recipe/signed/')
+            assert res.status_code == 200
+            # It isn't important to assert a particular value for max-age
+            assert 'max-age=' in res['Cache-Control']
+            assert 'public' in res['Cache-Control']
+
+        def test_signed_only_lists_signed_recipes(self, api_client):
+            r1 = RecipeFactory(signed=True)
+            r2 = RecipeFactory(signed=True)
+            RecipeFactory(signed=False)
+            res = api_client.get('/api/v1/recipe/signed/')
+            assert res.status_code == 200
+            assert len(res.data) == 2
+
+            res.data.sort(key=lambda r: r['recipe']['id'])
+
+            assert res.data[0]['recipe']['id'] == r1.id
+            assert res.data[0]['signature']['signature'] == r1.signature.signature
+            assert res.data[1]['recipe']['id'] == r2.id
+            assert res.data[1]['signature']['signature'] == r2.signature.signature
+
+        def test_signed_listing_filters_by_enabled(Self, api_client):
+            enabled_recipe = RecipeFactory(signed=True, approver=UserFactory(), enabled=True)
+            disabled_recipe = RecipeFactory(signed=True, enabled=False)
+
+            res = api_client.get('/api/v1/recipe/signed/?enabled=1')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['recipe']['id'] == enabled_recipe.id
+
+            res = api_client.get('/api/v1/recipe/signed/?enabled=0')
+            assert res.status_code == 200
+            assert len(res.data) == 1
+            assert res.data[0]['recipe']['id'] == disabled_recipe.id
 
 
 @pytest.mark.django_db

--- a/recipe-server/normandy/recipes/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_api.py
@@ -81,408 +81,419 @@ class TestActionAPI(object):
 
 @pytest.mark.django_db
 class TestRecipeAPI(object):
-    def test_it_works(self, api_client):
-        res = api_client.get('/api/v2/recipe/')
-        assert res.status_code == 200
-        assert res.data['results'] == []
 
-    def test_it_serves_recipes(self, api_client):
-        recipe = RecipeFactory()
+    @pytest.mark.django_db
+    class TestListing(object):
+        def test_it_works(self, api_client):
+            res = api_client.get('/api/v2/recipe/')
+            assert res.status_code == 200
+            assert res.data['results'] == []
 
-        res = api_client.get('/api/v2/recipe/')
-        assert res.status_code == 200
-        assert res.data['results'][0]['name'] == recipe.name
+        def test_it_serves_recipes(self, api_client):
+            recipe = RecipeFactory()
 
-    def test_it_can_create_recipes(self, api_client):
-        action = ActionFactory()
+            res = api_client.get('/api/v2/recipe/')
+            assert res.status_code == 200
+            assert res.data['results'][0]['name'] == recipe.name
 
-        # Enabled recipe
-        res = api_client.post('/api/v2/recipe/', {
-            'name': 'Test Recipe',
-            'action_id': action.id,
-            'arguments': {},
-            'extra_filter_expression': 'whatever',
-            'enabled': True
-        })
-        assert res.status_code == 201
+        def test_available_if_admin_enabled(self, api_client, settings):
+            settings.ADMIN_ENABLED = True
+            res = api_client.get('/api/v2/recipe/')
+            assert res.status_code == 200
+            assert res.data['results'] == []
 
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 1
+        def test_readonly_if_admin_disabled(self, api_client, settings):
+            settings.ADMIN_ENABLED = False
+            res = api_client.get('/api/v2/recipe/')
+            assert res.status_code == 200
 
-    def test_it_can_create_disabled_recipes(self, api_client):
-        action = ActionFactory()
+            recipe = RecipeFactory(name='unchanged')
+            res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {'name': 'changed'})
+            assert res.status_code == 403
+            assert res.data['detail'] == AdminEnabledOrReadOnly.message
 
-        # Disabled recipe
-        res = api_client.post('/api/v2/recipe/', {
-            'name': 'Test Recipe',
-            'action_id': action.id,
-            'arguments': {},
-            'extra_filter_expression': 'whatever',
-            'enabled': False
-        })
-        assert res.status_code == 201
+        def test_list_view_includes_cache_headers(self, api_client):
+            res = api_client.get('/api/v2/recipe/')
+            assert res.status_code == 200
+            # It isn't important to assert a particular value for max_age
+            assert 'max-age=' in res['Cache-Control']
+            assert 'public' in res['Cache-Control']
 
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 1
+        def test_list_sets_no_cookies(self, api_client):
+            res = api_client.get('/api/v2/recipe/')
+            assert res.status_code == 200
+            assert 'Cookies' not in res
 
-    def test_it_can_edit_recipes(self, api_client):
-        recipe = RecipeFactory(name='unchanged', extra_filter_expression='true')
-        old_revision_id = recipe.revision_id
+    @pytest.mark.django_db
+    class TestCreation(object):
+        def test_it_can_create_recipes(self, api_client):
+            action = ActionFactory()
 
-        res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {
-            'name': 'changed',
-            'extra_filter_expression': 'false',
-        })
-        assert res.status_code == 200
+            # Enabled recipe
+            res = api_client.post('/api/v2/recipe/', {
+                'name': 'Test Recipe',
+                'action_id': action.id,
+                'arguments': {},
+                'extra_filter_expression': 'whatever',
+                'enabled': True
+            })
+            assert res.status_code == 201
 
-        recipe = Recipe.objects.all()[0]
-        assert recipe.name == 'changed'
-        assert recipe.filter_expression == 'false'
-        assert recipe.revision_id != old_revision_id
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 1
 
-    def test_creation_when_action_does_not_exist(self, api_client):
-        res = api_client.post('/api/v2/recipe/', {'name': 'Test Recipe',
-                                                  'action_id': 1234,
-                                                  'arguments': '{}'})
-        assert res.status_code == 400
+        def test_it_can_create_disabled_recipes(self, api_client):
+            action = ActionFactory()
 
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 0
+            # Disabled recipe
+            res = api_client.post('/api/v2/recipe/', {
+                'name': 'Test Recipe',
+                'action_id': action.id,
+                'arguments': {},
+                'extra_filter_expression': 'whatever',
+                'enabled': False
+            })
+            assert res.status_code == 201
 
-    def test_creation_when_arguments_are_invalid(self, api_client):
-        action = ActionFactory(
-            name='foobarbaz',
-            arguments_schema={
-                'type': 'object',
-                'properties': {'message': {'type': 'string'}},
-                'required': ['message']
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 1
+
+        def test_creation_when_action_does_not_exist(self, api_client):
+            res = api_client.post('/api/v2/recipe/', {'name': 'Test Recipe',
+                                                    'action_id': 1234,
+                                                    'arguments': '{}'})
+            assert res.status_code == 400
+
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 0
+
+        def test_creation_when_arguments_are_invalid(self, api_client):
+            action = ActionFactory(
+                name='foobarbaz',
+                arguments_schema={
+                    'type': 'object',
+                    'properties': {'message': {'type': 'string'}},
+                    'required': ['message']
+                }
+            )
+            res = api_client.post('/api/v2/recipe/', {'name': 'Test Recipe',
+                                                    'enabled': True,
+                                                    'extra_filter_expression': 'true',
+                                                    'action_id': action.id,
+                                                    'arguments': {'message': ''}})
+            assert res.status_code == 400
+
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 0
+
+        def test_creation_when_identicon_seed_is_invalid(self, api_client):
+            action = ActionFactory()
+
+            res = api_client.post('/api/v2/recipe/', {
+                'name': 'Test Recipe',
+                'action_id': action.id,
+                'arguments': {},
+                'extra_filter_expression': 'whatever',
+                'enabled': True,
+                'identicon_seed': 'invalid_identicon_seed'
+            })
+            assert res.status_code == 400
+
+    @pytest.mark.django_db
+    class TestUpdates(object):
+        def test_it_can_edit_recipes(self, api_client):
+            recipe = RecipeFactory(name='unchanged', extra_filter_expression='true')
+            old_revision_id = recipe.revision_id
+
+            res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {
+                'name': 'changed',
+                'extra_filter_expression': 'false',
+            })
+            assert res.status_code == 200
+
+            recipe = Recipe.objects.all()[0]
+            assert recipe.name == 'changed'
+            assert recipe.filter_expression == 'false'
+            assert recipe.revision_id != old_revision_id
+
+        def test_it_can_change_action_for_recipes(self, api_client):
+            recipe = RecipeFactory()
+            action = ActionFactory()
+
+            res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {'action_id': action.id})
+            assert res.status_code == 200
+
+            recipe = Recipe.objects.get(pk=recipe.id)
+            assert recipe.action == action
+
+        def test_it_can_change_arguments_for_recipes(self, api_client):
+            recipe = RecipeFactory(arguments_json='{}')
+            action = ActionFactory(
+                name='foobarbaz',
+                arguments_schema={
+                    'type': 'object',
+                    'properties': {
+                        'message': {'type': 'string'},
+                        'checkbox': {'type': 'boolean'},
+                    },
+                    'required': ['message', 'checkbox']
+                }
+            )
+
+            arguments = {
+                'message': 'test message',
+                'checkbox': False,
             }
-        )
-        res = api_client.post('/api/v2/recipe/', {'name': 'Test Recipe',
-                                                  'enabled': True,
-                                                  'extra_filter_expression': 'true',
-                                                  'action_id': action.id,
-                                                  'arguments': {'message': ''}})
-        assert res.status_code == 400
 
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 0
+            res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {
+                'action_id': action.id,
+                'arguments': arguments,
+            })
+            assert res.status_code == 200, res.json()
+            recipe.refresh_from_db()
+            assert recipe.arguments == arguments
 
-    def test_creation_when_identicon_seed_is_invalid(self, api_client):
-        action = ActionFactory()
+            res = api_client.get('/api/v2/recipe/%s/' % recipe.id)
+            assert res.status_code == 200, res.json()
+            assert res.json()['arguments'] == arguments
 
-        res = api_client.post('/api/v2/recipe/', {
-            'name': 'Test Recipe',
-            'action_id': action.id,
-            'arguments': {},
-            'extra_filter_expression': 'whatever',
-            'enabled': True,
-            'identicon_seed': 'invalid_identicon_seed'
-        })
-        assert res.status_code == 400
-
-    def test_it_can_change_action_for_recipes(self, api_client):
-        recipe = RecipeFactory()
-        action = ActionFactory()
-
-        res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {'action_id': action.id})
-        assert res.status_code == 200
-
-        recipe = Recipe.objects.get(pk=recipe.id)
-        assert recipe.action == action
-
-    def test_it_can_change_arguments_for_recipes(self, api_client):
-        recipe = RecipeFactory(arguments_json='{}')
-        action = ActionFactory(
-            name='foobarbaz',
-            arguments_schema={
-                'type': 'object',
-                'properties': {
-                    'message': {'type': 'string'},
-                    'checkbox': {'type': 'boolean'},
-                },
-                'required': ['message', 'checkbox']
+            arguments = {
+                'message': 'second message',
+                'checkbox': True,
             }
-        )
+            res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {
+                'action_id': action.id,
+                'arguments': arguments,
+            })
+            assert res.status_code == 200, res.json()
+            recipe.refresh_from_db()
+            assert recipe.arguments == arguments
 
-        arguments = {
-            'message': 'test message',
-            'checkbox': False,
-        }
+            res = api_client.get('/api/v2/recipe/%s/' % recipe.id)
+            assert res.status_code == 200, res.json()
+            assert res.json()['arguments'] == arguments
 
-        res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {
-            'action_id': action.id,
-            'arguments': arguments,
-        })
-        assert res.status_code == 200, res.json()
-        recipe.refresh_from_db()
-        assert recipe.arguments == arguments
+        def test_it_can_delete_recipes(self, api_client):
+            recipe = RecipeFactory()
 
-        res = api_client.get('/api/v2/recipe/%s/' % recipe.id)
-        assert res.status_code == 200, res.json()
-        assert res.json()['arguments'] == arguments
+            res = api_client.delete('/api/v2/recipe/%s/' % recipe.id)
+            assert res.status_code == 204
 
-        arguments = {
-            'message': 'second message',
-            'checkbox': True,
-        }
-        res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {
-            'action_id': action.id,
-            'arguments': arguments,
-        })
-        assert res.status_code == 200, res.json()
-        recipe.refresh_from_db()
-        assert recipe.arguments == arguments
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 0
 
-        res = api_client.get('/api/v2/recipe/%s/' % recipe.id)
-        assert res.status_code == 200, res.json()
-        assert res.json()['arguments'] == arguments
+        def test_update_recipe_action(self, api_client):
+            r = RecipeFactory()
+            a = ActionFactory(name='test')
 
-    def test_it_can_delete_recipes(self, api_client):
-        recipe = RecipeFactory()
+            res = api_client.patch(f'/api/v2/recipe/{r.pk}/', {'action_id': a.id})
+            assert res.status_code == 200
 
-        res = api_client.delete('/api/v2/recipe/%s/' % recipe.id)
-        assert res.status_code == 204
+            r.refresh_from_db()
+            assert r.action == a
 
-        recipes = Recipe.objects.all()
-        assert recipes.count() == 0
+        def test_update_recipe_locale(self, api_client):
+            l1 = LocaleFactory(code='fr-FR')
+            l2 = LocaleFactory(code='en-US')
+            r = RecipeFactory(locales=[l1])
 
-    def test_available_if_admin_enabled(self, api_client, settings):
-        settings.ADMIN_ENABLED = True
-        res = api_client.get('/api/v2/recipe/')
-        assert res.status_code == 200
-        assert res.data['results'] == []
+            res = api_client.patch(f'/api/v2/recipe/{r.pk}/', {'locales': ['en-US']})
+            assert res.status_code == 200
 
-    def test_readonly_if_admin_disabled(self, api_client, settings):
-        settings.ADMIN_ENABLED = False
-        res = api_client.get('/api/v2/recipe/')
-        assert res.status_code == 200
+            r.refresh_from_db()
+            assert list(r.locales.all()) == [l2]
 
-        recipe = RecipeFactory(name='unchanged')
-        res = api_client.patch('/api/v2/recipe/%s/' % recipe.id, {'name': 'changed'})
-        assert res.status_code == 403
-        assert res.data['detail'] == AdminEnabledOrReadOnly.message
+        def test_update_recipe_country(self, api_client):
+            c1 = CountryFactory(code='US')
+            c2 = CountryFactory(code='CA')
+            r = RecipeFactory(countries=[c1])
 
-    def test_history(self, api_client):
-        recipe = RecipeFactory(name='version 1')
-        recipe.revise(name='version 2')
-        recipe.revise(name='version 3')
+            res = api_client.patch(f'/api/v2/recipe/{r.pk}/', {'countries': ['CA']})
+            assert res.status_code == 200
 
-        res = api_client.get('/api/v2/recipe/%s/history/' % recipe.id)
+            r.refresh_from_db()
+            assert list(r.countries.all()) == [c2]
 
-        assert res.data[0]['recipe']['name'] == 'version 3'
-        assert res.data[1]['recipe']['name'] == 'version 2'
-        assert res.data[2]['recipe']['name'] == 'version 1'
+        def test_update_recipe_channel(self, api_client):
+            c1 = ChannelFactory(slug='release')
+            c2 = ChannelFactory(slug='beta')
+            r = RecipeFactory(channels=[c1])
 
-    def test_it_can_enable_recipes(self, api_client):
-        recipe = RecipeFactory(enabled=False, approver=UserFactory())
+            res = api_client.patch(f'/api/v2/recipe/{r.pk}/', {'channels': ['beta']})
+            assert res.status_code == 200
 
-        res = api_client.post('/api/v2/recipe/%s/enable/' % recipe.id)
-        assert res.status_code == 200
-        assert res.data['enabled'] is True
+            r.refresh_from_db()
+            assert list(r.channels.all()) == [c2]
 
-        recipe = Recipe.objects.all()[0]
-        assert recipe.enabled
+    @pytest.mark.django_db
+    class TestDetail(object):
+        def test_history(self, api_client):
+            recipe = RecipeFactory(name='version 1')
+            recipe.revise(name='version 2')
+            recipe.revise(name='version 3')
 
-    def test_cannot_enable_unapproved_recipes(self, api_client):
-        recipe = RecipeFactory(enabled=False)
+            res = api_client.get('/api/v2/recipe/%s/history/' % recipe.id)
 
-        res = api_client.post('/api/v2/recipe/%s/enable/' % recipe.id)
-        assert res.status_code == 409
-        assert res.data['enabled'] == 'Cannot enable a recipe that is not approved.'
+            assert res.data[0]['recipe']['name'] == 'version 3'
+            assert res.data[1]['recipe']['name'] == 'version 2'
+            assert res.data[2]['recipe']['name'] == 'version 1'
 
-    def test_it_can_disable_recipes(self, api_client):
-        recipe = RecipeFactory(approver=UserFactory(), enabled=True)
+        def test_it_can_enable_recipes(self, api_client):
+            recipe = RecipeFactory(enabled=False, approver=UserFactory())
 
-        res = api_client.post('/api/v2/recipe/%s/disable/' % recipe.id)
-        assert res.status_code == 200
-        assert res.data['enabled'] is False
+            res = api_client.post('/api/v2/recipe/%s/enable/' % recipe.id)
+            assert res.status_code == 200
+            assert res.data['enabled'] is True
 
-        recipe = Recipe.objects.all()[0]
-        assert not recipe.is_approved
-        assert not recipe.enabled
+            recipe = Recipe.objects.all()[0]
+            assert recipe.enabled
 
-    def test_filtering_by_enabled_lowercase(self, api_client):
-        r1 = RecipeFactory(approver=UserFactory(), enabled=True)
-        RecipeFactory(enabled=False)
+        def test_cannot_enable_unapproved_recipes(self, api_client):
+            recipe = RecipeFactory(enabled=False)
 
-        res = api_client.get('/api/v2/recipe/?enabled=true')
-        assert res.status_code == 200
-        assert [r['id'] for r in res.data['results']] == [r1.id]
+            res = api_client.post('/api/v2/recipe/%s/enable/' % recipe.id)
+            assert res.status_code == 409
+            assert res.data['enabled'] == 'Cannot enable a recipe that is not approved.'
 
-    def test_filtering_by_enabled_fuzz(self, api_client):
-        """
-        Test that we don't return 500 responses when we get unexpected boolean filters.
+        def test_it_can_disable_recipes(self, api_client):
+            recipe = RecipeFactory(approver=UserFactory(), enabled=True)
 
-        This was a real case that showed up in our error logging.
-        """
-        url = "/api/v2/recipe/?enabled=javascript%3a%2f*<%2fscript><svg%2fonload%3d'%2b%2f'%2f%2b"
-        res = api_client.get(url)
-        assert res.status_code == 400
-        assert res.data == {
-            'messages': [
-                "'javascript:/*</script><svg/onload='+/'/+' value must be either True or False.",
-            ],
-        }
+            res = api_client.post('/api/v2/recipe/%s/disable/' % recipe.id)
+            assert res.status_code == 200
+            assert res.data['enabled'] is False
 
-    def test_list_view_includes_cache_headers(self, api_client):
-        res = api_client.get('/api/v2/recipe/')
-        assert res.status_code == 200
-        # It isn't important to assert a particular value for max_age
-        assert 'max-age=' in res['Cache-Control']
-        assert 'public' in res['Cache-Control']
+            recipe = Recipe.objects.all()[0]
+            assert not recipe.is_approved
+            assert not recipe.enabled
 
-    def test_detail_view_includes_cache_headers(self, api_client):
-        recipe = RecipeFactory()
-        res = api_client.get(f'/api/v2/recipe/{recipe.id}/')
-        assert res.status_code == 200
-        # It isn't important to assert a particular value for max-age
-        assert 'max-age=' in res['Cache-Control']
-        assert 'public' in res['Cache-Control']
+        def test_detail_view_includes_cache_headers(self, api_client):
+            recipe = RecipeFactory()
+            res = api_client.get(f'/api/v2/recipe/{recipe.id}/')
+            assert res.status_code == 200
+            # It isn't important to assert a particular value for max-age
+            assert 'max-age=' in res['Cache-Control']
+            assert 'public' in res['Cache-Control']
 
-    def test_list_sets_no_cookies(self, api_client):
-        res = api_client.get('/api/v2/recipe/')
-        assert res.status_code == 200
-        assert 'Cookies' not in res
+        def test_detail_sets_no_cookies(self, api_client):
+            recipe = RecipeFactory()
+            res = api_client.get('/api/v2/recipe/{id}/'.format(id=recipe.id))
+            assert res.status_code == 200
+            assert res.client.cookies == {}
 
-    def test_detail_sets_no_cookies(self, api_client):
-        recipe = RecipeFactory()
-        res = api_client.get('/api/v2/recipe/{id}/'.format(id=recipe.id))
-        assert res.status_code == 200
-        assert res.client.cookies == {}
+    @pytest.mark.django_db
+    class TestFiltering(object):
+        def test_filtering_by_enabled_lowercase(self, api_client):
+            r1 = RecipeFactory(approver=UserFactory(), enabled=True)
+            RecipeFactory(enabled=False)
 
-    def test_list_filter_status(self, api_client):
-        r1 = RecipeFactory(enabled=False)
-        r2 = RecipeFactory(approver=UserFactory(), enabled=True)
+            res = api_client.get('/api/v2/recipe/?enabled=true')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data['results']] == [r1.id]
 
-        res = api_client.get('/api/v2/recipe/?status=enabled')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 1
-        assert results[0]['id'] == r2.id
+        def test_filtering_by_enabled_fuzz(self, api_client):
+            """
+            Test that we don't return 500 responses when we get unexpected boolean filters.
 
-        res = api_client.get('/api/v2/recipe/?status=disabled')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 1
-        assert results[0]['id'] == r1.id
+            This was a real case that showed up in our error logging.
+            """
+            url = "/api/v2/recipe/?enabled=javascript%3a%2f*<%2fscript><svg%2fonload%3d'%2b%2f'%2f%2b"
+            res = api_client.get(url)
+            assert res.status_code == 400
+            assert res.data == {
+                'messages': [
+                    "'javascript:/*</script><svg/onload='+/'/+' value must be either True or False.",
+                ],
+            }
 
-    def test_list_filter_channels(self, api_client):
-        r1 = RecipeFactory(channels=[ChannelFactory(slug='beta')])
-        r2 = RecipeFactory(channels=[ChannelFactory(slug='release')])
+        def test_list_filter_status(self, api_client):
+            r1 = RecipeFactory(enabled=False)
+            r2 = RecipeFactory(approver=UserFactory(), enabled=True)
 
-        res = api_client.get('/api/v2/recipe/?channels=beta')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 1
-        assert results[0]['id'] == r1.id
+            res = api_client.get('/api/v2/recipe/?status=enabled')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 1
+            assert results[0]['id'] == r2.id
 
-        res = api_client.get('/api/v2/recipe/?channels=beta,release')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 2
-        for recipe in results:
-            assert recipe['id'] in [r1.id, r2.id]
+            res = api_client.get('/api/v2/recipe/?status=disabled')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 1
+            assert results[0]['id'] == r1.id
 
-    def test_list_filter_countries(self, api_client):
-        r1 = RecipeFactory(countries=[CountryFactory(code='US')])
-        r2 = RecipeFactory(countries=[CountryFactory(code='CA')])
+        def test_list_filter_channels(self, api_client):
+            r1 = RecipeFactory(channels=[ChannelFactory(slug='beta')])
+            r2 = RecipeFactory(channels=[ChannelFactory(slug='release')])
 
-        res = api_client.get('/api/v2/recipe/?countries=US')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 1
-        assert results[0]['id'] == r1.id
+            res = api_client.get('/api/v2/recipe/?channels=beta')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 1
+            assert results[0]['id'] == r1.id
 
-        res = api_client.get('/api/v2/recipe/?countries=US,CA')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 2
-        for recipe in results:
-            assert recipe['id'] in [r1.id, r2.id]
+            res = api_client.get('/api/v2/recipe/?channels=beta,release')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 2
+            for recipe in results:
+                assert recipe['id'] in [r1.id, r2.id]
 
-    def test_list_filter_locales(self, api_client):
-        r1 = RecipeFactory(locales=[LocaleFactory(code='en-US')])
-        r2 = RecipeFactory(locales=[LocaleFactory(code='fr-CA')])
+        def test_list_filter_countries(self, api_client):
+            r1 = RecipeFactory(countries=[CountryFactory(code='US')])
+            r2 = RecipeFactory(countries=[CountryFactory(code='CA')])
 
-        res = api_client.get('/api/v2/recipe/?locales=en-US')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 1
-        assert results[0]['id'] == r1.id
+            res = api_client.get('/api/v2/recipe/?countries=US')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 1
+            assert results[0]['id'] == r1.id
 
-        res = api_client.get('/api/v2/recipe/?locales=en-US,fr-CA')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 2
-        for recipe in results:
-            assert recipe['id'] in [r1.id, r2.id]
+            res = api_client.get('/api/v2/recipe/?countries=US,CA')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 2
+            for recipe in results:
+                assert recipe['id'] in [r1.id, r2.id]
 
-    def test_list_filter_text(self, api_client):
-        r1 = RecipeFactory(name='first', extra_filter_expression='1 + 1 == 2')
-        r2 = RecipeFactory(name='second', extra_filter_expression='one + one == two')
+        def test_list_filter_locales(self, api_client):
+            r1 = RecipeFactory(locales=[LocaleFactory(code='en-US')])
+            r2 = RecipeFactory(locales=[LocaleFactory(code='fr-CA')])
 
-        res = api_client.get('/api/v2/recipe/?text=first')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 1
-        assert results[0]['id'] == r1.id
+            res = api_client.get('/api/v2/recipe/?locales=en-US')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 1
+            assert results[0]['id'] == r1.id
 
-        res = api_client.get('/api/v2/recipe/?text=one')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 1
-        assert results[0]['id'] == r2.id
+            res = api_client.get('/api/v2/recipe/?locales=en-US,fr-CA')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 2
+            for recipe in results:
+                assert recipe['id'] in [r1.id, r2.id]
 
-        res = api_client.get('/api/v2/recipe/?text=t')
-        assert res.status_code == 200
-        results = res.data['results']
-        assert len(results) == 2
-        for recipe in results:
-            assert recipe['id'] in [r1.id, r2.id]
+        def test_list_filter_text(self, api_client):
+            r1 = RecipeFactory(name='first', extra_filter_expression='1 + 1 == 2')
+            r2 = RecipeFactory(name='second', extra_filter_expression='one + one == two')
 
-    def test_update_recipe_action(self, api_client):
-        r = RecipeFactory()
-        a = ActionFactory(name='test')
+            res = api_client.get('/api/v2/recipe/?text=first')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 1
+            assert results[0]['id'] == r1.id
 
-        res = api_client.patch(f'/api/v2/recipe/{r.pk}/', {'action_id': a.id})
-        assert res.status_code == 200
+            res = api_client.get('/api/v2/recipe/?text=one')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 1
+            assert results[0]['id'] == r2.id
 
-        r.refresh_from_db()
-        assert r.action == a
-
-    def test_update_recipe_locale(self, api_client):
-        l1 = LocaleFactory(code='fr-FR')
-        l2 = LocaleFactory(code='en-US')
-        r = RecipeFactory(locales=[l1])
-
-        res = api_client.patch(f'/api/v2/recipe/{r.pk}/', {'locales': ['en-US']})
-        assert res.status_code == 200
-
-        r.refresh_from_db()
-        assert list(r.locales.all()) == [l2]
-
-    def test_update_recipe_country(self, api_client):
-        c1 = CountryFactory(code='US')
-        c2 = CountryFactory(code='CA')
-        r = RecipeFactory(countries=[c1])
-
-        res = api_client.patch(f'/api/v2/recipe/{r.pk}/', {'countries': ['CA']})
-        assert res.status_code == 200
-
-        r.refresh_from_db()
-        assert list(r.countries.all()) == [c2]
-
-    def test_update_recipe_channel(self, api_client):
-        c1 = ChannelFactory(slug='release')
-        c2 = ChannelFactory(slug='beta')
-        r = RecipeFactory(channels=[c1])
-
-        res = api_client.patch(f'/api/v2/recipe/{r.pk}/', {'channels': ['beta']})
-        assert res.status_code == 200
-
-        r.refresh_from_db()
-        assert list(r.channels.all()) == [c2]
+            res = api_client.get('/api/v2/recipe/?text=t')
+            assert res.status_code == 200
+            results = res.data['results']
+            assert len(results) == 2
+            for recipe in results:
+                assert recipe['id'] in [r1.id, r2.id]
 
 
 @pytest.mark.django_db

--- a/recipe-server/normandy/recipes/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_api.py
@@ -495,6 +495,48 @@ class TestRecipeAPI(object):
             for recipe in results:
                 assert recipe['id'] in [r1.id, r2.id]
 
+        def test_list_filter_action_legacy(self, api_client):
+            a1 = ActionFactory()
+            a2 = ActionFactory()
+            r1 = RecipeFactory(action=a1)
+            r2 = RecipeFactory(action=a2)
+
+            assert a1.id != a2.id
+
+            res = api_client.get(f'/api/v2/recipe/?latest_revision__action={a1.id}')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data['results']] == [r1.id]
+
+            res = api_client.get(f'/api/v2/recipe/?latest_revision__action={a2.id}')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data['results']] == [r2.id]
+
+            assert a1.id != -1 and a2.id != -1
+            res = api_client.get(f'/api/v2/recipe/?latest_revision__action=-1')
+            assert res.status_code == 200
+            assert res.data['count'] == 0
+
+        def test_list_filter_action(self, api_client):
+            a1 = ActionFactory()
+            a2 = ActionFactory()
+            r1 = RecipeFactory(action=a1)
+            r2 = RecipeFactory(action=a2)
+
+            assert a1.name != a2.name
+
+            res = api_client.get(f'/api/v2/recipe/?action={a1.name}')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data['results']] == [r1.id]
+
+            res = api_client.get(f'/api/v2/recipe/?action={a2.name}')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data['results']] == [r2.id]
+
+            assert a1.name != "nonexistant" and a2.name != "nonexistant"
+            res = api_client.get(f'/api/v2/recipe/?action=nonexistant')
+            assert res.status_code == 200
+            assert res.data['count'] == 0
+
 
 @pytest.mark.django_db
 class TestRecipeRevisionAPI(object):

--- a/recipe-server/normandy/recipes/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_api.py
@@ -160,8 +160,8 @@ class TestRecipeAPI(object):
 
         def test_creation_when_action_does_not_exist(self, api_client):
             res = api_client.post('/api/v2/recipe/', {'name': 'Test Recipe',
-                                                    'action_id': 1234,
-                                                    'arguments': '{}'})
+                                                      'action_id': 1234,
+                                                      'arguments': '{}'})
             assert res.status_code == 400
 
             recipes = Recipe.objects.all()
@@ -177,10 +177,10 @@ class TestRecipeAPI(object):
                 }
             )
             res = api_client.post('/api/v2/recipe/', {'name': 'Test Recipe',
-                                                    'enabled': True,
-                                                    'extra_filter_expression': 'true',
-                                                    'action_id': action.id,
-                                                    'arguments': {'message': ''}})
+                                                      'enabled': True,
+                                                      'extra_filter_expression': 'true',
+                                                      'action_id': action.id,
+                                                      'arguments': {'message': ''}})
             assert res.status_code == 400
 
             recipes = Recipe.objects.all()
@@ -396,12 +396,16 @@ class TestRecipeAPI(object):
 
             This was a real case that showed up in our error logging.
             """
-            url = "/api/v2/recipe/?enabled=javascript%3a%2f*<%2fscript><svg%2fonload%3d'%2b%2f'%2f%2b"
+            url = (
+                "/api/v2/recipe/?enabled=javascript%3a%2f*"
+                "<%2fscript><svg%2fonload%3d'%2b%2f'%2f%2b"
+            )
             res = api_client.get(url)
             assert res.status_code == 400
             assert res.data == {
                 'messages': [
-                    "'javascript:/*</script><svg/onload='+/'/+' value must be either True or False.",
+                    "'javascript:/*</script><svg/onload='+/'/+' "
+                    "value must be either True or False.",
                 ],
             }
 


### PR DESCRIPTION
The first commit here is quite large, and is just be moving code around because there was no structure or order to the recipe API tests.

The second commit is the real meat of things, allowing both the v1 and v2 recipe APIs to be filtered by action name, like `/api/v2/recipe/?action=preference-experiment`.