### PR TITLE
Fix name of setting for gcs bucket

### DIFF
--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -343,7 +343,7 @@ in other Django projects.
    ``DJANGO_AWS_SECRET_ACCESS_KEY`` may also be needed.
 
    When using GCP, it is required to also set
-   ``DJANGO_GCS_STORAGE_BUCKET_NAME``.
+   ``DJANGO_GS_BUCKET_NAME``.
 
 .. envvar:: DJANGO_AWS_ACCESS_KEY_ID
 
@@ -362,7 +362,7 @@ in other Django projects.
 
    The name of the S3 bucket to be used to store media files.
 
-.. envvar:: DJANGO_GCP_STORAGE_BUCKET_NAME
+.. envvar:: DJANGO_GS_BUCKET_NAME
 
    The name of the Google storage bucket to be used to store media files.
 

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -365,7 +365,7 @@ class Base(Core, CORS, OIDC):
     AWS_ACCESS_KEY_ID = values.Value()
     AWS_SECRET_ACCESS_KEY = values.Value()
     AWS_STORAGE_BUCKET_NAME = values.Value()
-    GCS_STORAGE_BUCKET_NAME = values.Value()
+    GS_BUCKET_NAME = values.Value()
 
     GITHUB_URL = values.Value("https://github.com/mozilla/normandy")
 


### PR DESCRIPTION
It should be GS_BUCKET_NAME according to the documentation at https://django-storages.readthedocs.io/en/latest/backends/gcloud.html

This will hopefully fix #1566 