### PR TITLE
moar select/prefetch related to get v3 recipes

### DIFF
--- a/normandy/recipes/api/v3/views.py
+++ b/normandy/recipes/api/v3/views.py
@@ -68,18 +68,26 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
         Recipe.objects.all()
         .select_related(
             "approved_revision__action",
+            "approved_revision__user",
             "approved_revision__approval_request",
+            "approved_revision__approval_request__creator",
+            "approved_revision__approval_request__approver",
             "latest_revision__action",
+            "latest_revision__user",
             "latest_revision__approval_request",
+            "latest_revision__approval_request__creator",
+            "latest_revision__approval_request__approver",
         )
         .prefetch_related(
             "approved_revision__channels",
             "approved_revision__countries",
             "approved_revision__enabled_states",
+            "approved_revision__enabled_states__creator",
             "approved_revision__locales",
             "latest_revision__channels",
             "latest_revision__countries",
             "latest_revision__enabled_states",
+            "latest_revision__enabled_states__creator",
             "latest_revision__locales",
         )
     )


### PR DESCRIPTION
Fixes #1669 

These are all the SQL statements sent to PG when loading `http://localhost:8000/api/v3/recipe/?ordering=-last_updated&page=1` with curl.

[Before](https://gist.github.com/peterbe/68e7f2cbc30bc151a1463be49cdb8f41)

[After](https://gist.github.com/peterbe/10292c7d4951e1f2bbe33b22a22d0a81) 

The price is a more complex JOIN, but fewer queries thereafter. Our only saving grace is that the batch size (10) [is hardcoded](https://github.com/mozilla/normandy/blob/9b253288ac13b99e91954cfe6d547f55553b03d4/normandy/settings.py#L110).

The really ideal solution would be if one could completely control the serialization of nested fields with some simple hacks. For example, we don't have that many active users so you could do *1* query to get them all to the point where you have something like this:

```python
all_users = {
  22: <User id=22 username=aaa>,
  101: <User id=101 username=peter>,
  45: <User id=45 username=mike>,
  ...
}
```

Then, you could curry the RecipeSerializer serializer with all of these. So when it comes time to fetch something related (e.g. `approved_revison.approver`) you could do something like...

```python
# pseudo code...

if self.approved_revision.approver_id in self.all_users:
    self.approved_revision.approver = self.all_users[self.approved_revision.approver_id]
else:
    # Leave it to Django to lazy load this later when needed
```

Honestly, at this point I'm not sure if it matters at all. I was hoping I'd learn about some neat trick I didn't know about in Django REST Framework but there appears not to be the case so it's back to regular Django ORM tricks. 
