### PR TITLE
v2 api index uses v1 urls, fixed #1008

### DIFF
--- a/recipe-server/normandy/base/tests/test_api.py
+++ b/recipe-server/normandy/base/tests/test_api.py
@@ -63,7 +63,6 @@ class TestApiRootV1(object):
 
 @pytest.mark.django_db
 class TestApiRootV2(object):
-    @pytest.mark.xfail(reason='issue #1008')
     def test_it_works(self, api_client):
         res = api_client.get('/api/v2/')
         assert res.status_code == 200

--- a/recipe-server/normandy/recipes/urls.py
+++ b/recipe-server/normandy/recipes/urls.py
@@ -25,8 +25,8 @@ v2_router.register(r'approval_request', api_v2_views.ApprovalRequestViewSet)
 app_name = 'recipes'
 
 urlpatterns = [
-    url(r'^api/v2/', include(v2_router.urls)),
-    url(r'^api/v1/', include(v1_router.urls)),
+    url(r'^api/v2/', include(v2_router.urls, namespace='v2')),
+    url(r'^api/v1/', include(v1_router.urls, namespace='v1')),
     url(
         r'^api/v1/action/(?P<name>[_\-\w]+)/implementation/(?P<impl_hash>[a-zA-Z0-9_-]*)/$',
         api_v1_views.ActionImplementationView.as_view(),


### PR DESCRIPTION
Much better:
<img width="708" alt="screen shot 2018-04-11 at 3 50 07 pm" src="https://user-images.githubusercontent.com/26739/38639717-167449e6-3da0-11e8-8d14-b8508c48293b.png">
