### PR TITLE
filter by text with null bytes shouldn't fail

### DIFF
--- a/normandy/recipes/api/v1/views.py
+++ b/normandy/recipes/api/v1/views.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 import django_filters
 from rest_framework import generics, permissions, views, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, ParseError
 from rest_framework.response import Response
 
 from normandy.base.api.mixins import CachingViewsetMixin
@@ -115,6 +115,8 @@ class RecipeViewSet(CachingViewsetMixin, viewsets.ReadOnlyModelViewSet):
 
         if "text" in self.request.GET:
             text = self.request.GET.get("text")
+            if "\x00" in text:
+                raise ParseError("Null bytes in text")
             queryset = queryset.filter(
                 Q(latest_revision__name__contains=text)
                 | Q(latest_revision__extra_filter_expression__contains=text)

--- a/normandy/recipes/api/v2/views.py
+++ b/normandy/recipes/api/v2/views.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse
 import django_filters
 from rest_framework import permissions, status, viewsets, views
 from rest_framework.decorators import action
+from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
 from normandy.base.api import UpdateOrCreateModelViewSet
@@ -82,6 +83,8 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
 
         if "text" in self.request.GET:
             text = self.request.GET.get("text")
+            if "\x00" in text:
+                raise ParseError("Null bytes in text")
             tokens = set(re.split(r"[ /_-]", text))
             query = Q()
             for token in tokens:

--- a/normandy/recipes/api/v3/views.py
+++ b/normandy/recipes/api/v3/views.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 import django_filters
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
 from normandy.base.api import UpdateOrCreateModelViewSet
@@ -80,6 +81,8 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
 
         if "text" in self.request.GET:
             text = self.request.GET.get("text")
+            if "\x00" in text:
+                raise ParseError("Null bytes in text")
             tokens = set(re.split(r"[ /_-]", text))
             query = Q()
             for token in tokens:

--- a/normandy/recipes/tests/api/v1/test_api.py
+++ b/normandy/recipes/tests/api/v1/test_api.py
@@ -349,6 +349,11 @@ class TestRecipeAPI(object):
             for recipe in res.data:
                 assert recipe["id"] in [r1.id, r2.id]
 
+        def test_list_filter_text_null_bytes(self, api_client):
+            res = api_client.get("/api/v1/recipe/?text=\x00")
+            assert res.status_code == 400
+            assert res.json()["detail"] == "Null bytes in text"
+
         def test_list_filter_action_legacy(self, api_client):
             a1 = ActionFactory()
             a2 = ActionFactory()

--- a/normandy/recipes/tests/api/v2/test_api.py
+++ b/normandy/recipes/tests/api/v2/test_api.py
@@ -877,6 +877,11 @@ class TestRecipeAPI(object):
             for recipe in results:
                 assert recipe["id"] in [r1.id, r2.id]
 
+        def test_list_filter_text_null_bytes(self, api_client):
+            res = api_client.get("/api/v2/recipe/?text=\x00")
+            assert res.status_code == 400
+            assert res.json()["detail"] == "Null bytes in text"
+
         def test_search_works_with_arguments(self, api_client):
             r1 = RecipeFactory(arguments={"one": 1})
             r2 = RecipeFactory(arguments={"two": 2})

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -912,6 +912,11 @@ class TestRecipeAPI(object):
             for recipe in results:
                 assert recipe["id"] in [r1.id, r2.id]
 
+        def test_list_filter_text_null_bytes(self, api_client):
+            res = api_client.get("/api/v3/recipe/?text=\x00")
+            assert res.status_code == 400
+            assert res.json()["detail"] == "Null bytes in text"
+
         def test_search_works_with_arguments(self, api_client):
             r1 = RecipeFactory(arguments={"one": 1})
             r2 = RecipeFactory(arguments={"two": 2})


### PR DESCRIPTION
Better than a `ValueError: A string literal cannot contain NUL (0x00) characters.` deep inside `django/db/backends/utils.py`