### PR TITLE
Publish docs to ghpages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,46 +99,61 @@ jobs:
               ./ci/deploy.sh "$CIRCLE_TAG"
             fi
 
-  docs:
+  docs-build:
     docker:
       - image: circleci/python:3.7
-
-    working_directory: ~/repo
-
     steps:
       - checkout
-
-      # Download and cache python dependencies
-      - restore_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "requirements/docs.txt" }}
-
-      - run:
-          name: Create virtualenv
-          command: |
-            python3 -m venv ~/venv
-            echo "source ~/venv/bin/activate" >> $BASH_ENV
       - run:
           name: Install requirements
           command: pip install -r requirements/docs.txt
-
-      - save_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "requirements/docs.txt" }}
-          paths:
-            - "~/venv"
-
-      # Build the docs!
       - run:
           name: Build docs
           command: |
             cd docs
             make html
+      - persist_to_workspace:
+          root: docs/_build
+          paths: html
+      - store_artifacts:
+          path: docs/_build/html
+
+  docs-publish:
+    docker:
+      - image: node:10
+    steps:
+      - checkout
+      - attach_workspace:
+          at: docs/_build
+      - run:
+          name: Install and configure dependencies
+          command: |
+            npm install -g gh-pages@2
+            git config user.email "ci-build@normandy.mozilla.org"
+            git config user.name "ci-build"
+      - run:
+          name: Disable jekyll builds
+          command: touch docs/_build/html/.nojekyll
+      - add_ssh_keys:
+          fingerprints:
+            - "5d:91:56:44:f2:f7:57:2a:29:88:f0:2e:37:fe:86:2a"
+      -run:
+        name: Deploy docs to gh-pages
+        command: gh-pages --dotfiles --message "[skip ci] Docs updates" --dist docs/_build/html
 
 workflows:
   version: 2
   main:
     jobs:
       - build_test_publish:
+          # run on all tags, as well as the default of all other commits
           filters:
             tags:
               only: /.*/
-      - docs
+      - docs-build
+      - docs-publish:
+          requires:
+            - docs-build
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "5d:91:56:44:f2:f7:57:2a:29:88:f0:2e:37:fe:86:2a"
-      -run:
+      - run:
         name: Deploy docs to gh-pages
         command: gh-pages --dotfiles --message "[skip ci] Docs updates" --dist docs/_build/html
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Create virtualenv
+          command: |
+            python3 -m venv ~/venv
+            echo "source ~/venv/bin/activate" >> $BASH_ENV
+      - run:
           name: Install requirements
           command: pip install -r requirements/docs.txt
       - run:

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
   "ci/circleci: build_test_publish",
-  "ci/circleci: docs"
+  "ci/circleci: docs-build"
 ]
 # Avoid including verbose details from PR bodies
 cut_body_after = "\n---\n"


### PR DESCRIPTION
This takes the docs build we were already doing in CI, and publishes it to ghpages when the commit is on master. It's based on [CircleCI's own guide on the subject](https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/).

I also configured the build to store the docs as an artifact, which we should be able to access to check docs in PRs.