### PR TITLE
Undo worry about exceptions raised in pyjexl validate(), fixes #1233

### DIFF
--- a/recipe-server/normandy/recipes/api/v1/serializers.py
+++ b/recipe-server/normandy/recipes/api/v1/serializers.py
@@ -155,17 +155,7 @@ class RecipeSerializer(serializers.ModelSerializer):
         jexl.add_transform('preferenceIsUserSet', lambda x: x)
         jexl.add_transform('preferenceExists', lambda x: x)
 
-        try:
-            errors = list(jexl.validate(value))
-        except Exception as exc:
-            # The JEXL parser can occasionally throw exceptions when
-            # called to validate certain invalid inputs.
-            # Catch them and at least indicate the field that failed,
-            # even if we can't explain exactly what the problem was.
-            # See https://github.com/mozilla/normandy/issues/1059.
-            error = f'The JEXL parser failed to validate {value}'
-            raise serializers.ValidationError([error])
-
+        errors = list(jexl.validate(value))
         if errors:
             raise serializers.ValidationError(errors)
 

--- a/recipe-server/normandy/recipes/api/v2/serializers.py
+++ b/recipe-server/normandy/recipes/api/v2/serializers.py
@@ -154,17 +154,7 @@ class RecipeSerializer(serializers.ModelSerializer):
         jexl.add_transform('preferenceIsUserSet', lambda x: x)
         jexl.add_transform('preferenceExists', lambda x: x)
 
-        try:
-            errors = list(jexl.validate(value))
-        except Exception as exc:
-            # The JEXL parser can occasionally throw exceptions when
-            # called to validate certain invalid inputs.
-            # Catch them and at least indicate the field that failed,
-            # even if we can't explain exactly what the problem was.
-            # See https://github.com/mozilla/normandy/issues/1059.
-            error = f'The JEXL parser failed to validate {value}'
-            raise serializers.ValidationError([error])
-
+        errors = list(jexl.validate(value))
         if errors:
             raise serializers.ValidationError(errors)
 

--- a/recipe-server/normandy/recipes/tests/api/v2/test_serializers.py
+++ b/recipe-server/normandy/recipes/tests/api/v2/test_serializers.py
@@ -1,4 +1,3 @@
-from unittest import mock
 import pytest
 from rest_framework import serializers
 
@@ -138,7 +137,7 @@ class TestRecipeSerializer:
         serializer = RecipeSerializer(data={
             'name': 'bar',
             'enabled': True,
-            'extra_filter_expression': 'aces',
+            'extra_filter_expression': '"\\',
             'action': 'show-heartbeat',
             'arguments': {
                 'surveyId': 'lorem-ipsum-dolor',
@@ -149,13 +148,10 @@ class TestRecipeSerializer:
             }
         })
 
-        jexl_mock = mock.Mock()
-        jexl_mock().validate.side_effect = Exception("didn't like this")
-        with mock.patch('normandy.recipes.api.v2.serializers.JEXL', jexl_mock):
-            assert not serializer.is_valid()
-            assert serializer.errors['extra_filter_expression'] == [
-                'The JEXL parser failed to validate aces'
-            ]
+        assert not serializer.is_valid()
+        assert serializer.errors['extra_filter_expression'] == [
+            'Could not parse expression: "\\'
+        ]
 
     def test_validation_with_valid_data(self):
         mockAction = ActionFactory(


### PR DESCRIPTION
The day we encounter a string that causes `pyjexlinstance.validate()` to raise an exception (as opposed to just returning the error) we should attack that by amending pyjexl. 