### PR TITLE
pass tag to deploy script on master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ deployment:
   latest:
     branch: master
     commands:
-      - ./bin/ci/deploy
+      - ./bin/ci/deploy latest
 
   tags:
     # push all tags


### PR DESCRIPTION
This is a follow up for #1238. There was a bug in the CI script for deploying the docker container. This should fix it, but the only way to verify it is to land it on master and let it run.