### PR TITLE
Support ability to sort by action name

### DIFF
--- a/normandy/base/api/filters.py
+++ b/normandy/base/api/filters.py
@@ -23,12 +23,15 @@ class AliasedOrderingFilter(filters.OrderingFilter):
 
     def get_valid_fields(self, *args, **kwargs):
         valid_fields = super().get_valid_fields(*args, **kwargs)
-        return valid_fields + list(self.aliases.values())
+        for alias, mapping in self.aliases.items():
+            valid_fields.append((alias, mapping[1]))
+        return valid_fields
 
     def get_ordering(self, *args, **kwargs):
         ordering = super().get_ordering(*args, **kwargs)
         if ordering is not None:
             return list(map(self.replace_alias, ordering))
+
         return ordering
 
     def replace_alias(self, term):

--- a/normandy/recipes/api/v2/views.py
+++ b/normandy/recipes/api/v2/views.py
@@ -51,6 +51,7 @@ class RecipeOrderingFilter(AliasedOrderingFilter):
     aliases = {
         "last_updated": ("latest_revision__updated", "Last Updated"),
         "name": ("latest_revision__name", "Name"),
+        "action": ("latest_revision__action__name", "Action"),
     }
 
 

--- a/normandy/recipes/api/v3/views.py
+++ b/normandy/recipes/api/v3/views.py
@@ -58,6 +58,7 @@ class RecipeOrderingFilter(AliasedOrderingFilter):
     aliases = {
         "last_updated": ("latest_revision__updated", "Last Updated"),
         "name": ("latest_revision__name", "Name"),
+        "action": ("latest_revision__action__name", "Action"),
     }
 
 

--- a/normandy/recipes/tests/api/v2/test_api.py
+++ b/normandy/recipes/tests/api/v2/test_api.py
@@ -979,6 +979,27 @@ class TestRecipeAPI(object):
             assert res.status_code == 200
             assert [r["id"] for r in res.data["results"]] == [r2.id, r1.id]
 
+        def test_order_by_action_name(self, api_client):
+            r1 = RecipeFactory(name="a")
+            r1.action.name = "Bee"
+            r1.action.save()
+            r2 = RecipeFactory(name="b")
+            r2.action.name = "Cee"
+            r2.action.save()
+            r3 = RecipeFactory(name="c")
+            r3.action.name = "Ahh"
+            r3.action.save()
+
+            res = api_client.get("/api/v2/recipe/?ordering=action")
+            assert res.status_code == 200
+            # Expected order is ['Ahh', 'Bee', 'Cee']
+            assert [r["id"] for r in res.data["results"]] == [r3.id, r1.id, r2.id]
+
+            res = api_client.get("/api/v2/recipe/?ordering=-action")
+            assert res.status_code == 200
+            # Expected order is ['Cee', 'Bee', 'Ahh']
+            assert [r["id"] for r in res.data["results"]] == [r2.id, r1.id, r3.id]
+
         def test_order_bogus(self, api_client):
             """Test that filtering by an unknown key doesn't change the sort order"""
             RecipeFactory(name="a")

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -1025,6 +1025,27 @@ class TestRecipeAPI(object):
             assert res.status_code == 200
             assert [r["id"] for r in res.data["results"]] == [r2.id, r1.id]
 
+        def test_order_by_action_name(self, api_client):
+            r1 = RecipeFactory(name="a")
+            r1.action.name = "Bee"
+            r1.action.save()
+            r2 = RecipeFactory(name="b")
+            r2.action.name = "Cee"
+            r2.action.save()
+            r3 = RecipeFactory(name="c")
+            r3.action.name = "Ahh"
+            r3.action.save()
+
+            res = api_client.get("/api/v3/recipe/?ordering=action")
+            assert res.status_code == 200
+            # Expected order is ['Ahh', 'Bee', 'Cee']
+            assert [r["id"] for r in res.data["results"]] == [r3.id, r1.id, r2.id]
+
+            res = api_client.get("/api/v3/recipe/?ordering=-action")
+            assert res.status_code == 200
+            # Expected order is ['Cee', 'Bee', 'Ahh']
+            assert [r["id"] for r in res.data["results"]] == [r2.id, r1.id, r3.id]
+
         def test_order_bogus(self, api_client):
             """Test that filtering by an unknown key doesn't change the sort order"""
             RecipeFactory(name="a")


### PR DESCRIPTION
Fixes #1573 

I hope this doesn't screw up your pending work on v3 refactoring @mythmon 

The ultimate motive with this is to support [better filtering/sorting by action in delivery console](https://github.com/mozilla/delivery-console/issues/151).