### PR TITLE
Validate Heartbeat survey IDs as being unique

### DIFF
--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -698,6 +698,10 @@ class Action(DirtyFieldsMixin, models.Model):
 
         errors = default()
 
+        # Note, `recipe.arguments` refers to `recipe.current_revision.arguments`
+        # which in term is shorthand for
+        # `recipe.(approved_revision or latest_revision).arguments`.
+
         if self.name == "preference-experiment":
             # Feature branch slugs should be unique within an experiment.
             branch_slugs = set()
@@ -745,11 +749,8 @@ class Action(DirtyFieldsMixin, models.Model):
             other_recipes = Recipe.objects.filter(latest_revision__action=self)
             if revision.recipe and revision.recipe.id:
                 other_recipes = other_recipes.exclude(id=revision.recipe.id)
-            # Note, `recipe.arguments` refers to `recipe.current_revision.arguments`
-            # which in term is shorthand for
-            # `recipe.(approved_revision or latest_revision).arguments`.
             # So it *could* be that a different recipe's *latest_revision*'s argument
-            # has this same surveyId but its *approved_revision has a different surveyId.
+            # has this same surveyId but its *approved_revision* has a different surveyId.
             # It's unlikely in the real-world that different revisions, within a recipe,
             # has different surveyIds *and* that any of these clash with an entirely
             # different recipe.

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -742,9 +742,7 @@ class Action(DirtyFieldsMixin, models.Model):
 
         elif self.name == "show-heartbeat":
             # Survey ID should be unique across all recipes
-            other_recipes = Recipe.objects.filter(
-                latest_revision__action=self
-            )
+            other_recipes = Recipe.objects.filter(latest_revision__action=self)
             if revision.recipe and revision.recipe.id:
                 other_recipes = other_recipes.exclude(id=revision.recipe.id)
             # Note, `recipe.arguments` refers to `recipe.current_revision.arguments`

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -269,7 +269,7 @@ class TestValidateArgumentShowHeartbeat(object):
         approval_request = rev.request_approval(UserFactory())
         approval_request.approve(UserFactory(), "r+")
         rev.enable(UserFactory())
-        assert rev.arguments['surveyId'] == '001'
+        assert rev.arguments["surveyId"] == "001"
 
     def test_no_error_distinctly_different_survey_ids(self):
         action = ActionFactory(name="show-heartbeat")
@@ -292,12 +292,12 @@ class TestValidateArgumentShowHeartbeat(object):
         approval_request = rev.request_approval(UserFactory())
         approval_request.approve(UserFactory(), "r+")
         rev.enable(UserFactory())
-        assert rev.arguments['surveyId'] == '001'
+        assert rev.arguments["surveyId"] == "001"
 
-        arguments['surveyId'] = '002'
+        arguments["surveyId"] = "002"
         recipe = RecipeFactory(action=action, arguments=arguments)
         rev = recipe.latest_revision
-        assert rev.arguments['surveyId'] == '002'
+        assert rev.arguments["surveyId"] == "002"
 
     def test_repeated_identical_survey_ids(self):
         action = ActionFactory(name="show-heartbeat")
@@ -315,7 +315,7 @@ class TestValidateArgumentShowHeartbeat(object):
         RecipeFactory(action=action, arguments=arguments)
         # Reusing the same "surveyId" should cause a ValidationError.
         # But you can change other things.
-        arguments['message'] += ' And this!'
+        arguments["message"] += " And this!"
         with pytest.raises(serializers.ValidationError) as exc_info:
             RecipeFactory(action=action, arguments=arguments)
         expected_error = action.errors["duplicate_survey_id"]


### PR DESCRIPTION
Fixes #1655

Seems to work:
<img width="2037" alt="screen shot 2019-01-16 at 3 39 59 pm" src="https://user-images.githubusercontent.com/26739/51277734-733aa700-19a6-11e9-8729-26565d756568.png">

There *is* a corner case. The checking is only done when you edit a recipe (revision), right? Suppose I do this:

1. Create **recipe A** with surveyId 001
2. Ask for approval, get approval, and publish it (still with surveyId 001). (I guess publishing is unrelated)
3. Now I edit it again and change the surveyId to 002. At this point `recipe.arguments['surveyId'] == '001'` because the approved revision is the "current" one. 
4. Create **recipe B** with surveyId 002 (which I'm allowed to do without an error). Approval or not, this is `recipe.arguments['surveyId'] == '002'` and that's based on its latest_revision.
5. I *go back* to **recipe A** and ask for approval for the latest revision. But I don't edit it. And this will unfortunately allow me to have duplicate surveyId in **recipe A** and **recipe B**.

Options:

1. Ignore this corner case because it's too unrealistic. 
2. Trigger whatever code does that arguments validation when you're changing the recipe's current_revision pointer. 
3. In the uniqueness code (the bulk of this patch) we could search other non-current revisions for that surveyId too. I.e. "You want surveyID 'xxx'? Lemme check *every* revision, approved or not, of every other recipe."

