### PR TITLE
Expose last_updated in the v1 serialization

### DIFF
--- a/normandy/recipes/api/v1/serializers.py
+++ b/normandy/recipes/api/v1/serializers.py
@@ -113,7 +113,8 @@ class MinimalRecipeSerializer(RecipeSerializer):
         # Attributes serialized here are made available to filter expressions via
         # normandy.recipe, and should be documented if they are intended to be
         # used in filter expressions.
-        fields = ["id", "name", "revision_id", "action", "arguments", "filter_expression"]
+        fields = ["id", "name", "revision_id", "action", "arguments", "filter_expression",
+                  "last_updated"]
 
     def get_revision_id(self, recipe):
         # Certain parts of Telemetry expect this to be a string, so coerce it to


### PR DESCRIPTION
Refs https://bugzilla.mozilla.org/show_bug.cgi?id=1530508. The goal is
to ensure that the recipes being seen by the client are "up to
date".