### PR TITLE
Do not use X-Forwarded-Host

### DIFF
--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -399,7 +399,6 @@ class Development(Base):
 class Production(Base):
     """Settings for the production environment."""
 
-    USE_X_FORWARDED_HOST = values.BooleanValue(False)
     SECURE_PROXY_SSL_HEADER = values.TupleValue(("HTTP_X_FORWARDED_PROTO", "https"))
     LOGGING_USE_JSON = values.Value(True)
     SECURE_HSTS_SECONDS = values.IntegerValue(31536000)  # 1 year

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -399,7 +399,7 @@ class Development(Base):
 class Production(Base):
     """Settings for the production environment."""
 
-    USE_X_FORWARDED_HOST = values.BooleanValue(True)
+    USE_X_FORWARDED_HOST = values.BooleanValue(False)
     SECURE_PROXY_SSL_HEADER = values.TupleValue(("HTTP_X_FORWARDED_PROTO", "https"))
     LOGGING_USE_JSON = values.Value(True)
     SECURE_HSTS_SECONDS = values.IntegerValue(31536000)  # 1 year


### PR DESCRIPTION
We started stripping this header at Nginx due to https://bugzilla.mozilla.org/show_bug.cgi?id=1433134

There is no reason to keep it enabled in the normandy codebase.