### PR TITLE
Downgrade django-rest-swagger due to incompatibility with our CSP policy

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -51,9 +51,10 @@ django-mozilla-product-details==0.13 \
     --hash=sha256:ce97fc2533aa06560d9b438ebba2522dc0b2ada86d6e0537cfb5ac06db1a6aa2
 django-npm==1.0.0 \
     --hash=sha256:2e6bba65e728fa18b9db3c8dc0d4490b70cb7f43bacf60eb3654d7dcb6424272
-django-rest-swagger==2.2.0 \
-    --hash=sha256:48f6aded9937e90ae7cbe9e6c932b9744b8af80cc4e010088b3278c700e0685b \
-    --hash=sha256:b039b0288bab4665cd45dc5d16f94b13911bc4ad0ed55f74ad3b90aa31c87c17
+django-rest-swagger==2.1.2 \
+    --hash=sha256:3471e6c21a3e97751fa6f7b81b66e916e40fa645cac36be1594c0efed810d247 \
+    --hash=sha256:ff889e2b339a9a57010dba7729d56471e05b77827f6dd36c0bcb983839882598 \
+    # pyup: <2.2 # django-rest-swagger 2.2 incompatible with our CSP policy: https://github.com/marcgibbons/django-rest-swagger/issues/795
 django-storages==1.7.1 \
     --hash=sha256:b1a63cd5ea286ee5a9fb45de6c3c5c0ae132d58308d06f1ce9865cfcd5e470a7 \
     --hash=sha256:8e35d2c7baeda5dc6f0b4f9a0fc142d25f9a1bf72b8cebfcbc5db4863abc552d


### PR DESCRIPTION
The CSP problem is being tracked in https://github.com/marcgibbons/django-rest-swagger/issues/795

Refs #1761