### PR TITLE
Avoid bare exceptions fixes #1231

### DIFF
--- a/recipe-server/normandy/recipes/api/v1/serializers.py
+++ b/recipe-server/normandy/recipes/api/v1/serializers.py
@@ -172,10 +172,17 @@ class RecipeSerializer(serializers.ModelSerializer):
         return value
 
     def validate_arguments(self, value):
+        # This in an invariance validation. It depends on the action_id
+        # being valid.
+        action_id = self.initial_data.get('action')
+        if not action_id:
+            # If this is the case, it will be caught by the basic
+            # validation.
+            return
         # Get the schema associated with the selected action
         try:
-            schema = Action.objects.get(name=self.initial_data.get('action')).arguments_schema
-        except:
+            schema = Action.objects.get(name=action_id).arguments_schema
+        except Action.DoesNotExist:
             raise serializers.ValidationError('Could not find arguments schema.')
 
         schemaValidator = JSONSchemaValidator(schema)

--- a/recipe-server/normandy/recipes/api/v2/serializers.py
+++ b/recipe-server/normandy/recipes/api/v2/serializers.py
@@ -171,10 +171,18 @@ class RecipeSerializer(serializers.ModelSerializer):
         return value
 
     def validate_arguments(self, value):
+        # This in an invariance validation. It depends on the action_id
+        # being valid.
+        action_id = self.initial_data.get('action_id')
+        if not action_id or not isinstance(action_id, int):
+            # If this is the case, it will be caught by the basic
+            # validation.
+            return
+
         # Get the schema associated with the selected action
         try:
-            schema = Action.objects.get(pk=self.initial_data.get('action_id')).arguments_schema
-        except:
+            schema = Action.objects.get(pk=action_id).arguments_schema
+        except Action.DoesNotExist:
             raise serializers.ValidationError('Could not find arguments schema.')
 
         schemaValidator = JSONSchemaValidator(schema)
@@ -206,7 +214,7 @@ class RecipeSerializer(serializers.ModelSerializer):
                     else:
                         currentLevel[path] = error.message
 
-        if (errorResponse):
+        if errorResponse:
             raise serializers.ValidationError(errorResponse)
 
         return value

--- a/recipe-server/normandy/recipes/tests/api/v2/test_api.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_api.py
@@ -195,10 +195,36 @@ class TestRecipeAPI(object):
             assert recipes.count() == 1
 
         def test_creation_when_action_does_not_exist(self, api_client):
-            res = api_client.post('/api/v2/recipe/', {'name': 'Test Recipe',
-                                                      'action_id': 1234,
-                                                      'arguments': '{}'})
+            res = api_client.post('/api/v2/recipe/', {
+                'name': 'Test Recipe',
+                'action_id': 1234,
+                'arguments': '{}',
+            })
             assert res.status_code == 400
+            assert res.json()['action_id']
+
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 0
+
+        def test_creation_when_action_id_is_missing(self, api_client):
+            res = api_client.post('/api/v2/recipe/', {
+                'name': 'Test Recipe',
+                'arguments': '{}'
+            })
+            assert res.status_code == 400
+            assert res.json()['action_id']
+
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 0
+
+        def test_creation_when_action_id_is_invalid(self, api_client):
+            res = api_client.post('/api/v2/recipe/', {
+                'name': 'Test Recipe',
+                'action_id': 'a string',
+                'arguments': '{}',
+            })
+            assert res.status_code == 400
+            assert res.json()['action_id']
 
             recipes = Recipe.objects.all()
             assert recipes.count() == 0
@@ -212,12 +238,15 @@ class TestRecipeAPI(object):
                     'required': ['message']
                 }
             )
-            res = api_client.post('/api/v2/recipe/', {'name': 'Test Recipe',
-                                                      'enabled': True,
-                                                      'extra_filter_expression': 'true',
-                                                      'action_id': action.id,
-                                                      'arguments': {'message': ''}})
+            res = api_client.post('/api/v2/recipe/', {
+                'name': 'Test Recipe',
+                'enabled': True,
+                'extra_filter_expression': 'true',
+                'action_id': action.id,
+                'arguments': {'message': ''},
+            })
             assert res.status_code == 400
+            assert res.json()['arguments']['message']
 
             recipes = Recipe.objects.all()
             assert recipes.count() == 0

--- a/recipe-server/normandy/recipes/tests/api/v2/test_serializers.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_serializers.py
@@ -64,17 +64,27 @@ class TestRecipeSerializer:
             'identicon_seed': Whatever.startswith('v1:'),
         }
 
-    # If the action specified cannot be found, raise validation
-    # error indicating the arguments schema could not be loaded
-    def test_validation_with_wrong_action(self):
+    def test_validation_with_invalid_action(self):
         serializer = RecipeSerializer(data={
-            'action': 'action-that-doesnt-exist', 'arguments': {}
+            'action_id': 'action-that-doesnt-exist', 'arguments': {}
         })
 
         with pytest.raises(serializers.ValidationError):
             serializer.is_valid(raise_exception=True)
 
-        assert serializer.errors['arguments'] == ['Could not find arguments schema.']
+        assert serializer.errors['action_id']
+
+    # If the action specified cannot be found, raise validation
+    # error indicating the arguments schema could not be loaded
+    def test_validation_with_wrong_action(self):
+        serializer = RecipeSerializer(data={
+            'action_id': '9999', 'arguments': {}
+        })
+
+        with pytest.raises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)
+
+        assert serializer.errors['action_id']
 
     # If the action can be found, raise validation error
     # with the arguments error formatted appropriately
@@ -86,6 +96,8 @@ class TestRecipeSerializer:
 
         serializer = RecipeSerializer(data={
             'action_id': action.id,
+            'name': 'Any name',
+            'extra_filter_expression': 'true',
             'arguments': {
                 'surveyId': '',
                 'surveys': [


### PR DESCRIPTION
This got messier than I had intended :)

The validation of the `arguments` shouldn't really happen until the action validation has succeeded. Ideally, the validation of the `arguments` should start after the `action` (or `action_id` for v2) has succeeded. Otherwise it's validating the wrong thing. But if I raise a `ValidationError` inside a `validate()` method, the error message isn't "namespaced" on the `arguments`. 

In this patch, the validation of `arguments` only kicks in if you have a valid `Action` instance found. 