### PR TITLE
Only sign enabled recipes, and include less data in the signed payload

### DIFF
--- a/normandy/recipes/api/v1/serializers.py
+++ b/normandy/recipes/api/v1/serializers.py
@@ -143,10 +143,7 @@ class MinimalRecipeSerializer(RecipeSerializer):
         # used in filter expressions.
         fields = [
             'id',
-            'last_updated',
             'name',
-            'enabled',
-            'is_approved',
             'revision_id',
             'action',
             'arguments',

--- a/normandy/recipes/management/commands/update_action_signatures.py
+++ b/normandy/recipes/management/commands/update_action_signatures.py
@@ -33,7 +33,8 @@ class Command(BaseCommand):
             self.stdout.write(f'Signing {count} actions:')
             for action in actions_to_update:
                 self.stdout.write(' * ' + action.name)
-            actions_to_update.update_signatures()
+                action.update_signature()
+                action.save()
 
     def get_outdated_actions(self):
         outdated_age = timedelta(seconds=settings.AUTOGRAPH_SIGNATURE_MAX_AGE)

--- a/normandy/recipes/management/commands/update_recipe_signatures.py
+++ b/normandy/recipes/management/commands/update_recipe_signatures.py
@@ -35,7 +35,8 @@ class Command(BaseCommand):
             self.stdout.write(f'Signing {count} recipes:')
             for recipe in recipes_to_update:
                 self.stdout.write(' * ' + recipe.name)
-            recipes_to_update.update_signatures()
+                recipe.update_signature()
+                recipe.save()
 
         recipes_to_unsign = Recipe.objects.only_disabled().exclude(signature=None)
         count = recipes_to_unsign.count()

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -227,6 +227,10 @@ class Recipe(DirtyFieldsMixin, models.Model):
             self.signature = None
             return
 
+        # Don't sign recipe that aren't enabled
+        if not self.enabled:
+            return
+
         logger.info(
             f'Requesting signature for recipe with id {self.id} from Autograph',
             extra={'code': INFO_REQUESTING_RECIPE_SIGNATURES, 'recipe_ids': [self.id]}

--- a/normandy/recipes/tests/api/v1/test_serializers.py
+++ b/normandy/recipes/tests/api/v1/test_serializers.py
@@ -101,13 +101,10 @@ class TestSignedRecipeSerializer:
             'recipe': {
                 'name': recipe.name,
                 'id': recipe.id,
-                'enabled': recipe.enabled,
                 'filter_expression': recipe.filter_expression,
                 'revision_id': str(recipe.revision_id),
                 'action': action.name,
                 'arguments': recipe.arguments,
-                'last_updated': Whatever(),
-                'is_approved': False,
             }
         }
 

--- a/normandy/recipes/tests/api/v2/test_api.py
+++ b/normandy/recipes/tests/api/v2/test_api.py
@@ -1145,10 +1145,12 @@ class TestApprovalFlow(object):
                               {'comment': 'r+'})
         assert res.status_code == 403  # Forbidden
 
-        # Approve the recipe
+        # Approve and enable the recipe
         api_client.force_authenticate(user2)
         res = api_client.post('/api/v2/approval_request/{}/approve/'.format(approval_data['id']),
                               {'comment': 'r+'})
+        assert res.status_code == 200
+        res = api_client.post('/api/v2/recipe/{}/enable/'.format(recipe_data_0['id']))
         assert res.status_code == 200
 
         # It is now visible in the API
@@ -1250,13 +1252,18 @@ class TestApprovalFlow(object):
         assert res.status_code == 201
         approval_request_id = res.json()['id']
 
-        # Approve the recipe
+        # Approve and enable the recipe
         api_client.force_authenticate(user2)
         res = api_client.post(
             f'/api/v2/approval_request/{approval_request_id}/approve/',
             {'comment': 'r+'}
         )
         assert res.status_code == 200
+        res = api_client.post(f'/api/v2/recipe/{recipe_id}/enable/')
+        assert res.status_code == 200
+
+        # The API should have correct signatures now
+        self.verify_signatures(api_client, expected_count=1)
 
         # Make another change
         api_client.force_authenticate(user1)

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -1188,10 +1188,12 @@ class TestApprovalFlow(object):
                               {'comment': 'r+'})
         assert res.status_code == 403  # Forbidden
 
-        # Approve the recipe
+        # Approve and enable the recipe
         api_client.force_authenticate(user2)
         res = api_client.post('/api/v3/approval_request/{}/approve/'.format(approval_data['id']),
                               {'comment': 'r+'})
+        assert res.status_code == 200
+        res = api_client.post('/api/v3/recipe/{}/enable/'.format(recipe_data_0['id']))
         assert res.status_code == 200
 
         # It is now visible in the API
@@ -1300,6 +1302,16 @@ class TestApprovalFlow(object):
             {'comment': 'r+'}
         )
         assert res.status_code == 200
+
+        # The API shouldn't have any signed recipe yet
+        self.verify_signatures(api_client, expected_count=0)
+
+        # Enable the recipe
+        res = api_client.post(f'/api/v3/recipe/{recipe_id}/enable/')
+        assert res.status_code == 200
+
+        # The API should have correct signatures now
+        self.verify_signatures(api_client, expected_count=1)
 
         # Make another change
         api_client.force_authenticate(user1)

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -333,18 +333,14 @@ class TestRecipe(object):
             '{'
             '"action":"action",'
             '"arguments":{"bar":2,"foo":1},'
-            '"enabled":false,'
             '"filter_expression":"%(filter_expression)s",'
             '"id":%(id)s,'
-            '"is_approved":false,'
-            '"last_updated":"%(last_updated)s",'
             '"name":"canonical",'
             '"revision_id":"%(revision_id)s"'
             '}'
         ) % {
             'id': recipe.id,
             'revision_id': recipe.revision_id,
-            'last_updated': recipe.last_updated.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             'filter_expression': filter_expression
         }
         expected = expected.encode()


### PR DESCRIPTION
I did some updating of our signing code.

I reduced the number of fields in the data that gets signed for recipes further, to be only exactly what Normandy client needs. This should make signatures need to be regenerated less often (though I didn't change how often we actually regenerate them.)

I also made it so we don't sign a recipe unless it is enabled. Since we shouldn't be running recipes that aren't enabled, this shouldn't hurt anything, and increase security.

Finally, I removed the bulk sign methods implemented on Recipe and Action querysets. They were a performance optimization, but maintaining two signing flows didn't seem worth it.

Fixes #758.