### PR TITLE
authentication backends should take 'request' as first pos argument

### DIFF
--- a/normandy/base/auth_backends.py
+++ b/normandy/base/auth_backends.py
@@ -22,8 +22,8 @@ class LoggingAuthBackendMixin(object):
     def get_username(self, **kwargs):
         raise NotImplemented()
 
-    def authenticate(self, **kwargs):
-        result = super().authenticate(**kwargs)
+    def authenticate(self, request, **kwargs):
+        result = super().authenticate(request, **kwargs)
         username = self.get_username(**kwargs)
 
         if result is None:

--- a/normandy/base/tests/test_auth_backends.py
+++ b/normandy/base/tests/test_auth_backends.py
@@ -1,5 +1,7 @@
 import pytest
 
+from django.test import RequestFactory
+
 from normandy.base.auth_backends import (
     INFO_LOGIN_SUCCESS,
     LoggingModelBackend,
@@ -20,7 +22,10 @@ class TestLoggingModelBackend(object):
 
     def test_log_failure_username(self, mock_logger, mock_authenticate):
         mock_authenticate.return_value = None
-        user = LoggingModelBackend().authenticate(username="fakeuser", password="does.not.exist")
+        request = RequestFactory().get("/")
+        user = LoggingModelBackend().authenticate(
+            request, username="fakeuser", password="does.not.exist"
+        )
         assert user is None
         mock_logger.warning.assert_called_with(
             Whatever.contains("fakeuser"), extra={"code": WARNING_LOGIN_FAILURE}
@@ -28,7 +33,8 @@ class TestLoggingModelBackend(object):
 
     def test_log_failure_no_username(self, mock_logger, mock_authenticate):
         mock_authenticate.return_value = None
-        user = LoggingModelBackend().authenticate(password="does.not.exist")
+        request = RequestFactory().get("/")
+        user = LoggingModelBackend().authenticate(request, password="does.not.exist")
         assert user is None
         mock_logger.warning.assert_called_with(
             Whatever.contains("no username provided"), extra={"code": WARNING_LOGIN_FAILURE}
@@ -36,7 +42,10 @@ class TestLoggingModelBackend(object):
 
     def test_log_success(self, mock_logger, mock_authenticate):
         mock_authenticate.return_value = True
-        user = LoggingModelBackend().authenticate(username="fakeuser", password="does.not.exist")
+        request = RequestFactory().get("/")
+        user = LoggingModelBackend().authenticate(
+            request, username="fakeuser", password="does.not.exist"
+        )
         assert user
         mock_logger.info.assert_called_with(
             Whatever.contains("fakeuser"), extra={"code": INFO_LOGIN_SUCCESS}


### PR DESCRIPTION
Fixes #1579

