### PR TITLE
Add checkout step to docker-image-publish CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
     docker:
       - image: mozilla/cidockerbases:docker-latest
     steps:
+      - checkout
       - setup_remote_docker:
           version: 17.09.0-ce
       - attach_workspace:


### PR DESCRIPTION
I had originally thought checking out the repository wouldn't be needed in this
step, but since it is using a script from the repository, it is.

You can see the original version failing in this workflow: https://circleci.com/workflow-run/7cfa20ed-2c73-43a4-9dbb-da7b340a90c8