### PR TITLE
Bug 1435210 - Provide a reason when stopping preference studies from actions.

### DIFF
--- a/recipe-server/client/actions/preference-experiment/index.js
+++ b/recipe-server/client/actions/preference-experiment/index.js
@@ -121,7 +121,10 @@ export async function postExecutionHook(normandy) {
   for (const experiment of activeExperiments) {
     if (!seenExperimentNames.includes(experiment.name)) {
       // eslint-disable-next-line no-await-in-loop
-      await normandy.preferenceExperiments.stop(experiment.name, true);
+      await normandy.preferenceExperiments.stop(experiment.name, {
+        resetValue: true,
+        reason: 'recipe-not-seen',
+      });
     }
   }
 }


### PR DESCRIPTION
This should explain the `reason: unknown` data for preference study unenrollment we've seen in early Telemetry data. The `stop` method called here is [this method on `PreferenceExperiments.jsm](https://github.com/mozilla/normandy/blob/b9ebeeb4867e61b59dc10331820a44c702e1d35e/recipe-client-addon/lib/PreferenceExperiments.jsm#L469).