### PR TITLE
Update links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ MaxMind, available from https://www.maxmind.com.
 
 Please see the [Developer Setup] documentation to get started.
 
-[Developer Setup]: https://normandy.readthedocs.io/dev/install.html
+[Developer Setup]: https://mozilla.github.io/normandy/dev/install.html

--- a/normandy/recipes/api/v3/serializers.py
+++ b/normandy/recipes/api/v3/serializers.py
@@ -177,7 +177,7 @@ class RecipeSerializer(CustomizableSerializerMixin, serializers.ModelSerializer)
             jexl = JEXL()
 
             # Add mock transforms for validation. See
-            # http://normandy.readthedocs.io/en/latest/user/filter_expressions.html#transforms
+            # https://mozilla.github.io/normandy/user/filters.html#transforms
             # for a list of what transforms we expect to be available.
             jexl.add_transform("date", lambda x: x)
             jexl.add_transform("stableSample", lambda x: x)


### PR DESCRIPTION
I set up a redirect for most of the docs from RTD to gh-pages, and made the root of the RTD page contain a message that the docs have moved. I think we can update our links now.