### PR TITLE
unbreak docs tests in 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
 
   docs:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Note, it's still a mystery how we managed to allow bors to land those changes despite the `docs` job failed. 