### PR TITLE
1535 test coverage holes in api

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+source = normandy
+branch = True
+data_file = /tmp/.coverage
+
+[report]
+omit =
+    tests/*
+    normandy/settings.py
+    normandy/wsgi.py
+
+[xml]
+output = /tmp/coverage.xml

--- a/docs/dev/coverage.rst
+++ b/docs/dev/coverage.rst
@@ -1,0 +1,35 @@
+=============
+Test Coverage
+=============
+
+We do not include test coverage as a metric or a requirement in CI but test coverage as a
+local tool is useful to make sure your code does test all the things you care about.
+
+To use it, install ``coverage`` in your virtualenv env.
+
+.. code-block:: bash
+
+    pip install coverage
+
+Now run the tests with coverage like this:
+
+.. code-block:: bash
+
+    coverage run -m pytest normandy
+
+To generate a report, run:
+
+.. code-block:: bash
+
+    coverage html --skip-covered
+
+This will create the HTML report in the ``./htmlcov/`` directory.
+
+.. code-block:: bash
+
+    open htmlcov/index.html
+
+.. note::
+
+    The ``--skip-covered`` flag means it doesn't create a HTML report for files with 100%
+    test coverage.

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -14,6 +14,7 @@ of the Normandy client.
    workflow
    api-tests
    code-style
+   coverage
    feature-experiments
    troubleshooting
    ci

--- a/normandy/recipes/api/v2/views.py
+++ b/normandy/recipes/api/v2/views.py
@@ -137,10 +137,7 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
         recipe = self.get_object()
 
         if recipe.enabled:
-            try:
-                recipe.approved_revision.disable(user=request.user)
-            except EnabledState.NotActionable as e:
-                return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
+            recipe.approved_revision.disable(user=request.user)
 
         return Response(RecipeSerializer(recipe).data)
 

--- a/normandy/recipes/api/v2/views.py
+++ b/normandy/recipes/api/v2/views.py
@@ -136,8 +136,10 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
     def disable(self, request, pk=None):
         recipe = self.get_object()
 
-        if recipe.enabled:
+        try:
             recipe.approved_revision.disable(user=request.user)
+        except EnabledState.NotActionable as e:
+            return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
 
         return Response(RecipeSerializer(recipe).data)
 

--- a/normandy/recipes/api/v3/views.py
+++ b/normandy/recipes/api/v3/views.py
@@ -134,8 +134,10 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
     def disable(self, request, pk=None):
         recipe = self.get_object()
 
-        if recipe.enabled:
+        try:
             recipe.approved_revision.disable(user=request.user)
+        except EnabledState.NotActionable as e:
+            return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
 
         return Response(RecipeSerializer(recipe).data)
 

--- a/normandy/recipes/api/v3/views.py
+++ b/normandy/recipes/api/v3/views.py
@@ -135,10 +135,7 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
         recipe = self.get_object()
 
         if recipe.enabled:
-            try:
-                recipe.approved_revision.disable(user=request.user)
-            except EnabledState.NotActionable as e:
-                return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
+            recipe.approved_revision.disable(user=request.user)
 
         return Response(RecipeSerializer(recipe).data)
 

--- a/normandy/recipes/tests/api/v2/test_api.py
+++ b/normandy/recipes/tests/api/v2/test_api.py
@@ -689,17 +689,7 @@ class TestRecipeAPI(object):
             assert res.status_code == 409
             assert res.data["error"] == "This revision is already enabled."
 
-        def test_it_can_disable_recipes(self, api_client):
-            recipe = RecipeFactory(approver=UserFactory())
-
-            res = api_client.post("/api/v2/recipe/%s/disable/" % recipe.id)
-            assert res.status_code == 200
-            assert res.data["enabled"] is False
-
-            recipe = Recipe.objects.all()[0]
-            assert not recipe.enabled
-
-        def test_it_cant_disable_enabled_recipes(self, api_client):
+        def test_it_can_disable_enabled_recipes(self, api_client):
             recipe = RecipeFactory(approver=UserFactory(), enabler=UserFactory())
             assert recipe.enabled
 
@@ -709,6 +699,11 @@ class TestRecipeAPI(object):
 
             recipe = Recipe.objects.all()[0]
             assert not recipe.enabled
+
+            # Can't disable it a second time.
+            res = api_client.post("/api/v2/recipe/%s/disable/" % recipe.id)
+            assert res.status_code == 409
+            assert res.json()["error"] == "This revision is already disabled."
 
         def test_detail_view_includes_cache_headers(self, api_client):
             recipe = RecipeFactory()
@@ -1119,6 +1114,13 @@ class TestApprovalFlow(object):
         assert res.status_code == 200
         assert res.json() == recipe_data_2
         self.verify_signatures(api_client, expected_count=1)
+
+        # Can't reject your own approval
+        res = api_client.post(
+            "/api/v2/approval_request/{}/reject/".format(approval_data["id"]), {"comment": "r-"}
+        )
+        assert res.status_code == 403
+        assert res.json()["error"] == "You cannot reject your own approval request."
 
         # Reject the change
         api_client.force_authenticate(user2)

--- a/normandy/recipes/tests/api/v2/test_api.py
+++ b/normandy/recipes/tests/api/v2/test_api.py
@@ -1265,6 +1265,11 @@ class TestIdenticonAPI(object):
         assert "public" in res["Cache-Control"]
         assert "immutable" in res["Cache-Control"]
 
+    def test_unrecognized_generation(self, client):
+        res = client.get("/api/v2/identicon/v9:foobar.svg")
+        assert res.status_code == 400
+        assert res.json()["error"] == "Invalid identicon generation, only v1 is supported."
+
 
 @pytest.mark.django_db
 class TestFilterObjects(object):

--- a/normandy/recipes/tests/api/v2/test_api.py
+++ b/normandy/recipes/tests/api/v2/test_api.py
@@ -699,6 +699,17 @@ class TestRecipeAPI(object):
             recipe = Recipe.objects.all()[0]
             assert not recipe.enabled
 
+        def test_it_cant_disable_enabled_recipes(self, api_client):
+            recipe = RecipeFactory(approver=UserFactory(), enabler=UserFactory())
+            assert recipe.enabled
+
+            res = api_client.post("/api/v2/recipe/%s/disable/" % recipe.id)
+            assert res.status_code == 200
+            assert res.data["enabled"] is False
+
+            recipe = Recipe.objects.all()[0]
+            assert not recipe.enabled
+
         def test_detail_view_includes_cache_headers(self, api_client):
             recipe = RecipeFactory()
             res = api_client.get(f"/api/v2/recipe/{recipe.id}/")

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -734,6 +734,17 @@ class TestRecipeAPI(object):
             recipe = Recipe.objects.all()[0]
             assert not recipe.enabled
 
+        def test_it_cant_disable_enabled_recipes(self, api_client):
+            recipe = RecipeFactory(approver=UserFactory(), enabler=UserFactory())
+            assert recipe.enabled
+
+            res = api_client.post("/api/v3/recipe/%s/disable/" % recipe.id)
+            assert res.status_code == 200
+            assert res.data["enabled"] is False
+
+            recipe = Recipe.objects.all()[0]
+            assert not recipe.enabled
+
         def test_detail_view_includes_cache_headers(self, api_client):
             recipe = RecipeFactory()
             res = api_client.get(f"/api/v3/recipe/{recipe.id}/")


### PR DESCRIPTION
To test this I ran:

```bash
pip install coverage
coverage run -m pytest normandy && coverage html --skip-covered
open htmlcov/index.html
```
I also had to create a `.coveragerc` which I don't know if we can add to the repo since we don't do coverage testing regularly. But I had to create this:

`.coveragerc`:
```
[run]
source = normandy
branch = True
data_file = /tmp/.coverage

[report]
omit =
    tests/*
    normandy/settings.py
    normandy/wsgi.py
    *management*
    *management/commands*

[xml]
output = /tmp/coverage.xml
```