### PR TITLE
unit test untested checks

### DIFF
--- a/normandy/base/checks.py
+++ b/normandy/base/checks.py
@@ -13,7 +13,6 @@ ERROR_MISCONFIGURED_OIDC_LOGOUT_URL = "normandy.base.E005"
 
 def setting_cdn_url(app_configs, **kwargs):
     errors = []
-
     if settings.CDN_URL is not None:
         if settings.CDN_URL[-1] != "/":
             msg = "The setting CDN_URL must end in a slash"

--- a/normandy/base/tests/test_checks.py
+++ b/normandy/base/tests/test_checks.py
@@ -1,0 +1,29 @@
+import pytest
+
+from django.core.checks.registry import run_checks
+
+from normandy.base import checks
+
+
+@pytest.mark.django_db
+def test_run_checks_happy_path():
+    errors = run_checks()
+    assert errors == []
+
+
+@pytest.mark.django_db
+def test_run_checks_all_things_that_can_go_wrong(settings):
+    settings.CDN_URL = "http://cdn.example.com"
+    settings.APP_SERVER_URL = "http://app.example.com"
+    settings.OIDC_REMOTE_AUTH_HEADER = "Y_HTTP_HEADER"
+    settings.OIDC_LOGOUT_URL = None
+    settings.USE_OIDC = True
+    errors = run_checks()
+    assert errors != []
+    error_ids = [x.id for x in errors]
+    assert checks.ERROR_MISCONFIGURED_CDN_URL_SLASH in error_ids
+    assert checks.ERROR_MISCONFIGURED_CDN_URL_HTTPS in error_ids
+    assert checks.ERROR_MISCONFIGURED_APP_SERVER_URL_SLASH in error_ids
+    assert checks.ERROR_MISCONFIGURED_APP_SERVER_URL_HTTPS in error_ids
+    assert checks.ERROR_MISCONFIGURED_OIDC_LOGOUT_URL in error_ids
+    assert checks.WARNING_MISCONFIGURED_OIDC_REMOTE_AUTH_HEADER_PREFIX in error_ids


### PR DESCRIPTION
Part of #1223

This is a cheeky solution. One unit test to run them all in one big sweep. 

At first I thought I'd do something like this:

```python
def test_setting_cdn_url(settings):
    errors = checks.setting_cdn_url(None)
    assert something_about_errors
```

but it would get tedious and we've accepted to live without unit tests for these things for a long time. 

This PR will make sure every *registered* check is run in CI. It's not entirely different in philosophy from when we do...
```python
    def test_it_works(self):
        """
        Verify that the update_actions command doesn't throw an error.
        """
        call_command("update_actions")
```

