### PR TITLE
Wait longer for karma server to be ready

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     command: |
       bash -c "
         ./wait-for-it.sh -t 30 js-tests:9876
-        sleep 1
+        sleep 5
         firefox js-tests:9876 --headless "
 
 volumes:


### PR DESCRIPTION
We theorized this wasn't a long enough timer, and CI has proven that correct.