### PR TITLE
null bytes string in /api/v1/recipe/signed

### DIFF
--- a/normandy/recipes/api/filters.py
+++ b/normandy/recipes/api/filters.py
@@ -12,3 +12,13 @@ class EnabledStateFilter(django_filters.Filter):
             elif lc_value in ["false", "0"]:
                 return qs.only_disabled()
         return qs
+
+
+class CharSplitFilter(django_filters.CharFilter):
+    """Custom CharFilter class that splits the value (if it's set) by `,` into a list
+    and uses the `__in` operator."""
+
+    def filter(self, qs, value):
+        if value:
+            qs = qs.filter(**{"{}__in".format(self.field_name): value.split(",")})
+        return qs

--- a/normandy/recipes/api/v1/views.py
+++ b/normandy/recipes/api/v1/views.py
@@ -22,7 +22,7 @@ from normandy.recipes.models import (
     Recipe,
     RecipeRevision,
 )
-from normandy.recipes.api.filters import EnabledStateFilter
+from normandy.recipes.api.filters import CharSplitFilter, EnabledStateFilter
 from normandy.recipes.api.v1.serializers import (
     ActionSerializer,
     ApprovalRequestSerializer,
@@ -72,16 +72,6 @@ class ActionImplementationView(generics.RetrieveAPIView):
             raise NotFound("Hash does not match current stored action.")
 
         return Response(action.implementation)
-
-
-class CharSplitFilter(django_filters.CharFilter):
-    """Custom CharFilter class that splits the value (if it's set) by `,` into a list
-    and uses the `__in` operator."""
-
-    def filter(self, qs, value):
-        if value:
-            qs = qs.filter(**{"{}__in".format(self.field_name): value.split(",")})
-        return qs
 
 
 class RecipeFilters(django_filters.FilterSet):

--- a/normandy/recipes/api/v1/views.py
+++ b/normandy/recipes/api/v1/views.py
@@ -74,9 +74,22 @@ class ActionImplementationView(generics.RetrieveAPIView):
         return Response(action.implementation)
 
 
+class CharSplitFilter(django_filters.CharFilter):
+    """Custom CharFilter class that splits the value (if it's set) by `,` into a list
+    and uses the `__in` operator."""
+
+    def filter(self, qs, value):
+        if value:
+            qs = qs.filter(**{"{}__in".format(self.field_name): value.split(",")})
+        return qs
+
+
 class RecipeFilters(django_filters.FilterSet):
     enabled = EnabledStateFilter()
     action = django_filters.CharFilter(field_name="latest_revision__action__name")
+    channels = CharSplitFilter("latest_revision__channels__slug")
+    locales = CharSplitFilter("latest_revision__locales__code")
+    countries = CharSplitFilter("latest_revision__countries__code")
 
     class Meta:
         model = Recipe
@@ -109,18 +122,6 @@ class RecipeViewSet(CachingViewsetMixin, viewsets.ReadOnlyModelViewSet):
             queryset = queryset.only_enabled()
         elif self.request.GET.get("status") == "disabled":
             queryset = queryset.only_disabled()
-
-        if "channels" in self.request.GET:
-            channels = self.request.GET.get("channels").split(",")
-            queryset = queryset.filter(latest_revision__channels__slug__in=channels)
-
-        if "countries" in self.request.GET:
-            countries = self.request.GET.get("countries").split(",")
-            queryset = queryset.filter(latest_revision__countries__code__in=countries)
-
-        if "locales" in self.request.GET:
-            locales = self.request.GET.get("locales").split(",")
-            queryset = queryset.filter(latest_revision__locales__code__in=locales)
 
         if "text" in self.request.GET:
             text = self.request.GET.get("text")

--- a/normandy/recipes/api/v2/views.py
+++ b/normandy/recipes/api/v2/views.py
@@ -16,7 +16,7 @@ from normandy.base.api.mixins import CachingViewsetMixin
 from normandy.base.api.permissions import AdminEnabledOrReadOnly
 from normandy.base.decorators import api_cache_control
 from normandy.recipes.models import Action, ApprovalRequest, EnabledState, Recipe, RecipeRevision
-from normandy.recipes.api.filters import EnabledStateFilter
+from normandy.recipes.api.filters import CharSplitFilter, EnabledStateFilter
 from normandy.recipes.api.v2.serializers import (
     ActionSerializer,
     ApprovalRequestSerializer,
@@ -32,16 +32,6 @@ class ActionViewSet(CachingViewsetMixin, viewsets.ReadOnlyModelViewSet):
     queryset = Action.objects.all()
     serializer_class = ActionSerializer
     pagination_class = None
-
-
-class CharSplitFilter(django_filters.CharFilter):
-    """Custom CharFilter class that splits the value (if it's set) by `,` into a list
-    and uses the `__in` operator."""
-
-    def filter(self, qs, value):
-        if value:
-            qs = qs.filter(**{"{}__in".format(self.field_name): value.split(",")})
-        return qs
 
 
 class RecipeFilters(django_filters.FilterSet):

--- a/normandy/recipes/api/v3/views.py
+++ b/normandy/recipes/api/v3/views.py
@@ -14,7 +14,7 @@ from normandy.base.api.mixins import CachingViewsetMixin
 from normandy.base.api.permissions import AdminEnabledOrReadOnly
 from normandy.base.decorators import api_cache_control
 from normandy.recipes.models import Action, ApprovalRequest, EnabledState, Recipe, RecipeRevision
-from normandy.recipes.api.filters import EnabledStateFilter
+from normandy.recipes.api.filters import CharSplitFilter, EnabledStateFilter
 from normandy.recipes.api.v3.serializers import (
     ActionSerializer,
     ApprovalRequestSerializer,
@@ -35,6 +35,9 @@ class RecipeFilters(django_filters.FilterSet):
     enabled = EnabledStateFilter()
     action = django_filters.CharFilter(field_name="latest_revision__action__name")
     bug_number = django_filters.Filter(field_name="latest_revision__bug_number")
+    channels = CharSplitFilter("latest_revision__channels__slug")
+    locales = CharSplitFilter("latest_revision__locales__code")
+    countries = CharSplitFilter("latest_revision__countries__code")
 
     class Meta:
         model = Recipe
@@ -74,18 +77,6 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
             queryset = queryset.only_enabled()
         elif self.request.GET.get("status") == "disabled":
             queryset = queryset.only_disabled()
-
-        if "channels" in self.request.GET:
-            channels = self.request.GET.get("channels").split(",")
-            queryset = queryset.filter(latest_revision__channels__slug__in=channels)
-
-        if "countries" in self.request.GET:
-            countries = self.request.GET.get("countries").split(",")
-            queryset = queryset.filter(latest_revision__countries__code__in=countries)
-
-        if "locales" in self.request.GET:
-            locales = self.request.GET.get("locales").split(",")
-            queryset = queryset.filter(latest_revision__locales__code__in=locales)
 
         if "text" in self.request.GET:
             text = self.request.GET.get("text")

--- a/normandy/recipes/tests/api/v1/test_api.py
+++ b/normandy/recipes/tests/api/v1/test_api.py
@@ -287,6 +287,7 @@ class TestRecipeAPI(object):
         def test_list_filter_channels_null_bytes(self, api_client):
             res = api_client.get("/api/v1/recipe/?channels=\x00")
             assert res.status_code == 400
+            assert res.json()["channels"] == ["Null characters are not allowed."]
 
         def test_list_filter_countries(self, api_client):
             r1 = RecipeFactory(countries=[CountryFactory(code="US")])
@@ -306,6 +307,7 @@ class TestRecipeAPI(object):
         def test_list_filter_countries_with_null_bytes(self, api_client):
             res = api_client.get("/api/v1/recipe/?countries=\x00")
             assert res.status_code == 400
+            assert res.json()["countries"] == ["Null characters are not allowed."]
 
         def test_list_filter_locales(self, api_client):
             r1 = RecipeFactory(locales=[LocaleFactory(code="en-US")])
@@ -325,6 +327,7 @@ class TestRecipeAPI(object):
         def test_list_filter_locales_null_bytes(self, api_client):
             res = api_client.get("/api/v1/recipe/?locales=\x00")
             assert res.status_code == 400
+            assert res.json()["locales"] == ["Null characters are not allowed."]
 
         def test_list_filter_text(self, api_client):
             r1 = RecipeFactory(name="first", extra_filter_expression="1 + 1 == 2")

--- a/normandy/recipes/tests/api/v1/test_api.py
+++ b/normandy/recipes/tests/api/v1/test_api.py
@@ -284,6 +284,10 @@ class TestRecipeAPI(object):
             for recipe in res.data:
                 assert recipe["id"] in [r1.id, r2.id]
 
+        def test_list_filter_channels_null_bytes(self, api_client):
+            res = api_client.get("/api/v1/recipe/?channels=\x00")
+            assert res.status_code == 400
+
         def test_list_filter_countries(self, api_client):
             r1 = RecipeFactory(countries=[CountryFactory(code="US")])
             r2 = RecipeFactory(countries=[CountryFactory(code="CA")])
@@ -299,6 +303,10 @@ class TestRecipeAPI(object):
             for recipe in res.data:
                 assert recipe["id"] in [r1.id, r2.id]
 
+        def test_list_filter_countries_with_null_bytes(self, api_client):
+            res = api_client.get("/api/v1/recipe/?countries=\x00")
+            assert res.status_code == 400
+
         def test_list_filter_locales(self, api_client):
             r1 = RecipeFactory(locales=[LocaleFactory(code="en-US")])
             r2 = RecipeFactory(locales=[LocaleFactory(code="fr-CA")])
@@ -313,6 +321,10 @@ class TestRecipeAPI(object):
             assert len(res.data) == 2
             for recipe in res.data:
                 assert recipe["id"] in [r1.id, r2.id]
+
+        def test_list_filter_locales_null_bytes(self, api_client):
+            res = api_client.get("/api/v1/recipe/?locales=\x00")
+            assert res.status_code == 400
 
         def test_list_filter_text(self, api_client):
             r1 = RecipeFactory(name="first", extra_filter_expression="1 + 1 == 2")

--- a/normandy/recipes/tests/api/v2/test_api.py
+++ b/normandy/recipes/tests/api/v2/test_api.py
@@ -785,6 +785,11 @@ class TestRecipeAPI(object):
             for recipe in results:
                 assert recipe["id"] in [r1.id, r2.id]
 
+        def test_list_filter_channels_null_bytes(self, api_client):
+            res = api_client.get("/api/v2/recipe/?channels=\x00")
+            assert res.status_code == 400
+            assert res.json()["channels"] == ["Null characters are not allowed."]
+
         def test_list_filter_countries(self, api_client):
             r1 = RecipeFactory(countries=[CountryFactory(code="US")])
             r2 = RecipeFactory(countries=[CountryFactory(code="CA")])
@@ -802,6 +807,11 @@ class TestRecipeAPI(object):
             for recipe in results:
                 assert recipe["id"] in [r1.id, r2.id]
 
+        def test_list_filter_countries_null_bytes(self, api_client):
+            res = api_client.get("/api/v2/recipe/?countries=\x00")
+            assert res.status_code == 400
+            assert res.json()["countries"] == ["Null characters are not allowed."]
+
         def test_list_filter_locales(self, api_client):
             r1 = RecipeFactory(locales=[LocaleFactory(code="en-US")])
             r2 = RecipeFactory(locales=[LocaleFactory(code="fr-CA")])
@@ -818,6 +828,11 @@ class TestRecipeAPI(object):
             assert len(results) == 2
             for recipe in results:
                 assert recipe["id"] in [r1.id, r2.id]
+
+        def test_list_filter_locales_null_bytes(self, api_client):
+            res = api_client.get("/api/v2/recipe/?locales=\x00")
+            assert res.status_code == 400
+            assert res.json()["locales"] == ["Null characters are not allowed."]
 
         def test_list_filter_text(self, api_client):
             r1 = RecipeFactory(name="first", extra_filter_expression="1 + 1 == 2")

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -820,6 +820,11 @@ class TestRecipeAPI(object):
             for recipe in results:
                 assert recipe["id"] in [r1.id, r2.id]
 
+        def test_list_filter_channels_null_bytes(self, api_client):
+            res = api_client.get("/api/v3/recipe/?channels=\x00")
+            assert res.status_code == 400
+            assert res.json()["channels"] == ["Null characters are not allowed."]
+
         def test_list_filter_countries(self, api_client):
             r1 = RecipeFactory(countries=[CountryFactory(code="US")])
             r2 = RecipeFactory(countries=[CountryFactory(code="CA")])
@@ -837,6 +842,11 @@ class TestRecipeAPI(object):
             for recipe in results:
                 assert recipe["id"] in [r1.id, r2.id]
 
+        def test_list_filter_countries_null_bytes(self, api_client):
+            res = api_client.get("/api/v3/recipe/?countries=\x00")
+            assert res.status_code == 400
+            assert res.json()["countries"] == ["Null characters are not allowed."]
+
         def test_list_filter_locales(self, api_client):
             r1 = RecipeFactory(locales=[LocaleFactory(code="en-US")])
             r2 = RecipeFactory(locales=[LocaleFactory(code="fr-CA")])
@@ -853,6 +863,11 @@ class TestRecipeAPI(object):
             assert len(results) == 2
             for recipe in results:
                 assert recipe["id"] in [r1.id, r2.id]
+
+        def test_list_filter_locales_null_bytes(self, api_client):
+            res = api_client.get("/api/v3/recipe/?locales=\x00")
+            assert res.status_code == 400
+            assert res.json()["locales"] == ["Null characters are not allowed."]
 
         def test_list_filter_text(self, api_client):
             r1 = RecipeFactory(name="first", extra_filter_expression="1 + 1 == 2")


### PR DESCRIPTION
Fixes #1455 

The trick here to use `django_filters`'s `CharFilter` in some way. That has builtin support for rejecting strings with null bytes in them. 