### PR TITLE
Remove email from call to `docker login`

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -19,7 +19,7 @@ function retry() {
 }
 
 # configure docker creds
-retry 3 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+retry 3 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 
 # docker tag and push git branch to dockerhub
 if [ -n "$1" ]; then


### PR DESCRIPTION
It seems that email is no longer a valid option for this command, according to my local copy of `docker login --help`:

```
Usage:	docker login [OPTIONS] [SERVER]

Log in to a Docker registry

Options:
      --help              Print usage
  -p, --password string   Password
  -u, --username string   Username
```

I think this will fix #1444.