### PR TITLE
Tweak docs

### DIFF
--- a/docs/dev/concepts.rst
+++ b/docs/dev/concepts.rst
@@ -18,8 +18,9 @@ document describes those concepts in detail.
 Actions
 -------
 An action is one of the capabilities provided by Normandy. As of Firefox 66,
-actions are implemented entirely within the browser as native code. Actions
-are identified in recipes by name, such as "preference-experiment" or
+actions are implemented entirely within the browser as native code (though
+previously they were served by the server and retrieved at runtime). Actions are
+identified in recipes by name, such as "preference-experiment" or
 "show-heartbeat".
 
 Actions can accept a configuration object that is specified within the

--- a/docs/dev/remote-settings.rst
+++ b/docs/dev/remote-settings.rst
@@ -6,14 +6,8 @@ Remote Settings
 Remote Settings is a Mozilla service that makes it easy to manage evergreen
 settings data in Firefox.
 
-When enabled on the Normandy server, the enabled recipes are published as
-Remote Settings records.
-
-When enabled on the client side, instead of polling regularly the Normandy
-API to obtain the list of recipes, the recipes are read from the Remote
-Settings synchronized data locally.
-
-Delivering Normandy recipes via Remote Settings allows us:
+As of Firefox 68, Normandy uses Remote Settings to serve/update its
+recipes. This allows us to:
 
 - Unify the way we obtain fresh data from our services in Firefox
 - Get rid of the specific data channel of Normandy
@@ -53,25 +47,9 @@ Use ``--dry-run`` to only print out the result of the synchronization.
 Client side
 -----------
 
-The Normandy client integration is available from Firefox 68 (`Bug 1506175
-<https://bugzilla.mozilla.org/show_bug.cgi?id=1506175>`_, `Bug 1538248
-<https://bugzilla.mozilla.org/show_bug.cgi?id=1538248>`_) and can be enabled
-by flipping this preference:
-
-- ``features.normandy-remote-settings.enabled``: ``true``
-
-In order to populate the list of recipes to be picked up by the Recipe Runner, trigger a manual synchronization in the Browser console:
-
-.. code-block:: javascript
-
-      ChromeUtils.import("resource://normandy/lib/RecipeRunner.jsm", this);
-
-      await RecipeRunner.loadRecipes();
-
-.. seealso::
-
-    * `Client setup with a local Remote Settings server
-      <https://remote-settings.readthedocs.io/en/latest/tutorial-local-server.html#prepare-the-client>`_
-
-The Normandy recipe runner will now be able to read the list of recipes to
-execute from the local Remote Settings database.
+The Normandy client integration was added in Firefox 66 (`Bug 1506175
+<https://bugzilla.mozilla.org/show_bug.cgi?id=1506175>`_), refined through
+Firefox 67 and 68 (`Bug 1538248
+<https://bugzilla.mozilla.org/show_bug.cgi?id=1538248>`_) and turned on by
+default in Firefox 68 (`bug 1513854
+<https://bugzilla.mozilla.org/show_bug.cgi?id=1513854>`_).

--- a/docs/qa/environments.rst
+++ b/docs/qa/environments.rst
@@ -4,11 +4,19 @@ Environments
 ============
 Mozilla runs several instances of Normandy; this document provides information
 about each one of them, including what preferences you need to set to point an
-instance of Firefox towards them
+instance of Firefox towards them.
 
 Each environment may have several hostnames associated with it. Generally,
 there is a public, read-only server, a legacy admin server, a new Bearer
-auth admin server, and an API CDN. Not all environments have all of these.
+auth admin server, a Remote Settings server, and an API CDN. Not all
+environments have all of these.
+
+To change the Remote Settings server, the easiest thing is to use the `Remote
+Settings Devtools`_. Otherwise when changing from one environment to another
+(i.e. prod to stage), you run the risk of previously-synced data lingering and
+preventing syncs from the new environment.
+
+.. _`Remote Settings Devtools`: https://github.com/mozilla/remote-settings-devtools
 
 Production
 ----------


### PR DESCRIPTION
I've handled two different users lately who have had trouble with Remote Settings and Normandy so it seemed like it would be worth mentioning it in the documentation. I noticed also that these docs still assumed Remote Settings as a tentative feature, whereas it has been on since 68.

Some of the things I was going to write as notes for developing Normandy client seemed like they would fit better in this project's documentation, in particular the history of actions as external to the client. On the other hand, maybe it was being omitted to keep things simple. I'm happy to drop that commit if you don't think we need it.