### PR TITLE
Print a message when signing commands finish

### DIFF
--- a/normandy/recipes/management/commands/update_action_signatures.py
+++ b/normandy/recipes/management/commands/update_action_signatures.py
@@ -40,6 +40,7 @@ class Command(BaseCommand):
                 action.save()
 
         metrics.gauge("signed", count, tags=["force"] if force else [])
+        self.stdout.write("action signing done")
 
     def get_outdated_actions(self):
         outdated_age = timedelta(seconds=settings.AUTOGRAPH_SIGNATURE_MAX_AGE)

--- a/normandy/recipes/management/commands/update_recipe_signatures.py
+++ b/normandy/recipes/management/commands/update_recipe_signatures.py
@@ -63,6 +63,7 @@ class Command(BaseCommand):
                 sig.delete()
 
         metrics.gauge("unsigned", count, tags=["force"] if force else [])
+        self.stdout.write("all signing done")
 
     def get_outdated_recipes(self):
         outdated_age = timedelta(seconds=settings.AUTOGRAPH_SIGNATURE_MAX_AGE)

--- a/normandy/recipes/management/commands/update_signatures.py
+++ b/normandy/recipes/management/commands/update_signatures.py
@@ -20,3 +20,4 @@ class Command(BaseCommand):
         else:
             call_command("update_recipe_signatures")
             call_command("update_action_signatures")
+        self.stdout.write("all signing done")


### PR DESCRIPTION
This makes it much easier to tell that this commands finish succesfully when ops is looking at the logs.