### PR TITLE
Don't publish recipes that require advanced capabilities to the general collection

### DIFF
--- a/normandy/base/tests/__init__.py
+++ b/normandy/base/tests/__init__.py
@@ -84,7 +84,12 @@ class MigrationTest(object):
     """A base class for migration tests that resets migrations on teardown."""
 
     @pytest.fixture(autouse=True)
-    def reset_migrations(self, migrations):
+    def _check_migrations_enabled(self, django_db_use_migrations):
+        if not django_db_use_migrations:
+            skip_except_in_ci()
+
+    @pytest.fixture(autouse=True)
+    def _reset_migrations(self, migrations):
         yield
         migrations.reset()
 

--- a/normandy/base/utils.py
+++ b/normandy/base/utils.py
@@ -90,3 +90,21 @@ def sri_hash(data, url_safe=False):
     else:
         data_hash = b64encode(digest)
     return "sha384-" + data_hash.decode()
+
+
+class ScopedSettings:
+    """
+    Make a version of Django's settings that adds a prefix to all settings.
+
+    Example:
+
+        scoped = ScopedSettings("FOO_")
+        assert settings.FOO_BAR == scoped.BAR
+    """
+
+    def __init__(self, scope):
+        self.scope = scope
+
+    def __getattr__(self, name):
+        scoped_name = self.scope + name
+        return getattr(settings, scoped_name)

--- a/normandy/recipes/api/fields.py
+++ b/normandy/recipes/api/fields.py
@@ -5,7 +5,7 @@ from django.core.files.base import ContentFile
 
 from rest_framework.fields import CharField
 from rest_framework.reverse import reverse
-from rest_framework.serializers import HyperlinkedIdentityField, JSONField
+from rest_framework.serializers import HyperlinkedIdentityField, JSONField, ListField
 
 
 class ContentFileField(CharField):
@@ -59,3 +59,8 @@ class ActionImplementationHyperlinkField(HyperlinkedIdentityField):
 class FilterObjectField(JSONField):
     def to_representation(self, value):
         return super().to_representation(value.initial_data)
+
+
+class SortedListField(ListField):
+    def to_representation(self, value):
+        return sorted(super().to_representation(value))

--- a/normandy/recipes/api/filters.py
+++ b/normandy/recipes/api/filters.py
@@ -1,8 +1,10 @@
 import django_filters
 
+from normandy.recipes.models import Recipe
+
 
 class EnabledStateFilter(django_filters.Filter):
-    # A special case filter for filtering recipes by their enabled state
+    """A special case filter for filtering recipes by their enabled state"""
 
     def filter(self, qs, value):
         if value is not None:
@@ -11,6 +13,34 @@ class EnabledStateFilter(django_filters.Filter):
                 return qs.only_enabled()
             elif lc_value in ["false", "0"]:
                 return qs.only_disabled()
+        return qs
+
+
+class BaselineCapabilitiesFilter(django_filters.Filter):
+    """Filters recipe by whether they use only baseline capabilities, defaulting to only baseline."""
+
+    def __init__(self, *args, default_only_baseline=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.default_only_baseline = default_only_baseline
+
+    def filter(self, qs, value):
+        baseline_only = self.default_only_baseline
+
+        if value is not None:
+            lc_value = value.lower()
+            if lc_value in ["false", "0"]:
+                baseline_only = False
+
+        if baseline_only:
+            recipes = list(qs)
+            if not all(isinstance(recipe, Recipe) for recipe in recipes):
+                raise TypeError("BaselineCapabilitiesFilter can only be used to filter recipes")
+            match_ids = []
+            for recipe in recipes:
+                if recipe.uses_only_baseline_capabilities():
+                    match_ids.append(recipe.id)
+            return Recipe.objects.filter(id__in=match_ids)
+
         return qs
 
 

--- a/normandy/recipes/api/v1/serializers.py
+++ b/normandy/recipes/api/v1/serializers.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from rest_framework import serializers
 
 from normandy.base.api.v1.serializers import UserSerializer
-from normandy.recipes.api.fields import ActionImplementationHyperlinkField
+from normandy.recipes.api.fields import ActionImplementationHyperlinkField, SortedListField
 from normandy.recipes.models import Action, ApprovalRequest, Recipe, RecipeRevision, Signature
 
 
@@ -81,6 +81,7 @@ class RecipeSerializer(serializers.ModelSerializer):
     )
     approval_request = ApprovalRequestSerializer(read_only=True)
     identicon_seed = serializers.CharField(required=False)
+    capabilities = SortedListField(child=serializers.CharField())
 
     class Meta:
         model = Recipe
@@ -99,7 +100,11 @@ class RecipeSerializer(serializers.ModelSerializer):
             "approved_revision_id",
             "approval_request",
             "identicon_seed",
+            "capabilities",
         ]
+
+    def get_capabilities(self, recipe):
+        return recipe.capabilities
 
 
 class MinimalRecipeSerializer(RecipeSerializer):
@@ -113,7 +118,15 @@ class MinimalRecipeSerializer(RecipeSerializer):
         # Attributes serialized here are made available to filter expressions via
         # normandy.recipe, and should be documented if they are intended to be
         # used in filter expressions.
-        fields = ["id", "name", "revision_id", "action", "arguments", "filter_expression"]
+        fields = [
+            "id",
+            "name",
+            "revision_id",
+            "action",
+            "arguments",
+            "filter_expression",
+            "capabilities",
+        ]
 
     def get_revision_id(self, recipe):
         # Certain parts of Telemetry expect this to be a string, so coerce it to

--- a/normandy/recipes/exports.py
+++ b/normandy/recipes/exports.py
@@ -3,12 +3,12 @@ import logging
 import kinto_http
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-
-
-logger = logging.getLogger(__name__)
+from normandy.base.utils import ScopedSettings
 
 
 APPROVE_CHANGES_FLAG = {"status": "to-sign"}
+logger = logging.getLogger(__name__)
+rs_settings = ScopedSettings("REMOTE_SETTINGS_")
 
 
 def recipe_as_record(recipe):
@@ -49,12 +49,19 @@ class RemoteSettings:
     """
     Interacts with a RemoteSettings service.
 
-    Basically, a recipe becomes a record in the dedicated collection on Remote Settings.
-    When it is disabled, the associated record is deleted.
+    Recipes get published as records in one or both of the dedicated
+    collections on Remote Settings. When disabled, those records are removed.
 
     Since Normandy already has the required approval/signoff features, the integration
     bypasses the one of Remote Settings (leveraging a specific server configuration for this
     particular collection).
+
+    There are two collections used. One is the "baseline" collection, which
+    is used only for recipes that fit within the baseline capabilities, and
+    are therefore compatible with a broad range of clients. The second is the
+    "capabilities" collection, in which all recipes are published. Clients
+    that read from the capabilities collection are expected to process
+    capabilities and only execute compatible recipes.
 
     .. notes::
 
@@ -73,23 +80,16 @@ class RemoteSettings:
 
     """
 
-    MAIN_BUCKET_ID = "main"
-    """The name of the publicly readable bucket of Remote Settings where the approved
-    records are published.
-    """
-
     def __init__(self):
         # Kinto is the underlying implementation of Remote Settings. The client
         # is basically a tiny abstraction on top of the requests library.
         self.client = (
             kinto_http.Client(
-                server_url=settings.REMOTE_SETTINGS_URL,
-                auth=(settings.REMOTE_SETTINGS_USERNAME, settings.REMOTE_SETTINGS_PASSWORD),
-                bucket=settings.REMOTE_SETTINGS_BUCKET_ID,
-                collection=settings.REMOTE_SETTINGS_COLLECTION_ID,
-                retry=settings.REMOTE_SETTINGS_RETRY_REQUESTS,
+                server_url=rs_settings.URL,
+                auth=(rs_settings.USERNAME, rs_settings.PASSWORD),
+                retry=rs_settings.RETRY_REQUESTS,
             )
-            if settings.REMOTE_SETTINGS_URL
+            if rs_settings.URL
             else None
         )
 
@@ -100,7 +100,14 @@ class RemoteSettings:
         if self.client is None:
             return  # no check if disabled.
 
-        required_keys = ["COLLECTION_ID", "USERNAME", "PASSWORD"]
+        required_keys = [
+            "BASELINE_COLLECTION_ID",
+            "CAPABILITIES_COLLECTION_ID",
+            "WORKSPACE_BUCKET_ID",
+            "PUBLISH_BUCKET_ID",
+            "USERNAME",
+            "PASSWORD",
+        ]
         for key in required_keys:
             if not getattr(settings, f"REMOTE_SETTINGS_{key}"):
                 msg = f"set settings.REMOTE_SETTINGS_{key} to use Remote Settings integration"
@@ -109,44 +116,52 @@ class RemoteSettings:
         # Test authentication.
         server_info = self.client.server_info()
         is_authenticated = (
-            "user" in server_info
-            and settings.REMOTE_SETTINGS_USERNAME in server_info["user"]["id"]
+            "user" in server_info and rs_settings.USERNAME in server_info["user"]["id"]
         )
         if not is_authenticated:
             raise ImproperlyConfigured("Invalid Remote Settings credentials")
 
         # Test that collection is writable.
-        metadata = self.client.get_collection()
-        if server_info["user"]["id"] not in metadata["permissions"].get("write", []):
-            raise ImproperlyConfigured(
-                f"Remote Settings collection {settings.REMOTE_SETTINGS_COLLECTION_ID} "
-                "is not writable."
-            )
+        bucket_collection_pairs = [
+            (rs_settings.WORKSPACE_BUCKET_ID, rs_settings.BASELINE_COLLECTION_ID),
+            (rs_settings.WORKSPACE_BUCKET_ID, rs_settings.CAPABILITIES_COLLECTION_ID),
+            (rs_settings.PUBLISH_BUCKET_ID, rs_settings.BASELINE_COLLECTION_ID),
+            (rs_settings.PUBLISH_BUCKET_ID, rs_settings.CAPABILITIES_COLLECTION_ID),
+        ]
+        for bucket, collection in bucket_collection_pairs:
+            metadata = self.client.get_collection(id=collection, bucket=bucket)
+            if server_info["user"]["id"] not in metadata["permissions"].get("write", []):
+                raise ImproperlyConfigured(
+                    f"Remote Settings collection {collection} is not writable."
+                )
 
         # Test that collection has the proper review settings.
         capabilities = server_info["capabilities"]
         if "signer" in capabilities:
-            signer_config = capabilities["signer"]
-            normandy_resource = [
-                r
-                for r in signer_config["resources"]
-                if r["source"]["bucket"] == settings.REMOTE_SETTINGS_BUCKET_ID
-                and r["source"]["collection"] == settings.REMOTE_SETTINGS_COLLECTION_ID
-            ]
-            review_disabled = (
-                len(normandy_resource) == 1
-                and not normandy_resource[0].get(
-                    "to_review_enabled", signer_config["to_review_enabled"]
+            for collection in [
+                rs_settings.BASELINE_COLLECTION_ID,
+                rs_settings.CAPABILITIES_COLLECTION_ID,
+            ]:
+                signer_config = capabilities["signer"]
+                normandy_resource = [
+                    r
+                    for r in signer_config["resources"]
+                    if r["source"]["bucket"] == rs_settings.WORKSPACE_BUCKET_ID
+                    and r["source"]["collection"] == collection
+                ]
+                review_disabled = (
+                    len(normandy_resource) == 1
+                    and not normandy_resource[0].get(
+                        "to_review_enabled", signer_config["to_review_enabled"]
+                    )
+                    and not normandy_resource[0].get(
+                        "group_check_enabled", signer_config["group_check_enabled"]
+                    )
                 )
-                and not normandy_resource[0].get(
-                    "group_check_enabled", signer_config["group_check_enabled"]
-                )
-            )
-            if not review_disabled:
-                raise ImproperlyConfigured(
-                    "Review was not disabled on Remote Settings collection "
-                    f"{settings.REMOTE_SETTINGS_COLLECTION_ID}."
-                )
+                if not review_disabled:
+                    raise ImproperlyConfigured(
+                        f"Review was not disabled on Remote Settings collection {collection}."
+                    )
 
     def published_recipes(self):
         """
@@ -155,7 +170,37 @@ class RemoteSettings:
         if self.client is None:
             raise ImproperlyConfigured("Remote Settings is not enabled.")
 
-        return self.client.get_records(bucket=self.MAIN_BUCKET_ID)
+        capabilities_records = self.client.get_records(
+            bucket=rs_settings.PUBLISH_BUCKET_ID, collection=rs_settings.CAPABILITIES_COLLECTION_ID
+        )
+        baseline_records = self.client.get_records(
+            bucket=rs_settings.PUBLISH_BUCKET_ID, collection=rs_settings.BASELINE_COLLECTION_ID
+        )
+
+        capabilities_ids = set(r["id"] for r in capabilities_records)
+        baseline_ids = set(r["id"] for r in baseline_records)
+
+        # All baseline records *should* be present in the capabilities
+        # collection too. If not, that's concerning.
+        only_baseline_ids = baseline_ids - capabilities_ids
+        if only_baseline_ids:
+            logging.warn(
+                f"{len(only_baseline_ids)} records were found in the baseline collection "
+                f"that were not in the capabilities."
+            )
+            # Merge the list of records by id.
+            records_by_id = {}
+            for record in capabilities_records + baseline_records:
+                if record["id"] not in records_by_id:
+                    records_by_id[record["id"]] = record
+
+            records = records_by_id.values()
+        else:
+            # All records in baseline_records are also in capabilities_records,
+            # so just use the ones from capabilities
+            records = capabilities_records
+
+        return records
 
     def publish(self, recipe, approve_changes=True):
         """
@@ -164,12 +209,25 @@ class RemoteSettings:
         if self.client is None:
             return  # no-op if disabled.
 
+        baseline = False
+
         # 1. Put the record.
         record = recipe_as_record(recipe)
-        self.client.update_record(data=record)
+        self.client.update_record(
+            data=record,
+            bucket=rs_settings.WORKSPACE_BUCKET_ID,
+            collection=rs_settings.CAPABILITIES_COLLECTION_ID,
+        )
+        if recipe.uses_only_baseline_capabilities():
+            baseline = True
+            self.client.update_record(
+                data=record,
+                bucket=rs_settings.WORKSPACE_BUCKET_ID,
+                collection=rs_settings.BASELINE_COLLECTION_ID,
+            )
         # 2. Approve the changes immediately (multi-signoff is disabled).
         if approve_changes:
-            self.approve_changes()
+            self.approve_changes(baseline)
 
         logger.info(f"Published record '{recipe.id}' for recipe {recipe.name!r}")
 
@@ -180,22 +238,48 @@ class RemoteSettings:
         if self.client is None:
             return  # no-op if disabled.
 
-        # 1. Delete the record.
-        try:
-            self.client.delete_record(id=str(recipe.id))
+        # 1. Delete the record from both baseline and capabilities collections
+        either_existed = False
+        baseline = False
 
+        try:
+            self.client.delete_record(
+                id=str(recipe.id),
+                bucket=rs_settings.WORKSPACE_BUCKET_ID,
+                collection=rs_settings.CAPABILITIES_COLLECTION_ID,
+            )
+            either_existed = True
         except kinto_http.KintoException as e:
             if e.response.status_code == 404:
-                logger.warning(f"The recipe '{recipe.id}' was never published. Skip.")
-                return
-            raise
+                logger.warning(
+                    f"The recipe '{recipe.id}' was not published in the capabilities collection. Skip."
+                )
+            else:
+                raise
+
+        try:
+            self.client.delete_record(
+                id=str(recipe.id),
+                bucket=rs_settings.WORKSPACE_BUCKET_ID,
+                collection=rs_settings.BASELINE_COLLECTION_ID,
+            )
+            either_existed = True
+            baseline = True
+        except kinto_http.KintoException as e:
+            if e.response.status_code == 404:
+                logger.warning(
+                    f"The recipe '{recipe.id}' was not published in the baseline collection. Skip."
+                )
+            else:
+                raise
+
         # 2. Approve the changes immediately (multi-signoff is disabled).
-        if approve_changes:
-            self.approve_changes()
+        if either_existed and approve_changes:
+            self.approve_changes(baseline)
 
         logger.info(f"Deleted record '{recipe.id}' of recipe {recipe.name!r}")
 
-    def approve_changes(self):
+    def approve_changes(self, baseline=True):
         """
         Approve the changes made in the workspace collection.
 
@@ -207,25 +291,54 @@ class RemoteSettings:
             return  # no-op if disabled.
 
         try:
-            self.client.patch_collection(data=APPROVE_CHANGES_FLAG)
+            self.client.patch_collection(
+                id=rs_settings.CAPABILITIES_COLLECTION_ID,
+                data=APPROVE_CHANGES_FLAG,
+                bucket=rs_settings.WORKSPACE_BUCKET_ID,
+            )
+            if baseline:
+                self.client.patch_collection(
+                    id=rs_settings.BASELINE_COLLECTION_ID,
+                    data=APPROVE_CHANGES_FLAG,
+                    bucket=rs_settings.WORKSPACE_BUCKET_ID,
+                )
 
         except kinto_http.exceptions.KintoException:
             # Approval failed unexpectedly.
             # The changes in the `main-workspace` bucket must be reverted.
-            records_in_workspace = self.client.get_records()
-            records_in_prod = self.client.get_records(bucket=self.MAIN_BUCKET_ID)
-            in_prod_by_id = {r["id"]: r for r in records_in_prod}
-            # Compare records collection in prod vs. in workspace.
-            for record in records_in_workspace:
-                in_prod = in_prod_by_id.pop(record["id"], None)
-                if in_prod is None:
-                    # Record only exists in workspace, delete it.
-                    self.client.delete_record(id=record["id"])
-                elif not records_equal(record, in_prod):
-                    # Record was modified in workspace, restore it.
-                    self.client.update_record(data=in_prod)
-            # Remaining records only exist in prod, re-create them.
-            for in_prod in in_prod_by_id.values():
-                self.client.create_record(data=in_prod)
+            collections = [rs_settings.CAPABILITIES_COLLECTION_ID]
+            if baseline:
+                collections.append(rs_settings.BASELINE_COLLECTION_ID)
+
+            for collection in collections:
+                records_in_workspace = self.client.get_records(
+                    bucket=rs_settings.WORKSPACE_BUCKET_ID, collection=collection
+                )
+                records_in_prod = self.client.get_records(
+                    bucket=rs_settings.PUBLISH_BUCKET_ID, collection=collection
+                )
+                in_prod_by_id = {r["id"]: r for r in records_in_prod}
+                # Compare records collection in prod vs. in workspace.
+                for record in records_in_workspace:
+                    in_prod = in_prod_by_id.pop(record["id"], None)
+                    if in_prod is None:
+                        # Record only exists in workspace, delete it.
+                        self.client.delete_record(
+                            id=record["id"],
+                            bucket=rs_settings.WORKSPACE_BUCKET_ID,
+                            collection=collection,
+                        )
+                    elif not records_equal(record, in_prod):
+                        # Record was modified in workspace, restore it.
+                        self.client.update_record(
+                            data=in_prod,
+                            bucket=rs_settings.WORKSPACE_BUCKET_ID,
+                            collection=collection,
+                        )
+                # Remaining records only exist in prod, re-create them.
+                for in_prod in in_prod_by_id.values():
+                    self.client.create_record(
+                        data=in_prod, bucket=rs_settings.WORKSPACE_BUCKET_ID, collection=collection
+                    )
 
             raise

--- a/normandy/recipes/tests/test_exports.py
+++ b/normandy/recipes/tests/test_exports.py
@@ -1,5 +1,5 @@
 import base64
-import json
+from unittest.mock import call
 
 import pytest
 import kinto_http
@@ -19,14 +19,56 @@ def mock_logger(mocker):
 
 @pytest.mark.django_db
 class TestRemoteSettings:
+    @pytest.fixture
+    def rs_urls(self, rs_settings):
+        rv = {
+            "workspace": {"capabilities": {}, "baseline": {}},
+            "publish": {"capabilities": {}, "baseline": {}},
+        }
+        rv["workspace"]["baseline"]["collection"] = (
+            f"{rs_settings.REMOTE_SETTINGS_URL}"
+            f"/buckets/{rs_settings.REMOTE_SETTINGS_WORKSPACE_BUCKET_ID}"
+            f"/collections/{rs_settings.REMOTE_SETTINGS_BASELINE_COLLECTION_ID}"
+        )
+        rv["workspace"]["capabilities"]["collection"] = (
+            f"{rs_settings.REMOTE_SETTINGS_URL}"
+            f"/buckets/{rs_settings.REMOTE_SETTINGS_WORKSPACE_BUCKET_ID}"
+            f"/collections/{rs_settings.REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID}"
+        )
+        rv["publish"]["baseline"]["collection"] = (
+            f"{rs_settings.REMOTE_SETTINGS_URL}"
+            f"/buckets/{rs_settings.REMOTE_SETTINGS_PUBLISH_BUCKET_ID}"
+            f"/collections/{rs_settings.REMOTE_SETTINGS_BASELINE_COLLECTION_ID}"
+        )
+        rv["publish"]["capabilities"]["collection"] = (
+            f"{rs_settings.REMOTE_SETTINGS_URL}"
+            f"/buckets/{rs_settings.REMOTE_SETTINGS_PUBLISH_BUCKET_ID}"
+            f"/collections/{rs_settings.REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID}"
+        )
+
+        for bucket in ["workspace", "publish"]:
+            for collection in ["baseline", "capabilities"]:
+                rv[bucket][collection]["records"] = (
+                    rv[bucket][collection]["collection"] + "/records"
+                )
+                rv[bucket][collection]["record"] = (
+                    rv[bucket][collection]["collection"] + "/records/{}"
+                )
+
+        return rv
+
     def test_default_settings(self, settings):
         """Test default settings values."""
 
         assert settings.REMOTE_SETTINGS_URL is None
         assert settings.REMOTE_SETTINGS_USERNAME is None
         assert settings.REMOTE_SETTINGS_PASSWORD is None
-        assert settings.REMOTE_SETTINGS_BUCKET_ID == "main-workspace"
-        assert settings.REMOTE_SETTINGS_COLLECTION_ID == "normandy-recipes"
+        assert settings.REMOTE_SETTINGS_WORKSPACE_BUCKET_ID == "main-workspace"
+        assert settings.REMOTE_SETTINGS_PUBLISH_BUCKET_ID == "main"
+        assert settings.REMOTE_SETTINGS_BASELINE_COLLECTION_ID == "normandy-recipes"
+        assert (
+            settings.REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID == "normandy-recipes-capabilities"
+        )
         assert settings.REMOTE_SETTINGS_RETRY_REQUESTS == 3
 
     def test_it_checks_config(self, settings):
@@ -64,14 +106,25 @@ class TestRemoteSettings:
             exports.RemoteSettings().check_config()
         assert "REMOTE_SETTINGS_PASSWORD" in str(exc.value)
 
-        # Leave out COLLECTION_ID
+        # Leave out BASELINE_COLLECTION_ID
         settings.REMOTE_SETTINGS_URL = "http://some-server/v1"
         settings.REMOTE_SETTINGS_USERNAME = "usename"
         settings.REMOTE_SETTINGS_PASSWORD = "p4ssw0rd"
-        settings.REMOTE_SETTINGS_COLLECTION_ID = None
+        settings.REMOTE_SETTINGS_BASELINE_COLLECTION_ID = None
+        settings.REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID = "normandy-recipes-capabilities"
         with pytest.raises(ImproperlyConfigured) as exc:
             exports.RemoteSettings().check_config()
-        assert "REMOTE_SETTINGS_COLLECTION_ID" in str(exc.value)
+        assert "REMOTE_SETTINGS_BASELINE_COLLECTION_ID" in str(exc.value)
+
+        # Leave out CAPABILITIES_COLLECTION_ID
+        settings.REMOTE_SETTINGS_URL = "http://some-server/v1"
+        settings.REMOTE_SETTINGS_USERNAME = "usename"
+        settings.REMOTE_SETTINGS_PASSWORD = "p4ssw0rd"
+        settings.REMOTE_SETTINGS_BASELINE_COLLECTION_ID = "normandy-recipes"
+        settings.REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID = None
+        with pytest.raises(ImproperlyConfigured) as exc:
+            exports.RemoteSettings().check_config()
+        assert "REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID" in str(exc.value)
 
     def test_check_connection(self, rs_settings, requestsmock):
         # Root URL should return currently authenticated user.
@@ -101,33 +154,56 @@ class TestRemoteSettings:
             },
         )
 
-        # Collection should be writable.
-        collection_url = (
-            f"{rs_settings.REMOTE_SETTINGS_URL}/buckets/{rs_settings.REMOTE_SETTINGS_BUCKET_ID}"
-            f"/collections/{rs_settings.REMOTE_SETTINGS_COLLECTION_ID}"
-        )
-        requestsmock.get(collection_url, json={"data": {}, "permissions": {}})
-        with pytest.raises(ImproperlyConfigured) as exc:
-            exports.RemoteSettings().check_config()
-        assert (
-            f"Remote Settings collection {rs_settings.REMOTE_SETTINGS_COLLECTION_ID} "
-            "is not writable"
-        ) in str(exc.value)
+        # All collections should be writable
+        bucket_collection_pairs = [
+            (
+                rs_settings.REMOTE_SETTINGS_WORKSPACE_BUCKET_ID,
+                rs_settings.REMOTE_SETTINGS_BASELINE_COLLECTION_ID,
+            ),
+            (
+                rs_settings.REMOTE_SETTINGS_WORKSPACE_BUCKET_ID,
+                rs_settings.REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID,
+            ),
+            (
+                rs_settings.REMOTE_SETTINGS_PUBLISH_BUCKET_ID,
+                rs_settings.REMOTE_SETTINGS_BASELINE_COLLECTION_ID,
+            ),
+            (
+                rs_settings.REMOTE_SETTINGS_PUBLISH_BUCKET_ID,
+                rs_settings.REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID,
+            ),
+        ]
+        # Allow writes for all collections
+        allow_write_payload = {
+            "data": {},
+            "permissions": {"write": [f"account:{rs_settings.REMOTE_SETTINGS_USERNAME}"]},
+        }
+        readonly_payload = {"data": {}, "permissions": {}}
+        for bucket, collection in bucket_collection_pairs:
+            collection_url = (
+                f"{rs_settings.REMOTE_SETTINGS_URL}/buckets/{bucket}/collections/{collection}"
+            )
+            requestsmock.get(collection_url, json=allow_write_payload)
 
-        requestsmock.get(
-            collection_url,
-            json={
-                "data": {},
-                "permissions": {"write": [f"account:{rs_settings.REMOTE_SETTINGS_USERNAME}"]},
-            },
-        )
+        for bucket, collection in bucket_collection_pairs:
+            collection_url = (
+                f"{rs_settings.REMOTE_SETTINGS_URL}/buckets/{bucket}/collections/{collection}"
+            )
+            # make the collection readonly
+            requestsmock.get(collection_url, json=readonly_payload)
+            # test it
+            with pytest.raises(ImproperlyConfigured) as exc:
+                exports.RemoteSettings().check_config()
+            assert f"Remote Settings collection {collection} is not writable" in str(exc.value)
+            # restore write permissions
+            requestsmock.get(collection_url, json=allow_write_payload)
 
-        # Collection review should be explicitly disabled.
+        # Baseline collection review should be explicitly disabled.
         with pytest.raises(ImproperlyConfigured) as exc:
             exports.RemoteSettings().check_config()
         assert (
             "Review was not disabled on Remote Settings collection "
-            f"{rs_settings.REMOTE_SETTINGS_COLLECTION_ID}."
+            f"{rs_settings.REMOTE_SETTINGS_BASELINE_COLLECTION_ID}."
         ) in str(exc.value)
 
         requestsmock.get(
@@ -151,6 +227,57 @@ class TestRemoteSettings:
                                 "destination": {
                                     "bucket": "main",
                                     "collection": "normandy-recipes",
+                                },
+                                "to_review_enabled": False,
+                                "group_check_enabled": False,
+                            },
+                        ],
+                    }
+                },
+            },
+        )
+
+        # Capabilities collection review should be explicitly disabled.
+        with pytest.raises(ImproperlyConfigured) as exc:
+            exports.RemoteSettings().check_config()
+        assert (
+            "Review was not disabled on Remote Settings collection "
+            f"{rs_settings.REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID}."
+        ) in str(exc.value)
+
+        requestsmock.get(
+            f"{rs_settings.REMOTE_SETTINGS_URL}/",
+            json={
+                "user": {"id": f"account:{rs_settings.REMOTE_SETTINGS_USERNAME}"},
+                "capabilities": {
+                    "signer": {
+                        "to_review_enabled": True,
+                        "group_check_enabled": True,
+                        "resources": [
+                            {
+                                "source": {"bucket": "main-workspace", "collection": None},
+                                "destination": {"bucket": "main", "collection": None},
+                            },
+                            {
+                                "source": {
+                                    "bucket": "main-workspace",
+                                    "collection": "normandy-recipes",
+                                },
+                                "destination": {
+                                    "bucket": "main",
+                                    "collection": "normandy-recipes",
+                                },
+                                "to_review_enabled": False,
+                                "group_check_enabled": False,
+                            },
+                            {
+                                "source": {
+                                    "bucket": "main-workspace",
+                                    "collection": "normandy-recipes-capabilities",
+                                },
+                                "destination": {
+                                    "bucket": "main",
+                                    "collection": "normandy-recipes-capabilities",
                                 },
                                 "to_review_enabled": False,
                                 "group_check_enabled": False,
@@ -190,6 +317,7 @@ class TestRemoteSettings:
                 "id": recipe.id,
                 "name": recipe.name,
                 "revision_id": str(recipe.revision_id),
+                "capabilities": Whatever(lambda caps: set(caps) == recipe.capabilities),
             },
             "signature": {
                 "public_key": Whatever.regex(r"[a-zA-Z0-9/+]{160}"),
@@ -199,15 +327,14 @@ class TestRemoteSettings:
             },
         }
 
-    def test_publish_puts_record_and_approves(self, rs_settings, requestsmock, mock_logger):
+    def test_publish_puts_record_and_approves(
+        self, rs_urls, rs_settings, requestsmock, mock_logger
+    ):
         """Test that requests are sent to Remote Settings on publish."""
 
         recipe = RecipeFactory(name="Test", approver=UserFactory())
-        collection_url = (
-            f"{rs_settings.REMOTE_SETTINGS_URL}/buckets/{rs_settings.REMOTE_SETTINGS_BUCKET_ID}"
-            f"/collections/{rs_settings.REMOTE_SETTINGS_COLLECTION_ID}"
-        )
-        record_url = f"{collection_url}/records/{recipe.id}"
+        rs_settings.BASELINE_CAPABILITIES |= recipe.capabilities
+
         auth = (
             rs_settings.REMOTE_SETTINGS_USERNAME + ":" + rs_settings.REMOTE_SETTINGS_PASSWORD
         ).encode()
@@ -216,35 +343,49 @@ class TestRemoteSettings:
             "Content-Type": "application/json",
             "Authorization": f"Basic {base64.b64encode(auth).decode()}",
         }
-        requestsmock.request(
-            "put", record_url, content=b'{"data": {}}', request_headers=request_headers
-        )
-        requestsmock.request(
-            "patch", collection_url, content=b'{"data": {}}', request_headers=request_headers
-        )
+
+        for collection in ["baseline", "capabilities"]:
+            requestsmock.request(
+                "PUT",
+                rs_urls["workspace"][collection]["record"].format(recipe.id),
+                json={"data": {}},
+                request_headers=request_headers,
+            )
+            requestsmock.request(
+                "PATCH",
+                rs_urls["workspace"][collection]["collection"],
+                json={"data": {}},
+                request_headers=request_headers,
+            )
 
         remotesettings = exports.RemoteSettings()
         remotesettings.publish(recipe)
 
-        assert len(requestsmock.request_history) == 2
-        assert requestsmock.request_history[0].url == record_url
-        assert requestsmock.request_history[0].method == "PUT"
-        assert requestsmock.request_history[0].json() == {"data": exports.recipe_as_record(recipe)}
-        assert requestsmock.request_history[1].method == "PATCH"
-        assert requestsmock.request_history[1].url == collection_url
+        requests = requestsmock.request_history
+        assert len(requests) == 4
+        assert requests[0].url == rs_urls["workspace"]["capabilities"]["record"].format(recipe.id)
+        assert requests[0].method == "PUT"
+        assert requests[0].json() == {"data": exports.recipe_as_record(recipe)}
+        assert requests[1].url == rs_urls["workspace"]["baseline"]["record"].format(recipe.id)
+        assert requests[1].method == "PUT"
+        assert requests[1].json() == {"data": exports.recipe_as_record(recipe)}
+        assert requests[2].method == "PATCH"
+        assert requests[2].url == rs_urls["workspace"]["capabilities"]["collection"]
+        assert requests[3].method == "PATCH"
+        assert requests[3].url == rs_urls["workspace"]["baseline"]["collection"]
         mock_logger.info.assert_called_with(
             f"Published record '{recipe.id}' for recipe '{recipe.name}'"
         )
 
-    def test_unpublish_deletes_record_and_approves(self, rs_settings, requestsmock, mock_logger):
+    def test_unpublish_deletes_record_and_approves(
+        self, rs_urls, rs_settings, requestsmock, mock_logger
+    ):
         """Test that requests are sent to Remote Settings on unpublish."""
 
         recipe = RecipeFactory(name="Test", approver=UserFactory())
-        collection_url = (
-            f"{rs_settings.REMOTE_SETTINGS_URL}/buckets/{rs_settings.REMOTE_SETTINGS_BUCKET_ID}"
-            f"/collections/{rs_settings.REMOTE_SETTINGS_COLLECTION_ID}"
-        )
-        record_url = f"{collection_url}/records/{recipe.id}"
+        rs_settings.BASELINE_CAPABILITIES |= recipe.capabilities
+        urls = rs_urls["workspace"]
+
         auth = (
             rs_settings.REMOTE_SETTINGS_USERNAME + ":" + rs_settings.REMOTE_SETTINGS_PASSWORD
         ).encode()
@@ -253,32 +394,40 @@ class TestRemoteSettings:
             "Content-Type": "application/json",
             "Authorization": f"Basic {base64.b64encode(auth).decode()}",
         }
-        requestsmock.request(
-            "delete", record_url, content=b'{"data": {}}', request_headers=request_headers
-        )
-        requestsmock.request(
-            "patch", collection_url, content=b'{"data": {}}', request_headers=request_headers
-        )
+        for collection in ["baseline", "capabilities"]:
+            requestsmock.request(
+                "delete",
+                urls[collection]["record"].format(recipe.id),
+                json={"data": {}},
+                request_headers=request_headers,
+            )
+            requestsmock.request(
+                "patch",
+                urls[collection]["collection"],
+                json={"data": {}},
+                request_headers=request_headers,
+            )
 
         remotesettings = exports.RemoteSettings()
         remotesettings.unpublish(recipe)
 
-        assert len(requestsmock.request_history) == 2
-        assert requestsmock.request_history[0].url == record_url
-        assert requestsmock.request_history[0].method == "DELETE"
-        assert requestsmock.request_history[1].url == collection_url
-        assert requestsmock.request_history[1].method == "PATCH"
+        assert len(requestsmock.request_history) == 4
+        requests = requestsmock.request_history
+        assert requests[0].url == urls["capabilities"]["record"].format(recipe.id)
+        assert requests[0].method == "DELETE"
+        assert requests[1].url == urls["baseline"]["record"].format(recipe.id)
+        assert requests[1].method == "DELETE"
+        assert requests[2].url == urls["capabilities"]["collection"]
+        assert requests[2].method == "PATCH"
+        assert requests[3].url == urls["baseline"]["collection"]
+        assert requests[3].method == "PATCH"
         mock_logger.info.assert_called_with(
             f"Deleted record '{recipe.id}' of recipe '{recipe.name}'"
         )
 
-    def test_publish_raises_an_error_if_request_fails(self, rs_settings, requestsmock):
+    def test_publish_raises_an_error_if_request_fails(self, rs_urls, rs_settings, requestsmock):
         recipe = RecipeFactory(name="Test", approver=UserFactory())
-        record_url = (
-            f"{rs_settings.REMOTE_SETTINGS_URL}/buckets/{rs_settings.REMOTE_SETTINGS_BUCKET_ID}"
-            f"/collections/{rs_settings.REMOTE_SETTINGS_COLLECTION_ID}"
-            f"/records/{recipe.id}"
-        )
+        record_url = rs_urls["workspace"]["capabilities"]["record"].format(recipe.id)
         requestsmock.request("put", record_url, status_code=503)
 
         remotesettings = exports.RemoteSettings()
@@ -287,113 +436,245 @@ class TestRemoteSettings:
 
         assert requestsmock.call_count == rs_settings.REMOTE_SETTINGS_RETRY_REQUESTS + 1
 
-    def test_unpublish_ignores_error_about_missing_record(
-        self, rs_settings, requestsmock, mock_logger
+    def test_unpublish_ignores_error_about_missing_records(
+        self, rs_urls, rs_settings, requestsmock, mock_logger
     ):
         recipe = RecipeFactory(name="Test", approver=UserFactory())
-        record_url = (
-            f"{rs_settings.REMOTE_SETTINGS_URL}/buckets/{rs_settings.REMOTE_SETTINGS_BUCKET_ID}"
-            f"/collections/{rs_settings.REMOTE_SETTINGS_COLLECTION_ID}"
-            f"/records/{recipe.id}"
+        baseline_record_url = rs_urls["workspace"]["baseline"]["record"].format(recipe.id)
+        capabilities_record_url = rs_urls["workspace"]["capabilities"]["record"].format(recipe.id)
+        warning_message = (
+            f"The recipe '{recipe.id}' was not published in the {{}} collection. Skip."
         )
-        requestsmock.request("delete", record_url, status_code=404)
 
+        requestsmock.request("delete", baseline_record_url, status_code=404)
+        requestsmock.request("delete", capabilities_record_url, status_code=404)
         remotesettings = exports.RemoteSettings()
         # Assert doesn't raise.
         remotesettings.unpublish(recipe)
+        assert mock_logger.warning.call_args_list == [
+            call(warning_message.format("capabilities")),
+            call(warning_message.format("baseline")),
+        ]
 
-        assert requestsmock.call_count == 1
-        mock_logger.warning.assert_called_with(
-            f"The recipe '{recipe.id}' was never published. Skip."
-        )
-
-    def test_publish_reverts_changes_if_approval_fails(self, rs_settings, requestsmock):
+    def test_publish_reverts_changes_if_approval_fails(self, rs_urls, rs_settings, requestsmock):
+        # This test forces the recipe to not use baseline capabilities to
+        # simplify the test. This simplifies the test.
         recipe = RecipeFactory(name="Test", approver=UserFactory())
+        assert not recipe.uses_only_baseline_capabilities()
         record = exports.recipe_as_record(recipe)
         unchanged = exports.recipe_as_record(
             RecipeFactory(name="Unchanged", approver=UserFactory())
         )
-        collection_url = (
-            f"{rs_settings.REMOTE_SETTINGS_URL}/buckets/{rs_settings.REMOTE_SETTINGS_BUCKET_ID}"
-            f"/collections/{rs_settings.REMOTE_SETTINGS_COLLECTION_ID}"
-        )
-        records_url = f"{collection_url}/records"
-        record_url = f"{collection_url}/records/{recipe.id}"
-        records_prod_url = records_url.replace(
-            f"/buckets/{rs_settings.REMOTE_SETTINGS_BUCKET_ID}/",
-            f"/buckets/{exports.RemoteSettings.MAIN_BUCKET_ID}/",
-        )
+
+        capabilities_record_url = rs_urls["workspace"]["capabilities"]["record"].format(recipe.id)
         # Creating the record works.
-        requestsmock.request("put", record_url, content=b'{"data": {}}', status_code=201)
+        requestsmock.request("put", capabilities_record_url, json={"data": {}}, status_code=201)
         # Approving fails.
-        requestsmock.request("patch", collection_url, status_code=403)
+        requestsmock.request(
+            "patch", rs_urls["workspace"]["capabilities"]["collection"], status_code=403
+        )
         # Simulate that the record exists in workspace but not in main
         requestsmock.request(
-            "get", records_url, content=json.dumps({"data": [unchanged, record]}).encode()
+            "get",
+            rs_urls["workspace"]["capabilities"]["records"],
+            json={"data": [unchanged, record]},
         )
         requestsmock.request(
-            "get", records_prod_url, content=json.dumps({"data": [unchanged]}).encode()
+            "get", rs_urls["publish"]["capabilities"]["records"], json={"data": [unchanged]}
         )
+        # And nothing exists in the baseline collection
+        requestsmock.request("get", rs_urls["workspace"]["baseline"]["records"], json={"data": []})
+        requestsmock.request("get", rs_urls["publish"]["baseline"]["records"], json={"data": []})
         # Reverting changes means deleting this record.
-        requestsmock.request("delete", record_url, content=b'{"data": {"deleted":true}}')
+        requestsmock.request("delete", capabilities_record_url, json={"data": {"deleted": True}})
 
         remotesettings = exports.RemoteSettings()
         with pytest.raises(kinto_http.KintoException):
             remotesettings.publish(recipe)
 
-        assert len(requestsmock.request_history) == 5
-        assert requestsmock.request_history[0].url == record_url
-        assert requestsmock.request_history[0].method == "PUT"
-        assert requestsmock.request_history[1].url == collection_url
-        assert requestsmock.request_history[1].method == "PATCH"
-        assert requestsmock.request_history[2].url == records_url
-        assert requestsmock.request_history[3].url == records_prod_url
-        assert requestsmock.request_history[4].url == record_url
-        assert requestsmock.request_history[4].method == "DELETE"
+        requests = requestsmock.request_history
+        assert len(requests) == 5
+        # First it publishes a recipe
+        assert requests[0].method == "PUT"
+        assert requests[0].url == capabilities_record_url
+        # and then tries to approve it, which fails.
+        assert requests[1].method == "PATCH"
+        assert requests[1].url == rs_urls["workspace"]["capabilities"]["collection"]
+        # It gets the state of all the collections
+        assert requests[2].method == "GET"
+        assert requests[2].url == rs_urls["workspace"]["capabilities"]["records"]
+        assert requests[3].method == "GET"
+        assert requests[3].url == rs_urls["publish"]["capabilities"]["records"]
+        # And then deletes the record published in request 0
+        assert requests[4].method == "DELETE"
+        assert requests[4].url == capabilities_record_url
 
-    def test_unpublish_reverts_changes_if_approval_fails(self, rs_settings, requestsmock):
+    def test_unpublish_reverts_changes_if_approval_fails(self, rs_urls, rs_settings, requestsmock):
         recipe = RecipeFactory(name="Test", approver=UserFactory())
         record = exports.recipe_as_record(recipe)
         unchanged = exports.recipe_as_record(
             RecipeFactory(name="Unchanged", approver=UserFactory())
         )
-        collection_url = (
-            f"{rs_settings.REMOTE_SETTINGS_URL}/buckets/{rs_settings.REMOTE_SETTINGS_BUCKET_ID}"
-            f"/collections/{rs_settings.REMOTE_SETTINGS_COLLECTION_ID}"
-        )
-        records_url = f"{collection_url}/records"
-        record_url = f"{collection_url}/records/{recipe.id}"
-        records_prod_url = records_url.replace(
-            f"/buckets/{rs_settings.REMOTE_SETTINGS_BUCKET_ID}/",
-            f"/buckets/{exports.RemoteSettings.MAIN_BUCKET_ID}/",
-        )
+        baseline_record_url = rs_urls["workspace"]["baseline"]["record"].format(recipe.id)
+        capabilities_record_url = rs_urls["workspace"]["capabilities"]["record"].format(recipe.id)
         # Deleting the record works.
-        requestsmock.request("delete", record_url, content=b'{"data": {"deleted":true}}')
+        requestsmock.request("delete", baseline_record_url, json={"data": {"deleted": True}})
+        requestsmock.request("delete", capabilities_record_url, json={"data": {"deleted": True}})
         # Approving fails.
-        requestsmock.request("patch", collection_url, status_code=403)
-        # Simulate that the record exists in prod but not in workspace
         requestsmock.request(
-            "get", records_url, content=json.dumps({"data": [unchanged]}).encode()
+            "patch",
+            rs_urls["workspace"]["capabilities"]["collection"],
+            status_code=403,
+            json={"data": {}},
+        )
+        # Simulate that the record exists in prod but not in workspace, and not in the baseline collection
+        requestsmock.request(
+            "get", rs_urls["workspace"]["capabilities"]["records"], json={"data": [unchanged]}
         )
         requestsmock.request(
-            "get", records_prod_url, content=json.dumps({"data": [unchanged, record]}).encode()
+            "get",
+            rs_urls["publish"]["capabilities"]["records"],
+            json={"data": [unchanged, record]},
         )
+        for bucket in ["workspace", "publish"]:
+            requestsmock.request("get", rs_urls[bucket]["baseline"]["records"], json={"data": []})
         # Reverting changes means recreating this record.
-        requestsmock.request("put", record_url, content=b'{"data": {}}')
+        requestsmock.request("put", capabilities_record_url, json={"data": {}})
 
         remotesettings = exports.RemoteSettings()
         with pytest.raises(kinto_http.KintoException):
             remotesettings.unpublish(recipe)
 
-        assert len(requestsmock.request_history) == 5
-        assert requestsmock.request_history[0].url == record_url
-        assert requestsmock.request_history[0].method == "DELETE"
-        assert requestsmock.request_history[1].url == collection_url
-        assert requestsmock.request_history[1].method == "PATCH"
-        assert requestsmock.request_history[2].url == records_url
-        assert requestsmock.request_history[3].url == records_prod_url
-        assert requestsmock.request_history[4].url == record_url
-        assert requestsmock.request_history[4].method == "PUT"
-        submitted = requestsmock.request_history[4].json()
+        requests = requestsmock.request_history
+        assert len(requests) == 8
+        # Unpublish the recipe in both collections
+        assert requests[0].url == capabilities_record_url
+        assert requests[0].method == "DELETE"
+        assert requests[1].url == baseline_record_url
+        assert requests[1].method == "DELETE"
+        # Try (and fail) to approve the capabilities change
+        assert requests[2].url == rs_urls["workspace"]["capabilities"]["collection"]
+        assert requests[2].method == "PATCH"
+        # Get the state of the capabilities collection
+        assert requests[3].url == rs_urls["workspace"]["capabilities"]["records"]
+        assert requests[3].method == "GET"
+        assert requests[4].url == rs_urls["publish"]["capabilities"]["records"]
+        assert requests[4].method == "GET"
+        # Fix the capabilities collection
+        assert requests[5].url == capabilities_record_url
+        assert requests[5].method == "PUT"
+        # Get the state of the baseline collection
+        assert requests[6].url == rs_urls["workspace"]["baseline"]["records"]
+        assert requests[6].method == "GET"
+        assert requests[7].url == rs_urls["publish"]["baseline"]["records"]
+        assert requests[7].method == "GET"
+
+        submitted = requests[5].json()
         assert submitted["data"]["id"] == str(recipe.id)
-        assert submitted["data"]["recipe"]["name"] == "Test"
+        assert submitted["data"]["recipe"]["name"] == recipe.name
+
+    def test_publish_and_unpublish_baseline_recipe_to_both_collections(
+        self, rs_settings, rs_urls, requestsmock
+    ):
+        ws_urls = rs_urls["workspace"]
+
+        recipe = RecipeFactory()
+        rs_settings.BASELINE_CAPABILITIES |= recipe.capabilities
+        assert recipe.uses_only_baseline_capabilities()
+
+        # Expect publish calls to both collections
+        requestsmock.put(
+            ws_urls["baseline"]["record"].format(recipe.id), json={"data": {}}, status_code=201
+        )
+        requestsmock.put(
+            ws_urls["capabilities"]["record"].format(recipe.id), json={"data": {}}, status_code=201
+        )
+        # Expect both workspaces to be approved
+        requestsmock.patch(ws_urls["baseline"]["collection"], json={"data": {}})
+        requestsmock.patch(ws_urls["capabilities"]["collection"], json={"data": {}})
+
+        remotesettings = exports.RemoteSettings()
+        remotesettings.publish(recipe)
+
+        requests = requestsmock.request_history
+        assert len(requests) == 4
+        # First it publishes a recipe to both collections
+        assert requests[0].method == "PUT"
+        assert requests[0].url == ws_urls["capabilities"]["record"].format(recipe.id)
+        assert requests[1].method == "PUT"
+        assert requests[1].url == ws_urls["baseline"]["record"].format(recipe.id)
+        # and then approves both changes
+        assert requests[2].method == "PATCH"
+        assert requests[2].url == rs_urls["workspace"]["capabilities"]["collection"]
+        assert requests[3].method == "PATCH"
+        assert requests[3].url == rs_urls["workspace"]["baseline"]["collection"]
+
+        # reset request history
+        requestsmock._adapter.request_history = []
+
+        # Expect delete calls
+        requestsmock.delete(ws_urls["baseline"]["record"].format(recipe.id), json={"data": {}})
+        requestsmock.delete(ws_urls["capabilities"]["record"].format(recipe.id), json={"data": {}})
+
+        remotesettings.unpublish(recipe)
+
+        requests = requestsmock.request_history
+        assert len(requests) == 4
+        # First it removes the recipe from both collections
+        assert requests[0].method == "DELETE"
+        assert requests[0].url == ws_urls["capabilities"]["record"].format(recipe.id)
+        assert requests[1].method == "DELETE"
+        assert requests[1].url == ws_urls["baseline"]["record"].format(recipe.id)
+        # and then approves both changes
+        assert requests[2].method == "PATCH"
+        assert requests[2].url == rs_urls["workspace"]["capabilities"]["collection"]
+        assert requests[3].method == "PATCH"
+        assert requests[3].url == rs_urls["workspace"]["baseline"]["collection"]
+
+    def test_publish_and_unpublish_non_baseline_recipe_only_to_capabilities_collection(
+        self, rs_settings, rs_urls, requestsmock
+    ):
+        ws_urls = rs_urls["workspace"]
+
+        recipe = RecipeFactory()
+        assert not recipe.uses_only_baseline_capabilities()
+
+        # Expect calls only to the capabilities collection
+        requestsmock.put(
+            ws_urls["capabilities"]["record"].format(recipe.id), json={"data": {}}, status_code=201
+        )
+        requestsmock.patch(ws_urls["capabilities"]["collection"], json={"data": {}})
+
+        remotesettings = exports.RemoteSettings()
+        remotesettings.publish(recipe)
+
+        requests = requestsmock.request_history
+        assert len(requests) == 2
+        # First it publishes the recipe
+        assert requests[0].method == "PUT"
+        assert requests[0].url == ws_urls["capabilities"]["record"].format(recipe.id)
+        # and then approves the change
+        assert requests[1].method == "PATCH"
+        assert requests[1].url == rs_urls["workspace"]["capabilities"]["collection"]
+
+        # reset request history
+        requestsmock._adapter.request_history = []
+
+        # Expect delete calls
+        requestsmock.delete(ws_urls["capabilities"]["record"].format(recipe.id), json={"data": {}})
+        # Baseline is expected, just in case the recipe changed from baseline to not baseline
+        requestsmock.delete(ws_urls["baseline"]["record"].format(recipe.id), status_code=404)
+
+        remotesettings.unpublish(recipe)
+
+        requests = requestsmock.request_history
+        assert len(requests) == 3
+        # First it removes the recipe
+        assert requests[0].method == "DELETE"
+        assert requests[0].url == ws_urls["capabilities"]["record"].format(recipe.id)
+        # Tries to delete from baseline, just in case
+        assert requests[1].method == "DELETE"
+        assert requests[1].url == ws_urls["baseline"]["record"].format(recipe.id)
+        # and then approves the change only from capabilities
+        assert requests[2].method == "PATCH"
+        assert requests[2].url == rs_urls["workspace"]["capabilities"]["collection"]

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -406,6 +406,7 @@ class TestRecipe(object):
             "{"
             '"action":"action",'
             '"arguments":{"bar":2,"foo":1},'
+            '"capabilities":["action.action","capabilities-v1"],'
             '"filter_expression":"%(filter_expression)s",'
             '"id":%(id)s,'
             '"name":"canonical",'
@@ -698,124 +699,129 @@ class TestRecipeRevision(object):
         with pytest.raises(EnabledState.NotActionable):
             recipe.latest_revision.disable(user=UserFactory())
 
-    def test_it_publishes_when_enabled(self, mocked_remotesettings):
-        recipe = RecipeFactory(name="Test")
+    @pytest.mark.django_db
+    class TestRemoteSettings:
+        def test_it_publishes_when_enabled(self, mocked_remotesettings):
+            recipe = RecipeFactory(name="Test")
 
-        approval_request = recipe.latest_revision.request_approval(creator=UserFactory())
-        approval_request.approve(approver=UserFactory(), comment="r+")
-        recipe.approved_revision.enable(user=UserFactory())
-
-        mocked_remotesettings.return_value.publish.assert_called_with(recipe)
-
-        # Publishes once when enabled twice.
-        with pytest.raises(EnabledState.NotActionable):
+            approval_request = recipe.latest_revision.request_approval(creator=UserFactory())
+            approval_request.approve(approver=UserFactory(), comment="r+")
             recipe.approved_revision.enable(user=UserFactory())
 
-        assert mocked_remotesettings.return_value.publish.call_count == 1
+            mocked_remotesettings.return_value.publish.assert_called_with(recipe)
 
-    def test_it_publishes_new_revisions_if_enabled(self, mocked_remotesettings):
-        recipe = RecipeFactory(name="Test", approver=UserFactory(), enabler=UserFactory())
-        assert mocked_remotesettings.return_value.publish.call_count == 1
+            # Publishes once when enabled twice.
+            with pytest.raises(EnabledState.NotActionable):
+                recipe.approved_revision.enable(user=UserFactory())
 
-        recipe.revise(name="Modified")
-        approval_request = recipe.latest_revision.request_approval(creator=UserFactory())
-        approval_request.approve(approver=UserFactory(), comment="r+")
+            assert mocked_remotesettings.return_value.publish.call_count == 1
 
-        assert mocked_remotesettings.return_value.publish.call_count == 2
-        second_call_args, _ = mocked_remotesettings.return_value.publish.call_args_list[1]
-        modified_recipe, = second_call_args
-        assert modified_recipe.name == "Modified"
+        def test_it_publishes_new_revisions_if_enabled(self, mocked_remotesettings):
+            recipe = RecipeFactory(name="Test", approver=UserFactory(), enabler=UserFactory())
+            assert mocked_remotesettings.return_value.publish.call_count == 1
 
-    def test_it_does_not_publish_when_approved_if_not_enabled(self, mocked_remotesettings):
-        recipe = RecipeFactory(name="Test")
+            recipe.revise(name="Modified")
+            approval_request = recipe.latest_revision.request_approval(creator=UserFactory())
+            approval_request.approve(approver=UserFactory(), comment="r+")
 
-        approval_request = recipe.latest_revision.request_approval(creator=UserFactory())
-        approval_request.approve(approver=UserFactory(), comment="r+")
+            assert mocked_remotesettings.return_value.publish.call_count == 2
+            second_call_args, _ = mocked_remotesettings.return_value.publish.call_args_list[1]
+            modified_recipe, = second_call_args
+            assert modified_recipe.name == "Modified"
 
-        assert not mocked_remotesettings.return_value.publish.called
+        def test_it_does_not_publish_when_approved_if_not_enabled(self, mocked_remotesettings):
+            recipe = RecipeFactory(name="Test")
 
-    def test_it_unpublishes_when_disabled(self, mocked_remotesettings):
-        recipe = RecipeFactory(name="Test", approver=UserFactory(), enabler=UserFactory())
+            approval_request = recipe.latest_revision.request_approval(creator=UserFactory())
+            approval_request.approve(approver=UserFactory(), comment="r+")
 
-        recipe.approved_revision.disable(user=UserFactory())
+            assert not mocked_remotesettings.return_value.publish.called
 
-        mocked_remotesettings.return_value.unpublish.assert_called_with(recipe)
+        def test_it_unpublishes_when_disabled(self, mocked_remotesettings):
+            recipe = RecipeFactory(name="Test", approver=UserFactory(), enabler=UserFactory())
 
-        # Unpublishes once when disabled twice.
-        with pytest.raises(EnabledState.NotActionable):
             recipe.approved_revision.disable(user=UserFactory())
 
-        assert mocked_remotesettings.return_value.publish.call_count == 1
+            mocked_remotesettings.return_value.unpublish.assert_called_with(recipe)
 
-    def test_it_publishes_several_times_when_reenabled(self, mocked_remotesettings):
-        recipe = RecipeFactory(name="Test", approver=UserFactory(), enabler=UserFactory())
+            # Unpublishes once when disabled twice.
+            with pytest.raises(EnabledState.NotActionable):
+                recipe.approved_revision.disable(user=UserFactory())
 
-        recipe.approved_revision.disable(user=UserFactory())
-        recipe.approved_revision.enable(user=UserFactory())
+            assert mocked_remotesettings.return_value.publish.call_count == 1
 
-        assert mocked_remotesettings.return_value.unpublish.call_count == 1
-        assert mocked_remotesettings.return_value.publish.call_count == 2
+        def test_it_publishes_several_times_when_reenabled(self, mocked_remotesettings):
+            recipe = RecipeFactory(name="Test", approver=UserFactory(), enabler=UserFactory())
 
-    def test_it_rollbacks_changes_if_error_happens_on_publish(self, mocked_remotesettings):
-        recipe = RecipeFactory(name="Test", approver=UserFactory())
-        error = remote_settings_exceptions.KintoException
-        mocked_remotesettings.return_value.publish.side_effect = error
-
-        with pytest.raises(error):
+            recipe.approved_revision.disable(user=UserFactory())
             recipe.approved_revision.enable(user=UserFactory())
 
-        saved = Recipe.objects.get(id=recipe.id)
-        assert not saved.approved_revision.enabled
+            assert mocked_remotesettings.return_value.unpublish.call_count == 1
+            assert mocked_remotesettings.return_value.publish.call_count == 2
 
-    def test_it_rollbacks_changes_if_error_happens_on_unpublish(self, mocked_remotesettings):
-        recipe = RecipeFactory(name="Test", approver=UserFactory(), enabler=UserFactory())
-        error = remote_settings_exceptions.KintoException
-        mocked_remotesettings.return_value.unpublish.side_effect = error
+        def test_it_rollbacks_changes_if_error_happens_on_publish(self, mocked_remotesettings):
+            recipe = RecipeFactory(name="Test", approver=UserFactory())
+            error = remote_settings_exceptions.KintoException
+            mocked_remotesettings.return_value.publish.side_effect = error
 
-        with pytest.raises(error):
-            recipe.approved_revision.disable(user=UserFactory())
+            with pytest.raises(error):
+                recipe.approved_revision.enable(user=UserFactory())
 
-        saved = Recipe.objects.get(id=recipe.id)
-        assert saved.approved_revision.enabled
+            saved = Recipe.objects.get(id=recipe.id)
+            assert not saved.approved_revision.enabled
 
-    def test_enable_rollback_enable_rollout_invariance(self):
-        rollout_recipe = RecipeFactory(
-            name="Rollout",
-            approver=UserFactory(),
-            enabler=UserFactory(),
-            action=ActionFactory(name="preference-rollout"),
-            arguments={"slug": "myslug"},
-        )
-        assert rollout_recipe.enabled
+        def test_it_rollbacks_changes_if_error_happens_on_unpublish(self, mocked_remotesettings):
+            recipe = RecipeFactory(name="Test", approver=UserFactory(), enabler=UserFactory())
+            error = remote_settings_exceptions.KintoException
+            mocked_remotesettings.return_value.unpublish.side_effect = error
 
-        rollback_recipe = RecipeFactory(
-            name="Rollback",
-            action=ActionFactory(name="preference-rollback"),
-            arguments={"rolloutSlug": "myslug"},
-        )
-        approval_request = rollback_recipe.latest_revision.request_approval(creator=UserFactory())
-        approval_request.approve(approver=UserFactory(), comment="r+")
+            with pytest.raises(error):
+                recipe.approved_revision.disable(user=UserFactory())
 
-        with pytest.raises(ValidationError) as exc_info:
+            saved = Recipe.objects.get(id=recipe.id)
+            assert saved.approved_revision.enabled
+
+        def test_enable_rollback_enable_rollout_invariance(self):
+            rollout_recipe = RecipeFactory(
+                name="Rollout",
+                approver=UserFactory(),
+                enabler=UserFactory(),
+                action=ActionFactory(name="preference-rollout"),
+                arguments={"slug": "myslug"},
+            )
+            assert rollout_recipe.enabled
+
+            rollback_recipe = RecipeFactory(
+                name="Rollback",
+                action=ActionFactory(name="preference-rollback"),
+                arguments={"rolloutSlug": "myslug"},
+            )
+            approval_request = rollback_recipe.latest_revision.request_approval(
+                creator=UserFactory()
+            )
+            approval_request.approve(approver=UserFactory(), comment="r+")
+
+            with pytest.raises(ValidationError) as exc_info:
+                rollback_recipe.approved_revision.enable(user=UserFactory())
+            assert exc_info.value.message == "Rollout recipe 'Rollout' is currently enabled"
+
+            rollout_recipe.approved_revision.disable(user=UserFactory())
+            assert not rollout_recipe.enabled
+            # Now it should be possible to enable the rollback recipe.
             rollback_recipe.approved_revision.enable(user=UserFactory())
-        assert exc_info.value.message == "Rollout recipe 'Rollout' is currently enabled"
+            assert rollback_recipe.enabled
 
-        rollout_recipe.approved_revision.disable(user=UserFactory())
-        assert not rollout_recipe.enabled
-        # Now it should be possible to enable the rollback recipe.
-        rollback_recipe.approved_revision.enable(user=UserFactory())
-        assert rollback_recipe.enabled
-
-        # Can't make up your mind. Now try to enable the rollout recipe again even though
-        # the rollback recipe is enabled.
-        with pytest.raises(ValidationError) as exc_info:
-            rollout_recipe.approved_revision.enable(user=UserFactory())
-        assert exc_info.value.message == "Rollback recipe 'Rollback' is currently enabled"
+            # Can't make up your mind. Now try to enable the rollout recipe again even though
+            # the rollback recipe is enabled.
+            with pytest.raises(ValidationError) as exc_info:
+                rollout_recipe.approved_revision.enable(user=UserFactory())
+            assert exc_info.value.message == "Rollback recipe 'Rollback' is currently enabled"
 
     @pytest.mark.django_db
-    class TestCapabilitiesTests:
-        def test_v1_marker_is_automatically_included(self):
-            recipe = RecipeFactory()
+    class TestCapabilities:
+        def test_v1_marker_included_if_non_baseline_capabilities_are_present(self, settings):
+            recipe = RecipeFactory(extra_capabilities=["non-baseline"])
+            assert "non-baseline" not in settings.BASELINE_CAPABILITIES
             assert "capabilities-v1" in recipe.capabilities
 
         def test_uses_extra_capabilities(self):

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -376,8 +376,10 @@ class Base(Core, CORS, OIDC, Metrics):
     REMOTE_SETTINGS_URL = values.Value()
     REMOTE_SETTINGS_USERNAME = values.Value()
     REMOTE_SETTINGS_PASSWORD = values.Value()
-    REMOTE_SETTINGS_BUCKET_ID = values.Value("main-workspace")
-    REMOTE_SETTINGS_COLLECTION_ID = values.Value("normandy-recipes")
+    REMOTE_SETTINGS_PUBLISH_BUCKET_ID = values.Value("main")
+    REMOTE_SETTINGS_WORKSPACE_BUCKET_ID = values.Value("main-workspace")
+    REMOTE_SETTINGS_BASELINE_COLLECTION_ID = values.Value("normandy-recipes")
+    REMOTE_SETTINGS_CAPABILITIES_COLLECTION_ID = values.Value("normandy-recipes-capabilities")
     REMOTE_SETTINGS_RETRY_REQUESTS = values.IntegerValue(3)
 
     # How many days before expiration to warn for expired certificates
@@ -399,6 +401,28 @@ class Base(Core, CORS, OIDC, Metrics):
     GS_DEFAULT_ACL = values.Value("publicRead")
 
     GITHUB_URL = values.Value("https://github.com/mozilla/normandy")
+
+    BASELINE_CAPABILITIES = values.SetValue(
+        set(
+            [
+                "action.addon-study",
+                "action.console-log",
+                "action.preference-rollback",
+                "action.preference-rollout",
+                "action.show-heartbeat",
+                "action.single-preference-experiment",
+                "action.opt-out-study",
+                "action.preference-experiment",
+                "jexl.transform.date",
+                "jexl.transform.stableSample",
+                "jexl.transform.bucketSample",
+                "jexl.transform.preferenceValue",
+                "jexl.transform.preferenceIsUserSet",
+                "jexl.transform.preferenceExists",
+                "jexl.transform.keys",
+            ]
+        )
+    )
 
 
 class Development(InsecureAuthentication, Base):


### PR DESCRIPTION
This ended up being way more complicated than I thought. I'm not really happy with the amount of duplication and complexity it has introduced, but I also don't see a great way to improve it. Any ideas?

Fixes #1935