### PR TITLE
Change default page size to 25

### DIFF
--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -108,7 +108,7 @@ class Core(Configuration):
             "normandy.base.api.renderers.CustomBrowsableAPIRenderer",
         ),
         "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
-        "PAGE_SIZE": 10,
+        "PAGE_SIZE": 25,
         "EXCEPTION_HANDLER": "normandy.base.api.views.exception_handler",
     }
 


### PR DESCRIPTION
I've been meaning to do this for a long time. I've gotten feedback from several people that 10 is too small a page number. 25 seems like a better choice. I have no statistics about this. I'm happy to bike shed about what value it should be.