### PR TITLE
Send statsd signals on heartbeat page loads

### DIFF
--- a/normandy/health/apps.py
+++ b/normandy/health/apps.py
@@ -5,3 +5,7 @@ class HealthApp(AppConfig):
     name = 'normandy.health'
     label = 'health'
     verbose_name = 'Normandy Health'
+
+    def ready(self):
+        # Import for side-effect: registers signal handler
+        import normandy.health.signals  # NOQA

--- a/normandy/health/signals.py
+++ b/normandy/health/signals.py
@@ -1,0 +1,14 @@
+from django.dispatch import receiver
+
+from dockerflow.django.signals import heartbeat_passed, heartbeat_failed
+from statsd.defaults.django import statsd
+
+
+@receiver(heartbeat_passed)
+def heartbeat_passed_handler(sender, level, **kwargs):
+    statsd.incr('heartbeat.pass')
+
+
+@receiver(heartbeat_failed)
+def heartbeat_failed_handler(sender, level, **kwargs):
+    statsd.incr('heartbeat.fail')


### PR DESCRIPTION
This was a regression from #1337.

This is the method [recommended by python-dockerflow](https://github.com/mozilla-services/python-dockerflow/blob/master/src/dockerflow/django/signals.py).