### PR TITLE
Don't validate filter objects when rendering existing filters

### DIFF
--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -63,7 +63,7 @@ class ChannelFilter(BaseFilter):
         return value
 
     def to_jexl(self):
-        channels = ",".join(f'"{c}"' for c in self.data["channels"])
+        channels = ",".join(f'"{c}"' for c in self.initial_data["channels"])
         return f"normandy.channel in [{channels}]"
 
 
@@ -95,7 +95,7 @@ class LocaleFilter(BaseFilter):
         return value
 
     def to_jexl(self):
-        locales = ",".join(f'"{l}"' for l in self.data["locales"])
+        locales = ",".join(f'"{l}"' for l in self.initial_data["locales"])
         return f"normandy.locale in [{locales}]"
 
 
@@ -126,7 +126,7 @@ class CountryFilter(BaseFilter):
         return value
 
     def to_jexl(self):
-        countries = ",".join(f'"{c}"' for c in self.data["countries"])
+        countries = ",".join(f'"{c}"' for c in self.initial_data["countries"])
         return f"normandy.country in [{countries}]"
 
 
@@ -187,10 +187,10 @@ class BucketSampleFilter(BaseFilter):
     input = serializers.ListField(child=serializers.CharField(), min_length=1)
 
     def to_jexl(self):
-        inputs = ",".join(f"{i}" for i in self.data["input"])
-        start = self.data["start"]
-        count = self.data["count"]
-        total = self.data["total"]
+        inputs = ",".join(f"{i}" for i in self.initial_data["input"])
+        start = self.initial_data["start"]
+        count = self.initial_data["count"]
+        total = self.initial_data["total"]
         return f"[{inputs}]|bucketSample({start},{count},{total})"
 
 
@@ -230,8 +230,8 @@ class StableSampleFilter(BaseFilter):
     input = serializers.ListField(child=serializers.CharField(), min_length=1)
 
     def to_jexl(self):
-        inputs = ",".join(f"{i}" for i in self.data["input"])
-        rate = self.data["rate"]
+        inputs = ",".join(f"{i}" for i in self.initial_data["input"])
+        rate = self.initial_data["rate"]
         return f"[{inputs}]|stableSample({rate})"
 
 
@@ -268,7 +268,8 @@ class VersionFilter(BaseFilter):
         #   (normandy.version >= 57 && normandy.version < 58)
 
         return "||".join(
-            f'(normandy.version>="{v}"&&normandy.version<"{v + 1}")' for v in self.data["versions"]
+            f'(normandy.version>="{v}"&&normandy.version<"{v + 1}")'
+            for v in self.initial_data["versions"]
         )
 
 

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -372,7 +372,6 @@ class RecipeRevision(DirtyFieldsMixin, models.Model):
 
         for obj in self.filter_object:
             filter = filters.from_data(obj)
-            assert filter.is_valid(), [obj, filter.errors]
             parts.append(filter.to_jexl())
 
         if self.extra_filter_expression:

--- a/normandy/recipes/tests/api/v2/test_api.py
+++ b/normandy/recipes/tests/api/v2/test_api.py
@@ -416,7 +416,9 @@ class TestRecipeAPI(object):
     @pytest.mark.django_db
     class TestUpdates(object):
         def test_it_can_edit_recipes(self, api_client):
-            recipe = RecipeFactory(name="unchanged", extra_filter_expression="true")
+            recipe = RecipeFactory(
+                name="unchanged", extra_filter_expression="true", filter_object_json=None
+            )
             old_revision_id = recipe.revision_id
 
             res = api_client.patch(
@@ -703,7 +705,7 @@ class TestRecipeAPI(object):
 
             Recipe.objects.get(id=recipe_data["id"])
             assert recipe_data["filter_expression"] == (
-                "([normandy.userId,normandy.recipeId]|bucketSample(1.0,2.0,3.0)) && (true)"
+                "([normandy.userId,normandy.recipeId]|bucketSample(1,2,3)) && (true)"
             )
 
         def test_bucket_sample_correct_fields(self, api_client):
@@ -1556,7 +1558,7 @@ class TestFilterObjects(object):
         )
         assert res.status_code == 201, res.json()
         assert res.json()["filter_expression"] == (
-            "[normandy.userId,normandy.recipeId]|bucketSample(1.0,2.0,3.0)"
+            "[normandy.userId,normandy.recipeId]|bucketSample(1,2,3)"
         )
 
     def test_bucket_sample_correct_fields(self, api_client):

--- a/normandy/recipes/tests/api/v2/test_serializers.py
+++ b/normandy/recipes/tests/api/v2/test_serializers.py
@@ -18,7 +18,7 @@ from normandy.recipes.api.v2.serializers import (
 @pytest.mark.django_db()
 class TestRecipeSerializer:
     def test_it_works(self, rf):
-        recipe = RecipeFactory(arguments={"foo": "bar"})
+        recipe = RecipeFactory(arguments={"foo": "bar"}, filter_object_json=None)
         approval = ApprovalRequestFactory(revision=recipe.latest_revision)
         action = recipe.action
         serializer = RecipeSerializer(recipe, context={"request": rf.get("/")})

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -464,7 +464,9 @@ class TestRecipeAPI(object):
     @pytest.mark.django_db
     class TestUpdates(object):
         def test_it_can_edit_recipes(self, api_client):
-            recipe = RecipeFactory(name="unchanged", extra_filter_expression="true")
+            recipe = RecipeFactory(
+                name="unchanged", extra_filter_expression="true", filter_object_json=None
+            )
             old_revision_id = recipe.revision_id
 
             res = api_client.patch(
@@ -769,7 +771,7 @@ class TestRecipeAPI(object):
 
             Recipe.objects.get(id=recipe_data["id"])
             assert recipe_data["latest_revision"]["filter_expression"] == (
-                "([normandy.userId,normandy.recipeId]|bucketSample(1.0,2.0,3.0)) && (true)"
+                "([normandy.userId,normandy.recipeId]|bucketSample(1,2,3)) && (true)"
             )
 
         def test_bucket_sample_correct_fields(self, api_client):
@@ -1627,7 +1629,7 @@ class TestFilterObjects(object):
         )
         assert res.status_code == 201, res.json()
         assert res.json()["latest_revision"]["filter_expression"] == (
-            "[normandy.userId,normandy.recipeId]|bucketSample(1.0,2.0,3.0)"
+            "[normandy.userId,normandy.recipeId]|bucketSample(1,2,3)"
         )
 
     def test_bucket_sample_correct_fields(self, api_client):

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -268,10 +268,10 @@ class TestRecipe(object):
         assert recipe.revision_id == revision_id
 
     def test_filter_expression(self):
-        r = RecipeFactory()
+        r = RecipeFactory(extra_filter_expression="", filter_object_json=None)
         assert r.filter_expression == ""
 
-        r = RecipeFactory(extra_filter_expression="2 + 2 == 4")
+        r = RecipeFactory(extra_filter_expression="2 + 2 == 4", filter_object_json=None)
         assert r.filter_expression == "2 + 2 == 4"
 
     def test_canonical_json(self):
@@ -280,6 +280,7 @@ class TestRecipe(object):
             arguments_json='{"foo": 1, "bar": 2}',
             extra_filter_expression="2 + 2 == 4",
             name="canonical",
+            filter_object_json=None,
         )
         # Yes, this is really ugly, but we really do need to compare an exact
         # byte sequence, since this is used for hashing and signing
@@ -403,6 +404,7 @@ class TestRecipe(object):
             action=a1,
             arguments={"message": "something"},
             extra_filter_expression="something !== undefined",
+            filter_object_json=None,
         )
         a2 = ActionFactory()
         recipe.revise(name="changed", action=a2)


### PR DESCRIPTION
This was causing extra DB queries that weren't needed.

Fixes #1589