### PR TITLE
Pass CI envvar into test containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
           # requires an explicit list so it doesn't try to pull images that
           # have already been built.
           command: |
+            ./bin/download_geolite2.sh
             docker-compose build
             docker-compose pull db
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 .env*
 .floo*
 docs/_build
-GeoLite2-Country.mmdb
 media
 node_modules
 pip-cache

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ studies, user surveys and controlled rollout of new features.
 
 Normandy is licensed under the MPLv2. See the `LICENSE` file for details.
 
+The Docker images published for Normandy include GeoLite2 data created by
+MaxMind, available from https://www.maxmind.com.
+
 # Hacking
 
 Please see the [Developer Setup] documentation to get started.

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     ports:
       - 8000:8000
     environment:
+      - CI
       - DJANGO_CONFIGURATION=ProductionInsecure
       - DATABASE_URL=postgres://postgres@db/postgres
       - ARTIFACTS_PATH=/artifacts
@@ -28,6 +29,8 @@ services:
 
   artifact-collector:
     image: ubuntu:18.04 # TODO this could be a more minimal image
+    environment:
+      - CI
     volumes:
       - test-artifacts:/artifacts
     command: |
@@ -42,6 +45,7 @@ services:
     ports:
       - 9876:9876
     environment:
+      - CI
       - ARTIFACTS_PATH=/artifacts
     volumes:
       - test-artifacts:/artifacts
@@ -51,6 +55,8 @@ services:
     build:
       context: .
       dockerfile: js-tests-browser.Dockerfile
+    environment:
+      - CI
     # The test runner starts listening on the port slightly before it starts
     # acceptions requests. Waiting a second makes this work more reliably.
     command: |


### PR DESCRIPTION
I expect this will cause CI to fail on GeoIP tests until providing a maxmind db in CI.