### PR TITLE
Django 1.11.11

### DIFF
--- a/recipe-server/normandy/control/templatetags/normandy_logout_button.py
+++ b/recipe-server/normandy/control/templatetags/normandy_logout_button.py
@@ -1,6 +1,6 @@
 from django import template
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 

--- a/recipe-server/normandy/control/tests/test_templatetags.py
+++ b/recipe-server/normandy/control/tests/test_templatetags.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from normandy.control.templatetags.normandy_logout_button import logout_button
 

--- a/recipe-server/normandy/control/urls.py
+++ b/recipe-server/normandy/control/urls.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib.auth.views import login, logout_then_login
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 
 from normandy.control import views
 

--- a/recipe-server/normandy/recipes/api/v1/views.py
+++ b/recipe-server/normandy/recipes/api/v1/views.py
@@ -74,8 +74,8 @@ class ActionImplementationView(generics.RetrieveAPIView):
 
 
 class RecipeFilters(django_filters.FilterSet):
-    enabled = CaseInsensitiveBooleanFilter(name='enabled', lookup_expr='eq')
-    action = django_filters.CharFilter(name='latest_revision__action__name')
+    enabled = CaseInsensitiveBooleanFilter(field_name='enabled', lookup_expr='eq')
+    action = django_filters.CharFilter(field_name='latest_revision__action__name')
 
     class Meta:
         model = Recipe

--- a/recipe-server/normandy/recipes/api/v2/views.py
+++ b/recipe-server/normandy/recipes/api/v2/views.py
@@ -36,8 +36,8 @@ class ActionViewSet(CachingViewsetMixin, viewsets.ReadOnlyModelViewSet):
 
 
 class RecipeFilters(django_filters.FilterSet):
-    enabled = CaseInsensitiveBooleanFilter(name='enabled', lookup_expr='eq')
-    action = django_filters.CharFilter(name='latest_revision__action__name')
+    enabled = CaseInsensitiveBooleanFilter(field_name='enabled', lookup_expr='eq')
+    action = django_filters.CharFilter(field_name='latest_revision__action__name')
 
     class Meta:
         model = Recipe

--- a/recipe-server/normandy/recipes/models.py
+++ b/recipe-server/normandy/recipes/models.py
@@ -116,7 +116,10 @@ class Recipe(DirtyFieldsMixin, models.Model):
                                           related_name='approved_for_recipe')
 
     enabled = models.BooleanField(default=False)
-    signature = models.OneToOneField(Signature, related_name='recipe', null=True, blank=True)
+    signature = models.OneToOneField(
+        Signature, related_name='recipe', null=True, blank=True,
+        on_delete=models.CASCADE
+    )
 
     class Meta:
         ordering = ['-enabled', '-latest_revision__updated']
@@ -308,7 +311,7 @@ class RecipeRevision(models.Model):
     id = models.CharField(max_length=64, primary_key=True)
     parent = models.OneToOneField('self', null=True, on_delete=models.CASCADE,
                                   related_name='child')
-    recipe = models.ForeignKey(Recipe, related_name='revisions')
+    recipe = models.ForeignKey(Recipe, related_name='revisions', on_delete=models.CASCADE)
     created = models.DateTimeField(default=timezone.now)
     updated = models.DateTimeField(default=timezone.now)
     user = models.ForeignKey(User, on_delete=models.SET_NULL, related_name='recipe_revisions',
@@ -316,7 +319,7 @@ class RecipeRevision(models.Model):
     comment = models.TextField()
 
     name = models.CharField(max_length=255)
-    action = models.ForeignKey('Action', related_name='recipe_revisions')
+    action = models.ForeignKey('Action', related_name='recipe_revisions', on_delete=models.CASCADE)
     arguments_json = models.TextField(default='{}', validators=[validate_json])
     extra_filter_expression = models.TextField(blank=False)
     channels = models.ManyToManyField(Channel)
@@ -418,7 +421,11 @@ class RecipeRevision(models.Model):
 
 
 class ApprovalRequest(models.Model):
-    revision = models.OneToOneField(RecipeRevision, related_name='approval_request')
+    revision = models.OneToOneField(
+        RecipeRevision,
+        related_name='approval_request',
+        on_delete=models.CASCADE,
+    )
     created = models.DateTimeField(default=timezone.now)
     creator = models.ForeignKey(User, on_delete=models.SET_NULL, related_name='approval_requests',
                                 null=True)
@@ -526,7 +533,10 @@ class Action(DirtyFieldsMixin, models.Model):
     implementation = models.TextField()
     implementation_hash = models.CharField(max_length=71, editable=False)
     arguments_schema_json = models.TextField(default='{}', validators=[validate_json])
-    signature = models.OneToOneField(Signature, related_name='action', null=True, blank=True)
+    signature = models.OneToOneField(
+        Signature, related_name='action', null=True, blank=True,
+        on_delete=models.CASCADE,
+    )
 
     errors = {
         'duplicate_branch_slug': (

--- a/recipe-server/normandy/selfrepair/tests/test_views.py
+++ b/recipe-server/normandy/selfrepair/tests/test_views.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 

--- a/recipe-server/normandy/settings.py
+++ b/recipe-server/normandy/settings.py
@@ -25,6 +25,7 @@ class Core(Configuration):
         'raven.contrib.django.raven_compat',
         'webpack_loader',
         'corsheaders',
+        'django_filters',
 
         'django.contrib.admin',
         'django.contrib.auth',

--- a/recipe-server/requirements/default.txt
+++ b/recipe-server/requirements/default.txt
@@ -13,9 +13,9 @@ dj-database-url==0.3.0 \
     --hash=sha256:ca01768fdecde134301f3170743226f60edff5c3935f12437378ebd911506353
 dj-inmemorystorage==1.4.0 \
     --hash=sha256:35a37fac5955c3d9519fcab0cc7d88b43dc9bc95ffd2a6312badfa489ed30fd2
-Django==1.10.8 \
-    --hash=sha256:ffdc7e938391ae3c2ee8ff82e0b4444e4e6bb15c99d00770285233d42aaf33d6 \
-    --hash=sha256:d4ef83bd326573c00972cb9429beb396d210341a636e4b816fc9b3f505c498bb
+Django==1.11.11 \
+    --hash=sha256:fd186d544c7c2f835668cf11f77be071307c9eb22615a5b3a16bdb14c8357f41 \
+    --hash=sha256:74077d7309b48b97dacdac2dfb35c968028becf00a7a684e7f29b2af1b980edc
 django-configurations==1.0 \
     --hash=sha256:98a14951cd0870d0343fe9c243172dc110353b430c3e06a87a90dc7bc82b0b75 \
     --hash=sha256:93f4a09134145f4388c2ec2183ce623b1b57fd04e3e0d2a2cf3b32fadc8f9464
@@ -24,9 +24,9 @@ django-countries==3.4.1 \
     --hash=sha256:23c6b5455a2e68ed02601cee0d3c80481965d0c3a6bd2f07ca56902b0a4c55a6
 django-dirtyfields==1.2.1 \
     --hash=sha256:6f2e988121323cd8a15cef3035f5ea5942d3e41f76c3b2e1de0b81761a000c94
-django-filter==1.0.1 \
-    --hash=sha256:03ab2895e086aa579110a8945d7d9c5d28c4b57060cfc697cb5c74a18021fec4 \
-    --hash=sha256:7cca9dab22c72df734ba24fb81ca018fdb6d2020c840e758d473dcedd341aa7b
+django-filter==1.1.0 \
+    --hash=sha256:ec0ef1ba23ef95b1620f5d481334413700fb33f45cd76d56a63f4b0b1d76976a \
+    --hash=sha256:ea204242ea83790e1512c9d0d8255002a652a6f4986e93cee664f28955ba0c22
 django-mozilla-product-details==0.11.1 \
     --hash=sha256:6a9bf2898deae722876bd19eb874bfdcbe884f99c8096c2ddd6cdea8b95d4fa0
 django-npm==0.1.4 \

--- a/recipe-server/requirements/default.txt
+++ b/recipe-server/requirements/default.txt
@@ -19,9 +19,9 @@ Django==1.11.11 \
 django-configurations==1.0 \
     --hash=sha256:98a14951cd0870d0343fe9c243172dc110353b430c3e06a87a90dc7bc82b0b75 \
     --hash=sha256:93f4a09134145f4388c2ec2183ce623b1b57fd04e3e0d2a2cf3b32fadc8f9464
-django-countries==3.4.1 \
-    --hash=sha256:5bdda9d2c3473b519371428d88517f29befad7e35dfc489e8b0f95cb2aa941dc \
-    --hash=sha256:23c6b5455a2e68ed02601cee0d3c80481965d0c3a6bd2f07ca56902b0a4c55a6
+django-countries==5.1.1 \
+    --hash=sha256:f7f450fb58cdf125daa15dd49a1f578337f69ee7df546d36f135207c515a9c6e \
+    --hash=sha256:3c7cfeb396150b899116e46b5c6109e13b880db96792f9d5d4a953a9b9085111
 django-dirtyfields==1.2.1 \
     --hash=sha256:6f2e988121323cd8a15cef3035f5ea5942d3e41f76c3b2e1de0b81761a000c94
 django-filter==1.1.0 \


### PR DESCRIPTION
I don't know how else to test this. I started the server and clicked around a bit but I'm still not sure I know what I'm doing. At least the tests pass without and deprecation warnings *we* can immediately do something about:

```
▶ PYTHONWARNINGS=d pytest
/Users/peterbe/virtualenvs/recipe-server/bin/../lib/python3.6/site.py:165: DeprecationWarning: 'U' mode is deprecated
  f = open(fullname, "rU")
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/importlib/_bootstrap_external.py:426: ImportWarning: Not importing directory /Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/sphinxcontrib: missing __init__
  _warnings.warn(msg.format(portions[0]), ImportWarning)
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/importlib/_bootstrap_external.py:426: ImportWarning: Not importing directory /Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/backports: missing __init__
  _warnings.warn(msg.format(portions[0]), ImportWarning)
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/_pytest/assertion/rewrite.py:7: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_testrail/conftest.py:3: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from .plugin import TestRailPlugin
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_testrail/conftest.py:4: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from .testrail_api import APIClient
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/plugin.py:17: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from .django_compat import is_django_unittest
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/plugin.py:18: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from .fixtures import (_django_db_setup, _live_server_helper, admin_client,
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/fixtures.py:10: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from . import live_server_helper
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/live_server_helper.py:3: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from .lazy_django import get_django_version
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/fixtures.py:11: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from .db_reuse import (monkey_patch_creation_for_db_reuse,
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/fixtures.py:13: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from .django_compat import is_django_unittest
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/fixtures.py:14: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from .lazy_django import get_django_version, skip_if_no_django
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/plugin.py:22: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  from .lazy_django import django_settings_is_configured, skip_if_no_django
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/plugin.py:50: DeprecationWarning: type argument to addoption() is a string 'string'. For parsearg this should be a type. (options: ('--ds',))
  help='Set DJANGO_SETTINGS_MODULE.')
/Users/peterbe/virtualenvs/recipe-server/lib/python3.6/site-packages/pytest_django/plugin.py:53: DeprecationWarning: type argument to addoption() is a string 'string'. For parsearg this should be a type. (options: ('--dc',))
  help='Set DJANGO_CONFIGURATION.')
================================================================================================ test session starts ================================================================================================
platform darwin -- Python 3.6.4, pytest-3.0.2, py-1.4.31, pluggy-0.3.1
django settings: normandy.settings (from ini file)
rootdir: /Users/peterbe/dev/MOZILLA/NORMANDY/normandy/recipe-server, inifile: pytest.ini
plugins: testrail-0.0.11, mock-0.11.0, django-2.9.1
collected 352 items

normandy/base/tests/test_api.py ....x..............
normandy/base/tests/test_auth_backends.py ...
normandy/base/tests/test_decorators.py ...
normandy/base/tests/test_middleware.py ....
normandy/base/tests/test_renderers.py .
normandy/base/tests/test_storage.py .....
normandy/base/tests/test_templatetags.py ..
normandy/base/tests/test_urls.py .
normandy/base/tests/test_utils.py ........
normandy/base/tests/test_views.py ..
normandy/control/tests/test_templatetags.py ..
normandy/health/tests/test_api.py ........
normandy/recipes/tests/test_admin.py ..
normandy/recipes/tests/test_checks.py ....
normandy/recipes/tests/test_commands.py ....................
normandy/recipes/tests/test_factories.py ...
normandy/recipes/tests/test_geolocation.py ....
normandy/recipes/tests/test_models.py ................................................
normandy/recipes/tests/test_signing.py ......................
normandy/recipes/tests/test_storage.py .
normandy/recipes/tests/test_utils.py .......
normandy/recipes/tests/test_validators.py .
normandy/recipes/tests/api/v1/test_api.py .........................................................................
normandy/recipes/tests/api/v1/test_serializers.py ..........
normandy/recipes/tests/api/v2/test_api.py ..................................................................
normandy/recipes/tests/api/v2/test_serializers.py ......
normandy/recipes/tests/api/v2/test_shield_identicon.py ...
normandy/selfrepair/tests/test_views.py ....
normandy/studies/tests/test_models.py .
normandy/studies/tests/api/v2/test_api.py ..................
normandy/studies/tests/api/v2/test_serializers.py .

====================================================================================== 351 passed, 1 xfailed in 30.48 seconds =======================================================================================
```