### PR TITLE
Rename test shortcuts in run.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
 
       - run:
           name: Python Tests
-          command: docker-compose -f ci/docker-compose.yml run web pytest
+          command: docker-compose -f ci/docker-compose.yml run web python-tests
 
       - run:
           name: Start Django/Gunicorn server
@@ -81,7 +81,7 @@ jobs:
 
       - run:
           name: JavaScript tests
-          command: docker-compose -f ci/docker-compose.yml run --user root web karma
+          command: docker-compose -f ci/docker-compose.yml run --user root web js-tests
 
       - run:
           name: Copy Artifacts

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 usage() {
-  echo "usage: ./bin/run.sh pytests|jstests|lint|start"
+  echo "usage: ./bin/run.sh python-tests|js-tests|lint|start"
   exit 1
 }
 
@@ -37,13 +37,13 @@ case $1 in
     fi
     set -e
     ;;
-  pytest)
+  python-tests)
     echo "Running Python tests"
     junit_path=$ARTIFACTS_PATH/test_results/python_tests
     mkdir -p $junit_path
     py.test -vv --junitxml=$junit_path/junit.xml normandy/
     ;;
-  karma)
+  js-tests)
     apt install -y --no-install-recommends firefox-esr
     npm install -g get-firefox
     get-firefox -e


### PR DESCRIPTION
Matching on "pytest" and running a predefined set of commands prevented
us from running pytest with different arguments. We rename our pytest
launching shortcut to fix that and preemptively fix the same problem
with karma.