### PR TITLE
Bug 1462290 - Correctly update signatures when enabling recipes

### DIFF
--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -444,6 +444,7 @@ class RecipeRevision(DirtyFieldsMixin, models.Model):
         self.enabled_state = EnabledState.objects.create(revision=self, **kwargs)
         self.save()
 
+        self.recipe.approved_revision.refresh_from_db()
         self.recipe.update_signature()
         self.recipe.save()
 


### PR DESCRIPTION
Splitting this into two commits, one with a failing test, and one with the fix.