### PR TITLE
Deduplicate docker-compose file config in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,11 @@ jobs:
   build_test_publish:
     docker:
       - image: ubuntu:18.04
+
     working_directory: ~/normandy
+
+    environment:
+        COMPOSE_FILE: ci/docker-compose.yml
 
     steps:
       - run:
@@ -55,39 +59,39 @@ jobs:
 
       - run:
           name: Starting artifact collector
-          command: docker-compose -f ci/docker-compose.yml run --user root artifact-collector
+          command: docker-compose run --user root artifact-collector
           background: true
 
       - run:
           name: Build
-          command: docker-compose -f ci/docker-compose.yml build web
+          command: docker-compose build web
 
       - run:
           name: Linting
-          command: docker-compose -f ci/docker-compose.yml run web lint
+          command: docker-compose run web lint
 
       - run:
           name: Python Tests
-          command: docker-compose -f ci/docker-compose.yml run web python-tests
+          command: docker-compose run web python-tests
 
       - run:
           name: Start Django/Gunicorn server
-          command: docker-compose -f ci/docker-compose.yml up web
+          command: docker-compose up web
           background: true
 
       - run:
           name: Contract tests
-          command: docker-compose -f ci/docker-compose.yml run web contracttest
+          command: docker-compose run web contracttest
 
       - run:
           name: JavaScript tests
-          command: docker-compose -f ci/docker-compose.yml run --user root web js-tests
+          command: docker-compose run --user root web js-tests
 
       - run:
           name: Copy Artifacts
           when: always # run even if previous run commands failed
           command: |
-            docker cp $(docker-compose -f ci/docker-compose.yml ps -q artifact-collector):/artifacts /artifacts
+            docker cp $(docker-compose ps -q artifact-collector):/artifacts /artifacts
             ls /artifacts
 
       - store_artifacts:


### PR DESCRIPTION
Using an environment variable lets us stop repeating the docker-compose config file for every line.