### PR TITLE
Speed up docker step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 # DOCKER_PASS
 #
 
-version: 2
+version: 2.1
 
 jobs:
   lint:
@@ -50,6 +50,10 @@ jobs:
           command: therapist run --use-tracked-files
 
   docker-image-build:
+    parameters:
+      saveToWorkspace:
+        type: boolean
+        default: true
     docker:
       - image: mozilla/cidockerbases:docker-latest
     steps:
@@ -70,18 +74,19 @@ jobs:
       - run:
           name: Build Docker image
           command: docker build -t normandy:web .
-      - run:
-          name: Save image into workspace
-          command: |
-            mkdir -p workspace
-            if [ "${CIRCLE_BRANCH}" == "master" ] || [ ! -z "${CIRCLE_TAG}" ]; then
-              docker save -o workspace/normandy-web.tar normandy:web
-              gzip workspace/normandy-web.tar
-            fi
-      - persist_to_workspace:
-          root: workspace
-          paths:
-            - normandy-web.tar.gz
+      - when:
+          condition: << parameters.saveToWorkspace >>
+          steps:
+            - run:
+                name: Save image into workspace
+                command: |
+                  mkdir -p workspace
+                  docker save -o workspace/normandy-web.tar normandy:web
+                  gzip workspace/normandy-web.tar
+            - persist_to_workspace:
+                root: workspace
+                paths:
+                  - normandy-web.tar.gz
 
   docker-image-publish:
     docker:
@@ -300,9 +305,21 @@ workflows:
       # Group: Building artifacts
       - docs-build
       - docker-image-build:
+          name: docker-image-build-save
+          # A version of the job that save the docker image to the workspace
+          saveToWorkspace: true
           filters:
             tags:
               only: /.*/
+            branches:
+              only: master
+      - docker-image-build:
+          name: docker-image-build-pr
+          # A version of the job that does not save the image, as an optimization
+          saveToWorkspace: false
+          filters:
+            branches:
+              ignore: master
 
       # Group: Publish
       # All of these should only run on master and tags
@@ -319,7 +336,7 @@ workflows:
             - contract-tests
             - js-tests
             - lint
-            - docker-image-build
+            - docker-image-build-save
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 17.09.0-ce
+          docker_layer_caching: true
       - run:
           name: Create version.json
           command: |
@@ -74,8 +74,10 @@ jobs:
           name: Save image into workspace
           command: |
             mkdir -p workspace
-            docker save -o workspace/normandy-web.tar normandy:web
-            gzip workspace/normandy-web.tar
+            if [ "${CIRCLE_BRANCH}" == "master" ] || [ ! -z "${CIRCLE_TAG}" ]; then
+              docker save -o workspace/normandy-web.tar normandy:web
+              gzip workspace/normandy-web.tar
+            fi
       - persist_to_workspace:
           root: workspace
           paths:

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
   "ci/circleci: contract-tests",
-  "ci/circleci: docker-image-build",
+  "ci/circleci: docker-image-build-pr",
   "ci/circleci: docs-build",
   "ci/circleci: js-tests",
   "ci/circleci: lint",


### PR DESCRIPTION
Building the docker image currently takes twice as long as any other step in our set up. This should help it go a bit faster.