### PR TITLE
Use cidockerbases:docker-latest for CI base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 jobs:
   build_test_publish:
     docker:
-      - image: ubuntu:18.04
+      - image: cidockerbases:docker-latest
 
     working_directory: ~/normandy
 
@@ -16,30 +16,7 @@ jobs:
         COMPOSE_FILE: ci/docker-compose.yml
 
     steps:
-      - run:
-          name: Install essential packages
-          command: |
-            apt-get update && apt-get install -y ca-certificates curl git openssh-client
-
       - checkout
-
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            # Latest 200 OK version as of June 2018
-            # https://circleci.com/docs/2.0/building-docker-images/#docker-version
-            VER="17.09.0-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-
-      - run:
-          name: Install Docker Compose
-          command: |
-            curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
-            chmod +x ~/docker-compose
-            mv ~/docker-compose /usr/local/bin/docker-compose
 
       - setup_remote_docker:
           version: 17.09.0-ce

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 jobs:
   build_test_publish:
     docker:
-      - image: cidockerbases:docker-latest
+      - image: mozilla/cidockerbases:docker-latest
 
     working_directory: ~/normandy
 


### PR DESCRIPTION
This should speed up our CI builds.