### PR TITLE
catchall for any api/ request that doesn't match

### DIFF
--- a/normandy/base/tests/test_views.py
+++ b/normandy/base/tests/test_views.py
@@ -1,3 +1,10 @@
 def test_index(client):
     response = client.get("/")
     assert response.status_code == 200
+
+
+def test_api_notfound(client):
+    response = client.get("/api/gooblygook/")
+    assert response.status_code == 404
+    assert "application/json" in response["content-type"]
+    assert response.json()["path"] == "/api/gooblygook/"

--- a/normandy/control/views.py
+++ b/normandy/control/views.py
@@ -1,5 +1,6 @@
 import re
 
+from django.http import JsonResponse
 from django.shortcuts import render
 
 
@@ -11,6 +12,11 @@ delivery_console_urls = {
 
 
 def index(request):
+    if request.path.startswith("/api"):
+        # If you ended up here, your URL pattern didn't match anything and if your path
+        # starts with anything "api" you're going to expect JSON.
+        return JsonResponse({"path": request.path}, status=404)
+
     hostname = request.get_host()
 
     delivery_console_url = delivery_console_urls["prod"]


### PR DESCRIPTION
Fixes #1606 

Basically, any `/api/bla/ble/` should yield a JSON 404. At the moment it yields a 200 OK in HTML. 

I thought I could do this using url patterrns but if you do that, it matches and disables the append-slash functionality in Django. This'll do. 