### PR TITLE
Stop requiring explicit approval for bors merges

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -9,5 +9,4 @@ status = [
 # Avoid including verbose details from PR bodies
 cut_body_after = "\n---\n"
 block_labels = ["bors-dont-merge"]
-required_approvals = 1
 delete_merged_branches = true


### PR DESCRIPTION
After talking about it with @glasserc, I'm convinced that requiring both approval and a comment in order to trigger a bors merge is more pain than gain at this point.