### PR TITLE
v3 api recipe creation without action|arguments test coverage

### DIFF
--- a/normandy/recipes/api/v3/serializers.py
+++ b/normandy/recipes/api/v3/serializers.py
@@ -153,18 +153,10 @@ class RecipeSerializer(serializers.ModelSerializer):
     def validate(self, data):
         data = super().validate(data)
         action = data.get("action")
-        required_error_msg = serializers.PrimaryKeyRelatedField.default_error_messages["required"]
-
         if action is None:
-            if not self.instance:
-                raise serializers.ValidationError({"action_id": required_error_msg})
             action = self.instance.action
 
         arguments = data.get("arguments")
-
-        if arguments is None and not self.instance:
-            raise serializers.ValidationError({"arguments": required_error_msg})
-
         if arguments is not None:
             # Ensure the value is a dict
             if not isinstance(arguments, dict):

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -260,6 +260,32 @@ class TestRecipeAPI(object):
             recipes = Recipe.objects.all()
             assert recipes.count() == 0
 
+        def test_creation_when_arguments_is_missing(self, api_client):
+            action = ActionFactory(
+                name="foobarbaz",
+                arguments_schema={
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                },
+            )
+            res = api_client.post(
+                "/api/v3/recipe/",
+                {
+                    "name": "Test Recipe",
+                    "enabled": True,
+                    "extra_filter_expression": "true",
+                    "action_id": action.id,
+                },
+            )
+            assert res.status_code == 400
+            assert res.json()["arguments"] == [
+                serializers.PrimaryKeyRelatedField.default_error_messages["required"]
+            ]
+
+            recipes = Recipe.objects.all()
+            assert recipes.count() == 0
+
         def test_creation_when_arguments_is_a_string(self, api_client):
             action = ActionFactory(
                 name="foobarbaz",


### PR DESCRIPTION
Fixes #1547

There are *now* two unit tests that try to create a recipe with the v3 api but with `action_id` or `arguments` omitted from the JSON posted. That's actually, "natively", tested in django rest framework. 