### PR TITLE
Use pip 10's "pip check" command to check dependency compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 COPY ./requirements /app/requirements
 COPY ./package.json /app/package.json
 COPY ./yarn.lock /app/yarn.lock
-RUN pip install -U 'pip>=8' && \
+RUN pip install --upgrade --no-cache-dir -r requirements/pip.txt && \
     pip install --upgrade --no-cache-dir -r requirements/default.txt -c requirements/constraints.txt && \
     yarn install --frozen-lockfile
 

--- a/bin/ci/lint
+++ b/bin/ci/lint
@@ -3,7 +3,7 @@ set -eu
 
 echo "Linting Python files"
 bin/ci/docker-run.sh flake8 normandy/ contract-tests/
-bin/ci/docker-run.sh pipdeptree --warn fail --local-only
+bin/ci/docker-run.sh pip check
 
 echo "Linting JS files"
 bin/ci/docker-run.sh yarn lint:js

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -110,8 +110,6 @@ mozilla-cloud-services-logger==1.0.1 \
     --hash=sha256:2a2a524f9d05bc5c8a6f3d13a28cb06386b0720cee00ba58e22b2de68089c6e4
 newrelic==3.2.0.91 \
     --hash=sha256:2d1cf00e105f423c5c5fa9ce3f6179773683e6ee52fb64016441abd225b43bf3
-pipdeptree==0.12.1 \
-    --hash=sha256:362c5877b3b1641671ea05b99d068e86b5cf8b848e8affa8a4af67aa18762d46
 psycopg2==2.7.4 \
     --hash=sha256:0b9851e798bae024ed1a2a6377a8dab4b8a128a56ed406f572f9f06194e4b275 \
     --hash=sha256:733166464598c239323142c071fa4c9b91c14359176e5ae7e202db6bcc1d2eb5 \


### PR DESCRIPTION
This would have caught the error that caused #1339 to fail in a more easily understandable way. It will also detect more subtle package incompatibilities, should we find them in the future.