### PR TITLE
Upgrade to eslint-plugin-mozilla 0.6.0, enable ESLint of jsm files and fix issues.

### DIFF
--- a/recipe-client-addon/.eslintrc.js
+++ b/recipe-client-addon/.eslintrc.js
@@ -19,10 +19,13 @@ module.exports = {
     "indent-legacy": ["warn", 2, {SwitchCase: 1}],
     "mozilla/no-aArgs": "warn",
     "mozilla/balanced-listeners": 0,
-    "mozilla/use-services": "error",
     "no-console": "warn",
     "no-shadow": ["error"],
-    "no-unused-vars": "error",
+    "no-unused-vars": ["error", {
+      "args": "none",
+      "vars": "all",
+      "varsIgnorePattern": "^Cc|Ci|Cu|Cr|EXPORTED_SYMBOLS"
+    }],
     "prefer-const": "warn",
     "semi": ["error", "always"],
     "no-return-await": ["error"],

--- a/recipe-client-addon/lib/PreferenceExperiments.jsm
+++ b/recipe-client-addon/lib/PreferenceExperiments.jsm
@@ -189,7 +189,7 @@ this.PreferenceExperiments = {
         log.info(`Stopping experiment "${experiment.name}" because its value changed`);
         await this.stop(experiment.name, {
           didResetValue: false,
-          reason: "user-preference-changed-sideload"
+          reason: "user-preference-changed-sideload",
         });
         continue;
       }

--- a/recipe-client-addon/lib/ShieldRecipeClient.jsm
+++ b/recipe-client-addon/lib/ShieldRecipeClient.jsm
@@ -27,19 +27,6 @@ XPCOMUtils.defineLazyModuleGetter(this, "TelemetryEvents",
 
 this.EXPORTED_SYMBOLS = ["ShieldRecipeClient"];
 
-const {PREF_STRING, PREF_BOOL, PREF_INT} = Ci.nsIPrefBranch;
-
-const REASONS = {
-  APP_STARTUP: 1,      // The application is starting up.
-  APP_SHUTDOWN: 2,     // The application is shutting down.
-  ADDON_ENABLE: 3,     // The add-on is being enabled.
-  ADDON_DISABLE: 4,    // The add-on is being disabled. (Also sent during uninstallation)
-  ADDON_INSTALL: 5,    // The add-on is being installed.
-  ADDON_UNINSTALL: 6,  // The add-on is being uninstalled.
-  ADDON_UPGRADE: 7,    // The add-on is being upgraded.
-  ADDON_DOWNGRADE: 8,  // The add-on is being downgraded.
-};
-const PREF_DEV_MODE = "extensions.shield-recipe-client.dev_mode";
 const PREF_LOGGING_LEVEL = "extensions.shield-recipe-client.logging.level";
 const SHIELD_INIT_NOTIFICATION = "shield-init-complete";
 

--- a/recipe-client-addon/package.json
+++ b/recipe-client-addon/package.json
@@ -10,14 +10,14 @@
     "watch": "webpack --config ./webpack.config.js --watch",
     "build": "webpack --config ./webpack.config.js",
     "lint": "npm run lint-js; npm run lint-css;",
-    "lint-js": "eslint lib content bootstrap.js webpack.config.js test || true",
+    "lint-js": "eslint --ext js,jsm lib content bootstrap.js webpack.config.js test || true",
     "lint-css": "stylelint '**/*.css' --config .stylelintrc || true"
   },
   "devDependencies": {
     "babili-webpack-plugin": "0.1.2",
     "eslint": "4.10.0",
     "eslint-config-normandy": "1.0.0",
-    "eslint-plugin-mozilla": "0.4.9",
+    "eslint-plugin-mozilla": "0.6.0",
     "eslint-plugin-no-unsanitized": "2.0.1",
     "eslint-plugin-react": "^7.1.0",
     "license-webpack-plugin": "0.5.1",

--- a/recipe-client-addon/test/browser/browser_AddonStudies.js
+++ b/recipe-client-addon/test/browser/browser_AddonStudies.js
@@ -268,7 +268,7 @@ decorate_task(
       ["unenroll", "addon_study", study.name, {
         addonId,
         addonVersion: study.addonVersion,
-        reason: "test-reason"
+        reason: "test-reason",
       }],
       "stop should send the correct telemetry event"
     );


### PR DESCRIPTION
I'm preparing to change m-c's no-unused-vars rule for .jsm files to include global variables as well as normal ones. As a result of early tests, I picked up some issues in SheildRecipeClient.jsm - there's some unused variables that don't appear to be used anywhere.

Also included in this patch is an upgrade the plugin to 0.6.0 to get the necessary extra rules. As a result mozilla/use-services is now defined by default.

I also realised that the repository wasn't linting the .jsm files (though they're all pretty good!), so I fixed that as well.

Finally, there's a couple of comma-dangle fixes that Lint was complaining about (one was already there, not sure why automation hadn't picked it up).
