### PR TITLE
Use JSON array format for Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ EXPOSE $PORT
 
 ENTRYPOINT ["/bin/bash", "/app/bin/run.sh"]
 
-CMD start
+CMD ["start"]


### PR DESCRIPTION
Besides being a generally good idea, this is required when using both CMD and ENTRYPOINT.