### PR TITLE
Coerce IDs to string in signed endpoint

### DIFF
--- a/normandy/recipes/api/v1/serializers.py
+++ b/normandy/recipes/api/v1/serializers.py
@@ -227,7 +227,7 @@ class MinimalRecipeSerializer(RecipeSerializer):
     The minimum amount of fields needed for clients to verify and execute recipes.
     """
 
-    revision_id = serializers.IntegerField(source='current_revision.id', read_only=True)
+    revision_id = serializers.SerializerMethodField()
 
     class Meta(RecipeSerializer.Meta):
         # Attributes serialized here are made available to filter expressions via
@@ -244,6 +244,14 @@ class MinimalRecipeSerializer(RecipeSerializer):
             'arguments',
             'filter_expression',
         ]
+
+    def get_revision_id(self, recipe):
+        # Certain parts of Telemetry expect this to be a string, so coerce it to
+        # that, even though the data is actually an int
+        if recipe.current_revision:
+            return str(recipe.current_revision.id)
+        else:
+            None
 
 
 class RecipeRevisionSerializer(serializers.ModelSerializer):

--- a/normandy/recipes/tests/api/v1/test_serializers.py
+++ b/normandy/recipes/tests/api/v1/test_serializers.py
@@ -246,7 +246,7 @@ class TestSignedRecipeSerializer:
                 'id': recipe.id,
                 'enabled': recipe.enabled,
                 'filter_expression': recipe.filter_expression,
-                'revision_id': recipe.revision_id,
+                'revision_id': str(recipe.revision_id),
                 'action': action.name,
                 'arguments': recipe.arguments,
                 'last_updated': Whatever(),

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -275,7 +275,7 @@ class TestRecipe(object):
             '"is_approved":false,'
             '"last_updated":"%(last_updated)s",'
             '"name":"canonical",'
-            '"revision_id":%(revision_id)s'
+            '"revision_id":"%(revision_id)s"'
             '}'
         ) % {
             'id': recipe.id,


### PR DESCRIPTION
Fixes #1376 by making revision ID a string in the `/api/v1/recipe/signed/` endpoint.