### PR TITLE
Fix #1165 - Allow ordering the extension API.

### DIFF
--- a/recipe-server/normandy/recipes/tests/api/v1/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v1/test_api.py
@@ -1,5 +1,4 @@
 import hashlib
-from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from django.db import connection
@@ -572,7 +571,6 @@ class TestRecipeAPI(object):
             res = api_client.get('/api/v1/recipe/?action=nonexistant')
             assert res.status_code == 200
             assert res.data == []
-
 
     @pytest.mark.django_db
     class TestSigned(object):

--- a/recipe-server/normandy/recipes/tests/api/v1/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v1/test_api.py
@@ -579,7 +579,7 @@ class TestRecipeAPI(object):
             r1 = RecipeFactory(updated=yesterday)
             r2 = RecipeFactory(updated=now)
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=last_updated')
+            res = api_client.get('/api/v2/recipe/?ordering=last_updated')
             assert res.status_code == 200
             assert [r['id'] for r in res.data['results']] == [r1.id, r2.id]
 
@@ -598,6 +598,20 @@ class TestRecipeAPI(object):
             res = api_client.get(f'/api/v2/recipe/?ordering=-name')
             assert res.status_code == 200
             assert [r['id'] for r in res.data['results']] == [r2.id, r1.id]
+
+        def test_order_bogus(self, api_client):
+            """Test that filtering by an unknown key doesn't change the sort order"""
+            r1 = RecipeFactory(name="a")
+            r2 = RecipeFactory(name="b")
+
+            res = api_client.get(f'/api/v2/recipe/?ordering=bogus')
+            assert res.status_code == 200
+            first_ordering = [r['id'] for r in res.data['results']]
+
+            res = api_client.get(f'/api/v2/recipe/?ordering=-bogus')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data['results']] == first_ordering
+
 
     @pytest.mark.django_db
     class TestSigned(object):

--- a/recipe-server/normandy/recipes/tests/api/v1/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v1/test_api.py
@@ -548,7 +548,7 @@ class TestRecipeAPI(object):
             assert [r['id'] for r in res.data] == [r2.id]
 
             assert a1.id != -1 and a2.id != -1
-            res = api_client.get(f'/api/v1/recipe/?latest_revision__action=-1')
+            res = api_client.get('/api/v1/recipe/?latest_revision__action=-1')
             assert res.status_code == 200
             assert res.data == []
 
@@ -569,7 +569,7 @@ class TestRecipeAPI(object):
             assert [r['id'] for r in res.data] == [r2.id]
 
             assert a1.name != "nonexistant" and a2.name != "nonexistant"
-            res = api_client.get(f'/api/v1/recipe/?action=nonexistant')
+            res = api_client.get('/api/v1/recipe/?action=nonexistant')
             assert res.status_code == 200
             assert res.data == []
 
@@ -579,38 +579,38 @@ class TestRecipeAPI(object):
             r1 = RecipeFactory(updated=yesterday)
             r2 = RecipeFactory(updated=now)
 
-            res = api_client.get('/api/v2/recipe/?ordering=last_updated')
+            res = api_client.get('/api/v1/recipe/?ordering=last_updated')
             assert res.status_code == 200
-            assert [r['id'] for r in res.data['results']] == [r1.id, r2.id]
+            assert [r['id'] for r in res.data] == [r1.id, r2.id]
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=-last_updated')
+            res = api_client.get('/api/v1/recipe/?ordering=-last_updated')
             assert res.status_code == 200
-            assert [r['id'] for r in res.data['results']] == [r2.id, r1.id]
+            assert [r['id'] for r in res.data] == [r2.id, r1.id]
 
         def test_order_name(self, api_client):
             r1 = RecipeFactory(name="a")
             r2 = RecipeFactory(name="b")
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=name')
+            res = api_client.get('/api/v1/recipe/?ordering=name')
             assert res.status_code == 200
-            assert [r['id'] for r in res.data['results']] == [r1.id, r2.id]
+            assert [r['id'] for r in res.data] == [r1.id, r2.id]
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=-name')
+            res = api_client.get('/api/v1/recipe/?ordering=-name')
             assert res.status_code == 200
-            assert [r['id'] for r in res.data['results']] == [r2.id, r1.id]
+            assert [r['id'] for r in res.data] == [r2.id, r1.id]
 
         def test_order_bogus(self, api_client):
             """Test that filtering by an unknown key doesn't change the sort order"""
             r1 = RecipeFactory(name="a")
             r2 = RecipeFactory(name="b")
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=bogus')
+            res = api_client.get('/api/v1/recipe/?ordering=bogus')
             assert res.status_code == 200
-            first_ordering = [r['id'] for r in res.data['results']]
+            first_ordering = [r['id'] for r in res.data]
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=-bogus')
+            res = api_client.get('/api/v1/recipe/?ordering=-bogus')
             assert res.status_code == 200
-            assert [r['id'] for r in res.data['results']] == first_ordering
+            assert [r['id'] for r in res.data] == first_ordering
 
 
     @pytest.mark.django_db

--- a/recipe-server/normandy/recipes/tests/api/v1/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v1/test_api.py
@@ -573,45 +573,6 @@ class TestRecipeAPI(object):
             assert res.status_code == 200
             assert res.data == []
 
-        def test_order_last_updated(self, api_client):
-            now = datetime.now()
-            yesterday = now - timedelta(days=1)
-            r1 = RecipeFactory(updated=yesterday)
-            r2 = RecipeFactory(updated=now)
-
-            res = api_client.get('/api/v1/recipe/?ordering=last_updated')
-            assert res.status_code == 200
-            assert [r['id'] for r in res.data] == [r1.id, r2.id]
-
-            res = api_client.get('/api/v1/recipe/?ordering=-last_updated')
-            assert res.status_code == 200
-            assert [r['id'] for r in res.data] == [r2.id, r1.id]
-
-        def test_order_name(self, api_client):
-            r1 = RecipeFactory(name="a")
-            r2 = RecipeFactory(name="b")
-
-            res = api_client.get('/api/v1/recipe/?ordering=name')
-            assert res.status_code == 200
-            assert [r['id'] for r in res.data] == [r1.id, r2.id]
-
-            res = api_client.get('/api/v1/recipe/?ordering=-name')
-            assert res.status_code == 200
-            assert [r['id'] for r in res.data] == [r2.id, r1.id]
-
-        def test_order_bogus(self, api_client):
-            """Test that filtering by an unknown key doesn't change the sort order"""
-            r1 = RecipeFactory(name="a")
-            r2 = RecipeFactory(name="b")
-
-            res = api_client.get('/api/v1/recipe/?ordering=bogus')
-            assert res.status_code == 200
-            first_ordering = [r['id'] for r in res.data]
-
-            res = api_client.get('/api/v1/recipe/?ordering=-bogus')
-            assert res.status_code == 200
-            assert [r['id'] for r in res.data] == first_ordering
-
 
     @pytest.mark.django_db
     class TestSigned(object):

--- a/recipe-server/normandy/recipes/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_api.py
@@ -568,6 +568,20 @@ class TestRecipeAPI(object):
             assert res.status_code == 200
             assert [r['id'] for r in res.data['results']] == [r2.id, r1.id]
 
+        def test_order_bogus(self, api_client):
+            """Test that filtering by an unknown key doesn't change the sort order"""
+            RecipeFactory(name="a")
+            RecipeFactory(name="b")
+
+            res = api_client.get('/api/v2/recipe/?ordering=bogus')
+            assert res.status_code == 200
+            first_ordering = [r['id'] for r in res.data['results']]
+
+            res = api_client.get('/api/v2/recipe/?ordering=-bogus')
+            assert res.status_code == 200
+            assert [r['id'] for r in res.data['results']] == first_ordering
+
+
 
 @pytest.mark.django_db
 class TestRecipeRevisionAPI(object):

--- a/recipe-server/normandy/recipes/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_api.py
@@ -582,7 +582,6 @@ class TestRecipeAPI(object):
             assert [r['id'] for r in res.data['results']] == first_ordering
 
 
-
 @pytest.mark.django_db
 class TestRecipeRevisionAPI(object):
     def test_it_works(self, api_client):

--- a/recipe-server/normandy/recipes/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_api.py
@@ -517,7 +517,7 @@ class TestRecipeAPI(object):
             assert [r['id'] for r in res.data['results']] == [r2.id]
 
             assert a1.id != -1 and a2.id != -1
-            res = api_client.get(f'/api/v2/recipe/?latest_revision__action=-1')
+            res = api_client.get('/api/v2/recipe/?latest_revision__action=-1')
             assert res.status_code == 200
             assert res.data['count'] == 0
 
@@ -538,7 +538,7 @@ class TestRecipeAPI(object):
             assert [r['id'] for r in res.data['results']] == [r2.id]
 
             assert a1.name != "nonexistant" and a2.name != "nonexistant"
-            res = api_client.get(f'/api/v2/recipe/?action=nonexistant')
+            res = api_client.get('/api/v2/recipe/?action=nonexistant')
             assert res.status_code == 200
             assert res.data['count'] == 0
 
@@ -548,11 +548,11 @@ class TestRecipeAPI(object):
             r1 = RecipeFactory(updated=yesterday)
             r2 = RecipeFactory(updated=now)
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=last_updated')
+            res = api_client.get('/api/v2/recipe/?ordering=last_updated')
             assert res.status_code == 200
             assert [r['id'] for r in res.data['results']] == [r1.id, r2.id]
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=-last_updated')
+            res = api_client.get('/api/v2/recipe/?ordering=-last_updated')
             assert res.status_code == 200
             assert [r['id'] for r in res.data['results']] == [r2.id, r1.id]
 
@@ -560,11 +560,11 @@ class TestRecipeAPI(object):
             r1 = RecipeFactory(name="a")
             r2 = RecipeFactory(name="b")
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=name')
+            res = api_client.get('/api/v2/recipe/?ordering=name')
             assert res.status_code == 200
             assert [r['id'] for r in res.data['results']] == [r1.id, r2.id]
 
-            res = api_client.get(f'/api/v2/recipe/?ordering=-name')
+            res = api_client.get('/api/v2/recipe/?ordering=-name')
             assert res.status_code == 200
             assert [r['id'] for r in res.data['results']] == [r2.id, r1.id]
 

--- a/recipe-server/normandy/studies/api/v2/views.py
+++ b/recipe-server/normandy/studies/api/v2/views.py
@@ -2,10 +2,18 @@ from django.db.models import Q
 
 from rest_framework import permissions, viewsets
 
+from normandy.base.api.filters import AliasedOrderingFilter
 from normandy.base.api.mixins import CachingViewsetMixin
 from normandy.base.api.permissions import AdminEnabledOrReadOnly
 from normandy.studies.api.v2.serializers import ExtensionSerializer
 from normandy.studies.models import Extension
+
+
+class ExtensionOrderingFilter(AliasedOrderingFilter):
+    aliases = {
+        'id': ('id', 'ID'),
+        'name': ('name', 'Name'),
+    }
 
 
 class ExtensionViewSet(CachingViewsetMixin, viewsets.ModelViewSet):
@@ -15,6 +23,7 @@ class ExtensionViewSet(CachingViewsetMixin, viewsets.ModelViewSet):
         AdminEnabledOrReadOnly,
         permissions.DjangoModelPermissionsOrAnonReadOnly,
     ]
+    filter_backends = [ExtensionOrderingFilter]
 
     def get_queryset(self):
         queryset = self.queryset

--- a/recipe-server/normandy/studies/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/studies/tests/api/v2/test_api.py
@@ -163,3 +163,16 @@ class TestExtensionAPI(object):
         res = api_client.get(f'/api/v2/extension/?ordering=-id')
         assert res.status_code == 200
         assert [r['id'] for r in res.data['results']] == [e2.id, e1.id]
+
+    def test_order_bogus(self, api_client):
+        """Test that filtering by an unknown key doesn't change the sort order"""
+        ExtensionFactory()
+        ExtensionFactory()
+
+        res = api_client.get(f'/api/v2/extension/?ordering=bogus')
+        assert res.status_code == 200
+        first_ordering = [r['id'] for r in res.data['results']]
+
+        res = api_client.get(f'/api/v2/extension/?ordering=-bogus')
+        assert res.status_code == 200
+        assert [r['id'] for r in res.data['results']] == first_ordering

--- a/recipe-server/normandy/studies/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/studies/tests/api/v2/test_api.py
@@ -138,3 +138,28 @@ class TestExtensionAPI(object):
         # Download the XPI to make sure the url is actually good
         res = api_client.get(res.data['xpi'], follow=True)
         assert res.status_code == 200
+
+    def test_order_name(self, api_client):
+        e1 = ExtensionFactory(name="a")
+        e2 = ExtensionFactory(name="b")
+
+        res = api_client.get(f'/api/v2/extension/?ordering=name')
+        assert res.status_code == 200
+        assert [r['id'] for r in res.data['results']] == [e1.id, e2.id]
+
+        res = api_client.get(f'/api/v2/extension/?ordering=-name')
+        assert res.status_code == 200
+        assert [r['id'] for r in res.data['results']] == [e2.id, e1.id]
+
+    def test_order_id(self, api_client):
+        e1 = ExtensionFactory()
+        e2 = ExtensionFactory()
+        assert e1.id < e2.id
+
+        res = api_client.get(f'/api/v2/extension/?ordering=id')
+        assert res.status_code == 200
+        assert [r['id'] for r in res.data['results']] == [e1.id, e2.id]
+
+        res = api_client.get(f'/api/v2/extension/?ordering=-id')
+        assert res.status_code == 200
+        assert [r['id'] for r in res.data['results']] == [e2.id, e1.id]


### PR DESCRIPTION
This adds the ability to change the sort order of the extensions API, and adds tests for sorting the extensions API and the recipes API (which had sorting, but no tests for sorting).