### PR TITLE
Increase cache on deprecated self-repair to one week

### DIFF
--- a/normandy/selfrepair/views.py
+++ b/normandy/selfrepair/views.py
@@ -1,8 +1,10 @@
 from django.shortcuts import render
+from django.views.decorators.cache import cache_control
 
-from normandy.base.decorators import api_cache_control
+
+ONE_WEEK_IN_SECONDS = 60 * 60 * 24 * 7
 
 
-@api_cache_control()
+@cache_control(public=True, max_age=ONE_WEEK_IN_SECONDS)
 def repair(request, locale):
     return render(request, "selfrepair/repair.html")


### PR DESCRIPTION
This view serves a message that the system is no longer active. We keep it around because it is still gets about 40 million hits per day, primarily from Firefox ESR 52, which never got the Normandy client. Notably, when we dropped support for Windows XP from Firefox, we put all XP users onto ESR 52, so we are not likely to be able to remove this endpoint any time soon.

Fixes #1563