### PR TITLE
Use Firefox's --headless mode for CI tests

### DIFF
--- a/bin/ci/test
+++ b/bin/ci/test
@@ -10,7 +10,7 @@ echo "Running JS tests"
   echo "* Waiting for Karma server to start"
   docker run --net host -e CHECK_PORT=9876 -e CHECK_HOST=localhost giorgos/takis
   echo "* Starting Firefox"
-  firefox localhost:9876
+  firefox localhost:9876 --headless
 ) &
 echo "* Starting Karma server"
 bin/ci/docker-run.sh --user root -e NODE_ENV=production -p 9876:9876 node bin/ci/karma-ci.js


### PR DESCRIPTION
Surprisingly, this seems to fix #1359.