### PR TITLE
Exit sync_remote_settings with non-zero with dry-run if unsync

### DIFF
--- a/normandy/recipes/management/commands/sync_remote_settings.py
+++ b/normandy/recipes/management/commands/sync_remote_settings.py
@@ -1,3 +1,5 @@
+import sys
+
 from django.core.management.base import BaseCommand
 
 from normandy.recipes.models import Recipe
@@ -79,3 +81,7 @@ class Command(BaseCommand):
             self.stdout.write(f" * {name!r} (id={r.id!r})")
             if not dry_run:
                 remote_settings.unpublish(r)
+
+        # When running with dry-run, we return non-zero if some differences exist.
+        if dry_run and (to_publish or to_update or to_unpublish):
+            sys.exit(1)


### PR DESCRIPTION
follow-up #1616 

If the command `sync_remote_settings --dry-run` is meant to be ran in cronjob (or similar) it should exit with non-zero if some recipes are unsync. This will allow us to use the dry-run command as a way to check that everything is kept in sync successfully