### PR TITLE
Add standard API cache headers to GraphQL view

### DIFF
--- a/normandy/base/tests/test_views.py
+++ b/normandy/base/tests/test_views.py
@@ -1,3 +1,8 @@
+import pytest
+
+from normandy.base.tests import GQ, UserFactory
+
+
 def test_index(client):
     response = client.get("/")
     assert response.status_code == 200
@@ -8,3 +13,27 @@ def test_api_notfound(client):
     assert response.status_code == 404
     assert "application/json" in response["content-type"]
     assert response.json()["path"] == "/api/gooblygook/"
+
+
+@pytest.mark.django_db
+class TestGraphQLView:
+    # Note: most of the testing of GraphQL happens in normandy/base/tests/test_schema.py
+
+    def test_basic_query(self, client):
+        u = UserFactory()
+        query = GQ().query.allUsers.fields("id")
+        res = client.get(f"/api/graphql/?query={query}")
+        assert res.json() == {"data": {"allUsers": [{"id": str(u.id)}]}}
+
+    def test_get_includes_cache_headers(self, api_client):
+        query = GQ().query.allUsers.fields("id")
+        res = api_client.get(f"/api/graphql/?query={query}")
+        assert res.status_code == 200
+        assert "max-age=" in res["Cache-Control"]
+        assert "public" in res["Cache-Control"]
+
+    def test_post_explicit_no_cache(self, api_client):
+        query = GQ().query.allUsers.fields("id")
+        res = api_client.post(f"/api/graphql/?query={query}")
+        assert res.status_code == 200
+        assert "no-cache" in res["Cache-Control"]

--- a/normandy/urls.py
+++ b/normandy/urls.py
@@ -1,9 +1,8 @@
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
-from django.views.decorators.csrf import csrf_exempt
 
-from graphene_django.views import GraphQLView
+from normandy.base.views import NormandyGraphQLView
 
 
 app_name = "normandy"
@@ -18,7 +17,7 @@ urlpatterns += [
     # Swagger
     url(r"^api/v1/", include("normandy.base.api.swagger_urls", namespace="v1")),
     url(r"^api/v3/", include("normandy.base.api.swagger_urls", namespace="v3")),
-    url(r"^api/graphql/", csrf_exempt(GraphQLView.as_view())),
+    url(r"^api/graphql/", NormandyGraphQLView.as_view()),
 ]
 
 # static handles serving uploaded files during development; it disables


### PR DESCRIPTION
I noticed yesterday that a graphql query I was using had been cached for over 20 minutes. Lets add some explicit cache headers to avoid that.