### PR TITLE
Add generate_deploy_bug to Makefile fixes #1968

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -6,7 +6,7 @@ RUN groupadd --gid 10001 app && useradd -g app -d /app --uid 10001 --shell /usr/
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-    gcc libpq-dev curl apt-transport-https libffi-dev openssh-client gnupg python-dev libgmp3-dev
+    gcc libpq-dev curl apt-transport-https libffi-dev openssh-client gnupg python-dev libgmp3-dev git
 
 # Install node from NodeSource
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,7 @@ up: build
 	docker-compose up
 
 refresh: kill migrate load_data
+
+# Usage: make generate_deploy_bug FROM=fromtag TO=totag
+generate_deploy_bug: build
+	docker-compose run app python bin/generate_deploy_bug.py $(FROM) $(TO)


### PR DESCRIPTION
This allows you to run the handy `generate_deploy_bug` script from outside of the Docker context.