### PR TITLE
Fix capabilities for sampling filter objects

### DIFF
--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -221,7 +221,7 @@ class BucketSampleFilter(BaseFilter):
 
     @property
     def capabilities(self):
-        return {"jexl.transforms.bucketSample"}
+        return {"jexl.transform.bucketSample"}
 
 
 class StableSampleFilter(BaseFilter):
@@ -266,7 +266,7 @@ class StableSampleFilter(BaseFilter):
 
     @property
     def capabilities(self):
-        return {"jexl.transforms.stableSample"}
+        return {"jexl.transform.stableSample"}
 
 
 class VersionFilter(BaseFilter):

--- a/normandy/recipes/tests/test_filters.py
+++ b/normandy/recipes/tests/test_filters.py
@@ -14,6 +14,8 @@ from normandy.recipes.tests import ChannelFactory, LocaleFactory, CountryFactory
 class FilterTestsBase:
     """Common tests for all filter object types"""
 
+    should_be_baseline = True
+
     def create_basic_filter(self):
         """To be overwritten by subclasses to create test filters"""
         raise NotImplementedError
@@ -30,6 +32,14 @@ class FilterTestsBase:
         filter = self.create_basic_filter()
         # Would throw if not defined
         assert isinstance(filter.to_jexl(), str)
+
+    def test_uses_only_baseline_capabilities(self, settings):
+        filter = self.create_basic_filter()
+        capabilities = filter.capabilities
+        if self.should_be_baseline:
+            assert capabilities <= settings.BASELINE_CAPABILITIES
+        else:
+            assert capabilities > settings.BASELINE_CAPABILITIES
 
 
 class TestChannelFilter(FilterTestsBase):


### PR DESCRIPTION
@jkerim totally predicted this would happen.

I verified that [the correct capability names](https://searchfox.org/mozilla-central/rev/f43ae7e1c43a4a940b658381157a6ea6c5a185c1/toolkit/components/normandy/lib/RecipeRunner.jsm#404) are indeed `jexl.transform.bucketSample` and `jexl.transform.stableSample` (ie, `transform` not `transforms`).