### PR TITLE
1074: Immutable copy/paste values

### DIFF
--- a/recipe-server/client/control/components/recipes/RecipeDetails.js
+++ b/recipe-server/client/control/components/recipes/RecipeDetails.js
@@ -1,5 +1,5 @@
-import { Card, Icon } from 'antd';
-import { is, Map } from 'immutable';
+import { Card, Icon, Tooltip } from 'antd';
+import { is, List, Map } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -80,6 +80,15 @@ export class ArgumentsValue extends React.PureComponent {
     name: null,
   };
 
+  static stringifyImmutable(value) {
+    return JSON.stringify(value.toJS());
+  }
+
+  // Determine if an object is an instance of any of the given classes
+  compareInstances(obj, types) {
+    return types.some(type => obj instanceof type);
+  }
+
   renderBranchTable(branches) {
     const sumRatios = branches.map(branch => branch.get('ratio')).reduce((a, b) => a + b) || 1;
 
@@ -126,16 +135,21 @@ export class ArgumentsValue extends React.PureComponent {
       valueRender = this.renderBoolean;
     }
 
-    const textToCopy = value === undefined ? '' : value.toString();
+    let textToCopy = value === undefined ? '' : value.toString();
+    if (this.compareInstances(value, [List, Map])) {
+      textToCopy = ArgumentsValue.stringifyImmutable(value);
+    }
 
     return (
       <dd className="arguments-value">
         <div className="value">
           {valueRender(value)}
         </div>
-        <CopyToClipboard className="copy-icon" text={textToCopy}>
-          <Icon type="copy" />
-        </CopyToClipboard>
+        <Tooltip mouseEnterDelay={1} title="Copy to Clipboard" placement="top">
+          <CopyToClipboard className="copy-icon" text={textToCopy}>
+            <Icon type="copy" />
+          </CopyToClipboard>
+        </Tooltip>
       </dd>
     );
   }

--- a/recipe-server/client/control/components/recipes/RecipeDetails.js
+++ b/recipe-server/client/control/components/recipes/RecipeDetails.js
@@ -81,7 +81,7 @@ export class ArgumentsValue extends React.PureComponent {
   };
 
   static stringifyImmutable(value) {
-    return JSON.stringify(value.toJS());
+    return JSON.stringify(value);
   }
 
   // Determine if an object is an instance of any of the given classes

--- a/recipe-server/client/control/less/pages/recipe-details.less
+++ b/recipe-server/client/control/less/pages/recipe-details.less
@@ -56,6 +56,10 @@ dl.details {
         opacity: 1;
       }
     }
+
+    .anticon {
+      font-size: 2em;
+    }
   }
 
   h1 {

--- a/recipe-server/client/control/tests/components/recipes/test_RecipeDetails.js
+++ b/recipe-server/client/control/tests/components/recipes/test_RecipeDetails.js
@@ -42,8 +42,8 @@ describe('<ArgumentsValue>', () => {
 
   it('should render branches as a table', () => {
     const value = Immutable.fromJS([
-          { slug: 'one', value: 1, ratio: 1 },
-          { slug: 'two', value: 2, ratio: 3 },
+      { slug: 'one', value: 1, ratio: 1 },
+      { slug: 'two', value: 2, ratio: 3 },
     ]);
     const wrapper = shallow(<ArgumentsValue name="branches" value={value} />);
     const children = wrapper.find('.value').children();
@@ -58,5 +58,27 @@ describe('<ArgumentsValue>', () => {
     expect(content).toContain('two');
     expect(content).toContain('2');
     expect(content).toContain('75%');
+  });
+
+  describe('immutable objects', () => {
+    it('should convert Immutable objects into JSON strings', () => {
+      const testData = { slug: 'one', value: { test: 'fake-value' }, ratio: 1 };
+      // Test against Maps
+      let value = Immutable.fromJS(testData);
+      expect(ArgumentsValue.stringifyImmutable(value)).toBe(JSON.stringify(testData));
+
+      // Test against Lists
+      value = Immutable.fromJS([testData]);
+      expect(ArgumentsValue.stringifyImmutable(value)).toBe(JSON.stringify([testData]));
+    });
+
+    it('should use a JSON string for copy/pasting Immutable fields', () => {
+      const argumentVal = new Map({ slug: 'one', value: false, ratio: 1 });
+      const expectedText = ArgumentsValue.stringifyImmutable(argumentVal);
+
+      const wrapper = shallow(<ArgumentsValue value={argumentVal} />);
+      const copyPasteButton = wrapper.find('.copy-icon');
+      expect(copyPasteButton.props().text).toBe(expectedText);
+    });
   });
 });


### PR DESCRIPTION
Fixes #1074

- Changes Immutable copy/paste values (on Recipe Details page) to appropriate JSON strings
  - e.g. `List [ Map { "ratio": 1, ...` is now `[{"ratio": 1, ...`
- Increases size of copy/paste icons and adds a tooltip with helper text.
- Tests