### PR TITLE
User APIs shouldn't try to work on public servers

### DIFF
--- a/normandy/base/api/views.py
+++ b/normandy/base/api/views.py
@@ -15,7 +15,7 @@ from rest_framework.views import (
     set_rollback,
 )
 
-from normandy.base.api.permissions import CanChangeUser
+from normandy.base.api.permissions import AdminEnabled, CanChangeUser
 from normandy.base.api.serializers import (
     GroupSerializer,
     ServiceInfoSerializer,
@@ -94,7 +94,7 @@ class UserViewSet(viewsets.ModelViewSet):
     # Order by ID to prevent UnorderedObjectListWarning
     queryset = User.objects.order_by("id")
     serializer_class = UserWithGroupsSerializer
-    permission_classes = (CanChangeUser,)
+    permission_classes = (AdminEnabled, CanChangeUser)
 
     def get_serializer_class(self):
         # Don't allow users to update email address
@@ -118,7 +118,7 @@ class GroupViewSet(viewsets.ModelViewSet):
     # Order by ID to prevent UnorderedObjectListWarning
     queryset = Group.objects.order_by("id")
     serializer_class = GroupSerializer
-    permission_classes = (CanChangeUser,)
+    permission_classes = (AdminEnabled, CanChangeUser)
 
     @action(detail=True, methods=["POST"])
     def add_user(self, request, pk=None):


### PR DESCRIPTION
Fixes #1734 

I feel a bit rusty on this because I've never actually worked on anything that differentiates admin vs. non-admin. In particular is the nomenclature "read-only" or "not admin-enabled"?

Also, I simply made it so that **any** `/api/v3/group/*` or `/api/v3/user/*` is verboten. Even the GET. Bad idea? 