### PR TITLE
Tell pyup not to update pycodestyle, since it is incompatible with flake8

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -71,7 +71,8 @@ py==1.5.3 \
     --hash=sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a
 pycodestyle==2.3.1 \
     --hash=sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766 \
-    --hash=sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9
+    --hash=sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9 \
+    # pyup: >=2.3,<2.4  # flake8 doesn't support >=2.4
 pycparser==2.18 \
     --hash=sha256:99a8ca03e29851d96616ad0404b4aad7d9ee16f25c9f9708a11faf2810f7b226
 pyflakes==1.6.0 \


### PR DESCRIPTION
See #1339 and #1344.