### PR TITLE
Tag docker-compose built image for deploy

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -19,10 +19,12 @@ function retry() {
 }
 
 # configure docker creds
-retry 3 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+echo "$DOCKER_PASSWRD" | docker login --user="$DOCKER_USERNAME" --password-stdin
 
 # docker tag and push git branch to dockerhub
 if [ -n "$1" ]; then
+    # Tag docker-compose built image
+    docker tag normandy:web
     if [ "$1" == master ]; then
         TAG=latest
     else


### PR DESCRIPTION
After fixing #1444 with #1445, another problem was revealed. We never tagged the image that docker-compose built as the deploy script expected. This should fix that.