### PR TITLE
signature checking can fail if signature disappears

### DIFF
--- a/normandy/recipes/checks.py
+++ b/normandy/recipes/checks.py
@@ -99,9 +99,9 @@ def signatures_use_good_certificates(app_configs, **kwargs):
         Action = apps.get_model("recipes", "Action")
 
         urls = set()
-        for recipe in Recipe.objects.exclude(signature=None):
+        for recipe in Recipe.objects.exclude(signature__x5u=None).select_related("signature"):
             urls.add(recipe.signature.x5u)
-        for action in Action.objects.exclude(signature=None):
+        for action in Action.objects.exclude(signature__x5u=None).select_related("signature"):
             urls.add(action.signature.x5u)
     except (ProgrammingError, OperationalError, ImproperlyConfigured) as e:
         msg = f"Could not retrieve signatures: {e}"

--- a/normandy/recipes/checks.py
+++ b/normandy/recipes/checks.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import timedelta
 
 from django.apps import apps
@@ -98,35 +99,28 @@ def signatures_use_good_certificates(app_configs, **kwargs):
         Recipe = apps.get_model("recipes", "Recipe")
         Action = apps.get_model("recipes", "Action")
 
-        urls = set()
+        x5u_urls = defaultdict(list)
         for recipe in Recipe.objects.exclude(signature__x5u=None).select_related("signature"):
-            urls.add(recipe.signature.x5u)
+            x5u_urls[recipe.signature.x5u].append(str(recipe))
         for action in Action.objects.exclude(signature__x5u=None).select_related("signature"):
-            urls.add(action.signature.x5u)
+            x5u_urls[action.signature.x5u].append(str(action))
     except (ProgrammingError, OperationalError, ImproperlyConfigured) as e:
         msg = f"Could not retrieve signatures: {e}"
         errors.append(Info(msg, id=INFO_COULD_NOT_RETRIEVE_SIGNATURES))
     else:
 
-        def get_matching_object_names(url):
-            matching_recipes = Recipe.objects.filter(signature__x5u=url)
-            matching_actions = Action.objects.filter(signature__x5u=url)
-            matching_objects = list(matching_recipes) + list(matching_actions)
-            object_names = [str(o) for o in matching_objects]
-            return object_names
-
-        for url in urls:
+        for url in x5u_urls:
             try:
                 signing.verify_x5u(url, expire_early)
             except signing.BadCertificate as exc:
-                bad_object_names = get_matching_object_names(url)
+                bad_object_names = x5u_urls[url]
                 msg = (
                     f"{len(bad_object_names)} objects are signed with a bad cert: "
                     f"{bad_object_names}. {exc.detail}. Certificate url is {url}. "
                 )
                 errors.append(Error(msg, id=ERROR_BAD_SIGNING_CERTIFICATE))
             except requests.RequestException as exc:
-                bad_object_names = get_matching_object_names(url)
+                bad_object_names = x5u_urls[url]
                 msg = (
                     f"The certificate at {url} could not be fetched due to a network error to "
                     f"verify. {len(bad_object_names)} objects are signed with this certificate: "

--- a/normandy/recipes/tests/test_checks.py
+++ b/normandy/recipes/tests/test_checks.py
@@ -22,6 +22,7 @@ class TestSignaturesUseGoodCertificates(object):
         mock_verify_x5u.assert_called_once_with(recipe.signature.x5u, None)
         assert len(errors) == 1
         assert errors[0].id == checks.ERROR_BAD_SIGNING_CERTIFICATE
+        assert recipe.name in errors[0].msg
 
     def test_it_ignores_signatures_without_x5u(self):
         recipe = RecipeFactory(signed=True)

--- a/normandy/recipes/tests/test_checks.py
+++ b/normandy/recipes/tests/test_checks.py
@@ -4,7 +4,7 @@ import pytest
 import requests.exceptions
 
 from normandy.recipes import checks, signing
-from normandy.recipes.tests import RecipeFactory, SignatureFactory
+from normandy.recipes.tests import ActionFactory, RecipeFactory, SignatureFactory
 
 
 @pytest.mark.django_db
@@ -22,6 +22,15 @@ class TestSignaturesUseGoodCertificates(object):
         mock_verify_x5u.assert_called_once_with(recipe.signature.x5u, None)
         assert len(errors) == 1
         assert errors[0].id == checks.ERROR_BAD_SIGNING_CERTIFICATE
+
+    def test_it_ignores_signatures_without_x5u(self):
+        recipe = RecipeFactory(signed=True)
+        recipe.signature.x5u = None
+        recipe.signature.save()
+        actions = ActionFactory(signed=True)
+        actions.signature.x5u = None
+        actions.signature.save()
+        assert checks.signatures_use_good_certificates(None) == []
 
     def test_it_ignores_signatures_not_in_use(self, mocker, settings):
         settings.CERTIFICATES_EXPIRE_EARLY_DAYS = None


### PR DESCRIPTION
Fixes #1683

The only explanation I can think of why the checks would fail is if list of recipes-with-signatures is queried and then as it processes the for-loop one of those recipes ceases to have a signature. Feels extremely unlikely. But this PR prevents that from being possible to happen in principle. 