### PR TITLE
validate filter objects' locales, countries and channels

### DIFF
--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -22,7 +22,6 @@ field, so the final JSON would look something like this:
 
 from rest_framework import serializers
 
-
 # If you add a new filter to this file, remember to update the docs too!
 
 
@@ -54,6 +53,15 @@ class ChannelFilter(BaseFilter):
     type = "channel"
     channels = serializers.ListField(child=serializers.CharField(), min_length=1)
 
+    def validate_channels(self, value):
+        # Avoid circular imports
+        from normandy.recipes.models import Channel
+
+        for slug in value:
+            if not Channel.objects.filter(slug=slug).exists():
+                raise serializers.ValidationError(f"Unrecognized channel slug {slug!r}")
+        return value
+
     def to_jexl(self):
         channels = ",".join(f'"{c}"' for c in self.data["channels"])
         return f"normandy.channel in [{channels}]"
@@ -77,6 +85,15 @@ class LocaleFilter(BaseFilter):
     type = "locale"
     locales = serializers.ListField(child=serializers.CharField(), min_length=1)
 
+    def validate_locales(self, value):
+        # Avoid circular imports
+        from normandy.recipes.models import Locale
+
+        for code in value:
+            if not Locale.objects.filter(code=code).exists():
+                raise serializers.ValidationError(f"Unrecognized locale code {code!r}")
+        return value
+
     def to_jexl(self):
         locales = ",".join(f'"{l}"' for l in self.data["locales"])
         return f"normandy.locale in [{locales}]"
@@ -98,6 +115,15 @@ class CountryFilter(BaseFilter):
 
     type = "country"
     countries = serializers.ListField(child=serializers.CharField(), min_length=1)
+
+    def validate_countries(self, value):
+        # Avoid circular imports
+        from normandy.recipes.models import Country
+
+        for code in value:
+            if not Country.objects.filter(code=code).exists():
+                raise serializers.ValidationError(f"Unrecognized country code {code!r}")
+        return value
 
     def to_jexl(self):
         countries = ",".join(f'"{c}"' for c in self.data["countries"])

--- a/normandy/recipes/tests/__init__.py
+++ b/normandy/recipes/tests/__init__.py
@@ -9,12 +9,39 @@ from normandy.base.utils import sri_hash
 from normandy.recipes.models import (
     Action,
     ApprovalRequest,
+    Channel,
     Client,
+    Country,
     EnabledState,
+    Locale,
     Recipe,
     RecipeRevision,
     Signature,
 )
+
+
+class ChannelFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Channel
+
+    slug = "beta"
+    name = "Beta"
+
+
+class CountryFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Country
+
+    code = "SE"
+    name = "Sweden"
+
+
+class LocaleFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Locale
+
+    code = "sv"
+    name = "Swedish"
 
 
 class ActionFactory(factory.DjangoModelFactory):

--- a/normandy/recipes/tests/api/v2/test_api.py
+++ b/normandy/recipes/tests/api/v2/test_api.py
@@ -12,10 +12,13 @@ from pathlib import Path
 from normandy.base.api.permissions import AdminEnabledOrReadOnly
 from normandy.base.tests import UserFactory, Whatever
 from normandy.base.utils import canonical_json_dumps
-from normandy.recipes.models import ApprovalRequest, Channel, Country, Locale, Recipe
+from normandy.recipes.models import ApprovalRequest, Recipe
 from normandy.recipes.tests import (
     ActionFactory,
     ApprovalRequestFactory,
+    ChannelFactory,
+    CountryFactory,
+    LocaleFactory,
     RecipeFactory,
     RecipeRevisionFactory,
     fake_sign,
@@ -159,7 +162,7 @@ class TestRecipeAPI(object):
 
         def test_it_can_create_recipes_with_only_filter_object(self, api_client):
             action = ActionFactory()
-            Channel.objects.get_or_create(slug="beta", name="Beta")
+            channel = ChannelFactory()
 
             res = api_client.post(
                 "/api/v2/recipe/",
@@ -168,7 +171,7 @@ class TestRecipeAPI(object):
                     "action_id": action.id,
                     "arguments": {},
                     "extra_filter_expression": "   ",
-                    "filter_object": [{"type": "channel", "channels": ["beta"]}],
+                    "filter_object": [{"type": "channel", "channels": [channel.slug]}],
                     "enabled": True,
                 },
             )
@@ -177,11 +180,11 @@ class TestRecipeAPI(object):
             assert Recipe.objects.count() == 1
             recipe = Recipe.objects.get()
             assert recipe.extra_filter_expression == ""
-            assert recipe.filter_expression == 'normandy.channel in ["beta"]'
+            assert recipe.filter_expression == f'normandy.channel in ["{channel.slug}"]'
 
         def test_it_can_create_extra_filter_expression_omitted(self, api_client):
             action = ActionFactory()
-            Channel.objects.get_or_create(slug="beta", name="Beta")
+            channel = ChannelFactory()
 
             # First try to create a recipe with 0 filter objects.
             res = api_client.post(
@@ -206,7 +209,7 @@ class TestRecipeAPI(object):
                     "name": "Test Recipe",
                     "action_id": action.id,
                     "arguments": {},
-                    "filter_object": [{"type": "channel", "channels": ["beta"]}],
+                    "filter_object": [{"type": "channel", "channels": [channel.slug]}],
                     "enabled": True,
                 },
             )
@@ -215,7 +218,7 @@ class TestRecipeAPI(object):
             assert Recipe.objects.count() == 1
             recipe = Recipe.objects.get()
             assert recipe.extra_filter_expression == ""
-            assert recipe.filter_expression == 'normandy.channel in ["beta"]'
+            assert recipe.filter_expression == f'normandy.channel in ["{channel.slug}"]'
 
         def test_it_can_create_recipes_actions_without_implementation(self, api_client):
             action = ActionFactory(implementation=None)
@@ -500,26 +503,29 @@ class TestRecipeAPI(object):
 
         def test_it_can_update_recipes_with_only_filter_object(self, api_client):
             recipe = RecipeFactory(name="unchanged", extra_filter_expression="true")
-            Channel.objects.get_or_create(slug="beta", name="Beta")
+            channel = ChannelFactory()
 
             res = api_client.patch(
                 "/api/v2/recipe/%s/" % recipe.id,
                 {
                     "name": "changed",
                     "extra_filter_expression": "",
-                    "filter_object": [{"type": "channel", "channels": ["beta"]}],
+                    "filter_object": [{"type": "channel", "channels": [channel.slug]}],
                 },
             )
             assert res.status_code == 200, res.json()
             recipe.refresh_from_db()
             assert recipe.extra_filter_expression == ""
             assert recipe.filter_object
-            assert recipe.filter_expression == 'normandy.channel in ["beta"]'
+            assert recipe.filter_expression == f'normandy.channel in ["{channel.slug}"]'
 
             # And you can omit it too
             res = api_client.patch(
                 "/api/v2/recipe/%s/" % recipe.id,
-                {"name": "changed", "filter_object": [{"type": "channel", "channels": ["beta"]}]},
+                {
+                    "name": "changed",
+                    "filter_object": [{"type": "channel", "channels": [channel.slug]}],
+                },
             )
             assert res.status_code == 200, res.json()
             recipe.refresh_from_db()
@@ -579,7 +585,7 @@ class TestRecipeAPI(object):
             assert res.json() == {
                 "filter_object": {"0": {"channels": ["Unrecognized channel slug 'nightwolf'"]}}
             }
-            Channel.objects.create(slug="nightwolf", name="Nightwolf")
+            ChannelFactory(slug="nightwolf")
             res = self.make_recipe(
                 api_client, filter_object=[{"type": "channel", "channels": ["nightwolf"]}]
             )
@@ -594,9 +600,9 @@ class TestRecipeAPI(object):
                 "filter_object": {"0": {"locales": ["Unrecognized locale code 'sv'"]}}
             }
 
-            Locale.objects.create(code="sv", name="Swedish")
+            locale = LocaleFactory()
             res = self.make_recipe(
-                api_client, filter_object=[{"type": "locale", "locales": ["sv"]}]
+                api_client, filter_object=[{"type": "locale", "locales": [locale.code]}]
             )
             assert res.status_code == 201
 
@@ -609,24 +615,25 @@ class TestRecipeAPI(object):
                 "filter_object": {"0": {"countries": ["Unrecognized country code 'SS'"]}}
             }
 
-            Country.objects.create(code="SS", name="South Sudan")
+            CountryFactory(code="SS", name="South Sudan")
             res = self.make_recipe(
                 api_client, filter_object=[{"type": "country", "countries": ["SS"]}]
             )
             assert res.status_code == 201
 
         def test_channel_works(self, api_client):
-            Channel.objects.get_or_create(slug="beta", name="Beta")
-            Channel.objects.get_or_create(slug="release", name="Release")
+            channel1 = ChannelFactory(slug="beta")
+            channel2 = ChannelFactory(slug="release")
             res = self.make_recipe(
-                api_client, filter_object=[{"type": "channel", "channels": ["release", "beta"]}]
+                api_client,
+                filter_object=[{"type": "channel", "channels": [channel1.slug, channel2.slug]}],
             )
             assert res.status_code == 201, res.json()
             recipe_data = res.json()
 
             Recipe.objects.get(id=recipe_data["id"])
             assert recipe_data["filter_expression"] == (
-                '(normandy.channel in ["release","beta"]) && (true)'
+                f'(normandy.channel in ["{channel1.slug}","{channel2.slug}"]) && (true)'
             )
 
         def test_channel_correct_fields(self, api_client):
@@ -637,17 +644,18 @@ class TestRecipeAPI(object):
             }
 
         def test_locale_works(self, api_client):
-            Locale.objects.create(code="en-US", name="English")
-            Locale.objects.create(code="de", name="German")
+            locale1 = LocaleFactory()
+            locale2 = LocaleFactory(code="de")
             res = self.make_recipe(
-                api_client, filter_object=[{"type": "locale", "locales": ["en-US", "de"]}]
+                api_client,
+                filter_object=[{"type": "locale", "locales": [locale1.code, locale2.code]}],
             )
             assert res.status_code == 201, res.json()
             recipe_data = res.json()
 
             Recipe.objects.get(id=recipe_data["id"])
             assert recipe_data["filter_expression"] == (
-                '(normandy.locale in ["en-US","de"]) && (true)'
+                f'(normandy.locale in ["{locale1.code}","{locale2.code}"]) && (true)'
             )
 
         def test_locale_correct_fields(self, api_client):
@@ -656,17 +664,18 @@ class TestRecipeAPI(object):
             assert res.json() == {"filter_object": {"0": {"locales": ["This field is required."]}}}
 
         def test_country_works(self, api_client):
-            Country.objects.get_or_create(code="US", name="United States of America")
-            Country.objects.get_or_create(code="DE", name="Germany")
+            country1 = CountryFactory()
+            country2 = CountryFactory(code="DE")
             res = self.make_recipe(
-                api_client, filter_object=[{"type": "country", "countries": ["US", "DE"]}]
+                api_client,
+                filter_object=[{"type": "country", "countries": [country1.code, country2.code]}],
             )
             assert res.status_code == 201, res.json()
             recipe_data = res.json()
 
             Recipe.objects.get(id=recipe_data["id"])
             assert recipe_data["filter_expression"] == (
-                '(normandy.country in ["US","DE"]) && (true)'
+                f'(normandy.country in ["{country1.code}","{country2.code}"]) && (true)'
             )
 
         def test_country_correct_fields(self, api_client):
@@ -1483,13 +1492,16 @@ class TestFilterObjects(object):
         assert res.json() == {"filter_object": {"0": {"type": ["This field is required."]}}}
 
     def test_channel_works(self, api_client):
-        Channel.objects.get_or_create(slug="beta", name="Beta")
-        Channel.objects.get_or_create(slug="release", name="Release")
+        channel1 = ChannelFactory(slug="beta")
+        channel2 = ChannelFactory(slug="release")
         res = self.make_recipe(
-            api_client, filter_object=[{"type": "channel", "channels": ["release", "beta"]}]
+            api_client,
+            filter_object=[{"type": "channel", "channels": [channel1.slug, channel2.slug]}],
         )
         assert res.status_code == 201, res.json()
-        assert res.json()["filter_expression"] == ('normandy.channel in ["release","beta"]')
+        assert res.json()["filter_expression"] == (
+            f'normandy.channel in ["{channel1.slug}","{channel2.slug}"]'
+        )
 
     def test_channel_correct_fields(self, api_client):
         res = self.make_recipe(api_client, filter_object=[{"type": "channel"}])
@@ -1497,13 +1509,15 @@ class TestFilterObjects(object):
         assert res.json() == {"filter_object": {"0": {"channels": ["This field is required."]}}}
 
     def test_locale_works(self, api_client):
-        Locale.objects.get_or_create(code="en-US", name="English (US)")
-        Locale.objects.get_or_create(code="de", name="German")
+        locale1 = LocaleFactory()
+        locale2 = LocaleFactory(code="de")
         res = self.make_recipe(
-            api_client, filter_object=[{"type": "locale", "locales": ["en-US", "de"]}]
+            api_client, filter_object=[{"type": "locale", "locales": [locale1.code, locale2.code]}]
         )
         assert res.status_code == 201, res.json()
-        assert res.json()["filter_expression"] == ('normandy.locale in ["en-US","de"]')
+        assert res.json()["filter_expression"] == (
+            f'normandy.locale in ["{locale1.code}","{locale2.code}"]'
+        )
 
     def test_locale_correct_fields(self, api_client):
         res = self.make_recipe(api_client, filter_object=[{"type": "locale"}])
@@ -1511,13 +1525,16 @@ class TestFilterObjects(object):
         assert res.json() == {"filter_object": {"0": {"locales": ["This field is required."]}}}
 
     def test_country_works(self, api_client):
-        Country.objects.get_or_create(code="US", name="United States of America")
-        Country.objects.get_or_create(code="DE", name="Germany")
+        country1 = CountryFactory()
+        country2 = CountryFactory(code="DE")
         res = self.make_recipe(
-            api_client, filter_object=[{"type": "country", "countries": ["US", "DE"]}]
+            api_client,
+            filter_object=[{"type": "country", "countries": [country1.code, country2.code]}],
         )
         assert res.status_code == 201, res.json()
-        assert res.json()["filter_expression"] == ('normandy.country in ["US","DE"]')
+        assert res.json()["filter_expression"] == (
+            f'normandy.country in ["{country1.code}","{country2.code}"]'
+        )
 
     def test_country_correct_fields(self, api_client):
         res = self.make_recipe(api_client, filter_object=[{"type": "country"}])

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -10,7 +10,7 @@ from rest_framework.reverse import reverse
 from normandy.base.api.permissions import AdminEnabledOrReadOnly
 from normandy.base.tests import UserFactory, Whatever
 from normandy.base.utils import canonical_json_dumps
-from normandy.recipes.models import ApprovalRequest, Recipe, Channel, Country, Locale
+from normandy.recipes.models import ApprovalRequest, Channel, Country, Locale, Recipe
 from normandy.recipes.tests import (
     ActionFactory,
     ApprovalRequestFactory,
@@ -369,6 +369,7 @@ class TestRecipeAPI(object):
 
         def test_it_can_create_recipes_with_only_filter_object(self, api_client):
             action = ActionFactory()
+            Channel.objects.get_or_create(slug="beta", name="Beta")
 
             res = api_client.post(
                 "/api/v3/recipe/",
@@ -390,6 +391,7 @@ class TestRecipeAPI(object):
 
         def test_it_can_create_extra_filter_expression_omitted(self, api_client):
             action = ActionFactory()
+            Channel.objects.get_or_create(slug="beta", name="Beta")
 
             # First try to create a recipe with 0 filter objects.
             res = api_client.post(
@@ -533,6 +535,7 @@ class TestRecipeAPI(object):
 
         def test_it_can_update_recipes_with_only_filter_object(self, api_client):
             recipe = RecipeFactory(name="unchanged", extra_filter_expression="true")
+            Channel.objects.get_or_create(slug="beta", name="Beta")
 
             res = api_client.patch(
                 "/api/v3/recipe/%s/" % recipe.id,
@@ -603,7 +606,53 @@ class TestRecipeAPI(object):
             assert res.status_code == 400
             assert res.json() == {"filter_object": {"0": {"type": ["This field is required."]}}}
 
+        def test_validate_filter_objects_channels(self, api_client):
+            res = self.make_recipe(
+                api_client, filter_object=[{"type": "channel", "channels": ["nightwolf"]}]
+            )
+            assert res.status_code == 400
+            assert res.json() == {
+                "filter_object": {"0": {"channels": ["Unrecognized channel slug 'nightwolf'"]}}
+            }
+            Channel.objects.create(slug="nightwolf", name="Nightwolf")
+            res = self.make_recipe(
+                api_client, filter_object=[{"type": "channel", "channels": ["nightwolf"]}]
+            )
+            assert res.status_code == 201
+
+        def test_validate_filter_objects_locales(self, api_client):
+            res = self.make_recipe(
+                api_client, filter_object=[{"type": "locale", "locales": ["sv"]}]
+            )
+            assert res.status_code == 400
+            assert res.json() == {
+                "filter_object": {"0": {"locales": ["Unrecognized locale code 'sv'"]}}
+            }
+
+            Locale.objects.create(code="sv", name="Swedish")
+            res = self.make_recipe(
+                api_client, filter_object=[{"type": "locale", "locales": ["sv"]}]
+            )
+            assert res.status_code == 201
+
+        def test_validate_filter_objects_countries(self, api_client):
+            res = self.make_recipe(
+                api_client, filter_object=[{"type": "country", "countries": ["SS"]}]
+            )
+            assert res.status_code == 400
+            assert res.json() == {
+                "filter_object": {"0": {"countries": ["Unrecognized country code 'SS'"]}}
+            }
+
+            Country.objects.create(code="SS", name="South Sudan")
+            res = self.make_recipe(
+                api_client, filter_object=[{"type": "country", "countries": ["SS"]}]
+            )
+            assert res.status_code == 201
+
         def test_channel_works(self, api_client):
+            Channel.objects.get_or_create(slug="beta", name="Beta")
+            Channel.objects.get_or_create(slug="release", name="Release")
             res = self.make_recipe(
                 api_client, filter_object=[{"type": "channel", "channels": ["release", "beta"]}]
             )
@@ -623,6 +672,8 @@ class TestRecipeAPI(object):
             }
 
         def test_locale_works(self, api_client):
+            Locale.objects.create(code="en-US", name="English")
+            Locale.objects.create(code="de", name="German")
             res = self.make_recipe(
                 api_client, filter_object=[{"type": "locale", "locales": ["en-US", "de"]}]
             )
@@ -640,6 +691,8 @@ class TestRecipeAPI(object):
             assert res.json() == {"filter_object": {"0": {"locales": ["This field is required."]}}}
 
         def test_country_works(self, api_client):
+            Country.objects.get_or_create(code="US", name="United States of America")
+            Country.objects.get_or_create(code="DE", name="Germany")
             res = self.make_recipe(
                 api_client, filter_object=[{"type": "country", "countries": ["US", "DE"]}]
             )
@@ -1451,6 +1504,8 @@ class TestFilterObjects(object):
         assert res.json() == {"filter_object": {"0": {"type": ["This field is required."]}}}
 
     def test_channel_works(self, api_client):
+        Channel.objects.get_or_create(slug="beta", name="Beta")
+        Channel.objects.get_or_create(slug="release", name="Release")
         res = self.make_recipe(
             api_client, filter_object=[{"type": "channel", "channels": ["release", "beta"]}]
         )
@@ -1463,6 +1518,8 @@ class TestFilterObjects(object):
         assert res.json() == {"filter_object": {"0": {"channels": ["This field is required."]}}}
 
     def test_locale_works(self, api_client):
+        Locale.objects.get_or_create(code="en-US", name="English (US)")
+        Locale.objects.get_or_create(code="de", name="German")
         res = self.make_recipe(
             api_client, filter_object=[{"type": "locale", "locales": ["en-US", "de"]}]
         )
@@ -1475,6 +1532,8 @@ class TestFilterObjects(object):
         assert res.json() == {"filter_object": {"0": {"locales": ["This field is required."]}}}
 
     def test_country_works(self, api_client):
+        Country.objects.get_or_create(code="US", name="United States of America")
+        Country.objects.get_or_create(code="DE", name="Germany")
         res = self.make_recipe(
             api_client, filter_object=[{"type": "country", "countries": ["US", "DE"]}]
         )


### PR DESCRIPTION
Fixes #1544 

I'm generally very reluctant to fixtures but perhaps we could add some that add `Channel.objects.create(slug="beta, name="Beta"); Channel.objects.create(slug="release", name="Release")`