### PR TITLE
Verify with x5u instead of public_key

### DIFF
--- a/normandy/recipes/checks.py
+++ b/normandy/recipes/checks.py
@@ -58,8 +58,12 @@ def recipe_signatures_are_correct(app_configs, **kwargs):
             data = recipe.canonical_json()
             signature = recipe.signature.signature
             pubkey = recipe.signature.public_key
+            x5u = recipe.signature.x5u
             try:
-                signing.verify_signature_pubkey(data, signature, pubkey)
+                if x5u:
+                    signing.verify_signature_x5u(data, signature, x5u)
+                else:
+                    signing.verify_signature_pubkey(data, signature, pubkey)
             except signing.BadSignature as e:
                 msg = "Recipe '{recipe}' (id={recipe.id}) has a bad signature: {detail}".format(
                     recipe=recipe, detail=e.detail
@@ -89,8 +93,12 @@ def action_signatures_are_correct(app_configs, **kwargs):
             data = action.canonical_json()
             signature = action.signature.signature
             pubkey = action.signature.public_key
+            x5u = action.signature.x5u
             try:
-                signing.verify_signature_pubkey(data, signature, pubkey)
+                if x5u:
+                    signing.verify_signature_x5u(data, signature, x5u)
+                else:
+                    signing.verify_signature_pubkey(data, signature, pubkey)
             except signing.BadSignature as e:
                 msg = f"Action '{action}' (id={action.id}) has a bad signature: {e.detail}"
                 errors.append(Error(msg, id=ERROR_INVALID_ACTION_SIGNATURE))

--- a/normandy/recipes/checks.py
+++ b/normandy/recipes/checks.py
@@ -59,7 +59,7 @@ def recipe_signatures_are_correct(app_configs, **kwargs):
             signature = recipe.signature.signature
             pubkey = recipe.signature.public_key
             try:
-                signing.verify_signature(data, signature, pubkey)
+                signing.verify_signature_pubkey(data, signature, pubkey)
             except signing.BadSignature as e:
                 msg = "Recipe '{recipe}' (id={recipe.id}) has a bad signature: {detail}".format(
                     recipe=recipe, detail=e.detail
@@ -90,7 +90,7 @@ def action_signatures_are_correct(app_configs, **kwargs):
             signature = action.signature.signature
             pubkey = action.signature.public_key
             try:
-                signing.verify_signature(data, signature, pubkey)
+                signing.verify_signature_pubkey(data, signature, pubkey)
             except signing.BadSignature as e:
                 msg = f"Action '{action}' (id={action.id}) has a bad signature: {e.detail}"
                 errors.append(Error(msg, id=ERROR_INVALID_ACTION_SIGNATURE))

--- a/normandy/recipes/signing.py
+++ b/normandy/recipes/signing.py
@@ -12,6 +12,7 @@ import fastecdsa.ecdsa
 from fastecdsa.encoding.pem import PEMEncoder
 from hashlib import sha256
 from pyasn1.codec.der.decoder import decode as der_decode
+from pyasn1.codec.der.encoder import encode as der_encode
 from pyasn1_modules import rfc5280
 from requests_hawk import HawkAuth
 
@@ -93,6 +94,19 @@ BASE64_WRONG_LENGTH_RE = re.compile(
     r"Invalid base64-encoded string: number of data characters \(\d+\) cannot "
     r"be [123] more than a multiple of 4"
 )
+
+
+def verify_signature_x5u(data, signature, x5u):
+    """
+    Verify a signature, given the x5u of the public key.
+
+    If the signature is valid, returns True. If the signature is invalid, raise
+    an exception explaining why.
+    """
+    cert = verify_x5u(x5u)
+    encoded = der_encode(cert)
+    cert_b64 = base64.b64encode(encoded).decode()
+    return verify_signature_pubkey(data, signature, cert_b64)
 
 
 def verify_signature_pubkey(data, signature, pubkey):

--- a/normandy/recipes/signing.py
+++ b/normandy/recipes/signing.py
@@ -95,7 +95,7 @@ BASE64_WRONG_LENGTH_RE = re.compile(
 )
 
 
-def verify_signature(data, signature, pubkey):
+def verify_signature_pubkey(data, signature, pubkey):
     """
     Verify a signature.
 

--- a/normandy/recipes/signing.py
+++ b/normandy/recipes/signing.py
@@ -80,15 +80,12 @@ class Autographer(object):
 
         signatures = []
         for res in signing_responses:
+            logger.info(f"Autograph response: {res['ref']}")
 
-            signatures.append(
-                {
-                    "timestamp": ts,
-                    "signature": res["signature"],
-                    "x5u": res.get("x5u"),
-                    "public_key": res["public_key"],
-                }
-            )
+            assert res["signature"], "Response from Autograph did not contain signature"
+            assert res["x5u"], "Response from Autograph did not contain x5u"
+
+            signatures.append({"timestamp": ts, "signature": res["signature"], "x5u": res["x5u"]})
         return signatures
 
 

--- a/normandy/recipes/signing.py
+++ b/normandy/recipes/signing.py
@@ -185,8 +185,9 @@ def verify_x5u(url, expire_early=None):
     """
     Verify the certificate chain at a URL.
 
-    If the certificates are valid, return True. Otherwise, raise an
-    exception explaining why they are not valid.
+    If the certificates are valid, return the end of the
+    chain. Otherwise, raise an exception explaining why they are not
+    valid.
     """
     req = requests.get(url)
     req.raise_for_status()
@@ -241,7 +242,7 @@ def verify_x5u(url, expire_early=None):
         if common_name != expected:
             raise CertificateHasWrongSubject(expected=expected, actual=common_name)
 
-    return True
+    return decoded_certs[0]
 
 
 def check_validity(not_before, not_after, expire_early):

--- a/normandy/recipes/tests/test_signing.py
+++ b/normandy/recipes/tests/test_signing.py
@@ -280,7 +280,7 @@ class TestVerifyX5u(object):
             not_before=not_before, not_after=not_after
         )
 
-        assert signing.verify_x5u(url)
+        assert signing.verify_x5u(url) == mock_parse_cert_from_der.return_value
         assert mock_requests.get.called_once_with(url)
         body = mock_requests.get.return_value.content.decode.return_value
         assert mock_extract_certs_from_pem.called_once_with(body)

--- a/normandy/recipes/tests/test_signing.py
+++ b/normandy/recipes/tests/test_signing.py
@@ -127,7 +127,7 @@ class TestAutographer(object):
         )
 
 
-class TestVerifySignature(object):
+class TestVerifySignaturePubkey(object):
 
     # known good data
     data = '{"action":"console-log","arguments":{"message":"telemetry available"},"enabled":true,"filter_expression":"telemetry != undefined","id":1,"last_updated":"2017-01-02T11:32:07.687408Z","name":"mython\'s system addon test","revision_id":"6dc874ded7d14af9ef9c147c5d2ceef9d15b56ca933681e574cd96a50b75946e"}'  # noqa
@@ -135,26 +135,26 @@ class TestVerifySignature(object):
     pubkey = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEVEKiCAIkwRg1VFsP8JOYdSF6a3qvgbRPoEK9eTuLbrB6QixozscKR4iWJ8ZOOX6RPCRgFdfVDoZqjFBFNJN9QtRBk0mVtHbnErx64d2vMF0oWencS1hyLW2whgOgOz7p"  # noqa
 
     def test_known_good_signature(self):
-        assert signing.verify_signature(self.data, self.signature, self.pubkey)
+        assert signing.verify_signature_pubkey(self.data, self.signature, self.pubkey)
 
     def test_raises_nice_error_for_too_short_signatures_bad_padding(self):
         signature = "a_too_short_signature"
 
         with pytest.raises(signing.WrongSignatureSize):
-            signing.verify_signature(self.data, signature, self.pubkey)
+            signing.verify_signature_pubkey(self.data, signature, self.pubkey)
 
     def test_raises_nice_error_for_too_short_signatures_good_base64(self):
         signature = "aa=="
 
         with pytest.raises(signing.WrongSignatureSize):
-            signing.verify_signature(self.data, signature, self.pubkey)
+            signing.verify_signature_pubkey(self.data, signature, self.pubkey)
 
     def test_raises_nice_error_for_wrong_signature(self):
         # change the signature, but keep it a valid signature
         signature = self.signature.replace("s", "S")
 
         with pytest.raises(signing.SignatureDoesNotMatch):
-            signing.verify_signature(self.data, signature, self.pubkey)
+            signing.verify_signature_pubkey(self.data, signature, self.pubkey)
 
 
 class TestExtractCertsFromPem(object):

--- a/normandy/recipes/tests/test_signing.py
+++ b/normandy/recipes/tests/test_signing.py
@@ -157,6 +157,31 @@ class TestVerifySignaturePubkey(object):
             signing.verify_signature_pubkey(self.data, signature, self.pubkey)
 
 
+class TestVerifySignatureX5U(object):
+    def test_happy_path(self, mocker):
+        mock_verify_x5u = mocker.patch("normandy.recipes.signing.verify_x5u")
+        mock_der_encode = mocker.patch("normandy.recipes.signing.der_encode")
+        mock_verify_signature_pubkey = mocker.patch(
+            "normandy.recipes.signing.verify_signature_pubkey"
+        )
+
+        data = "abc"
+        signature = "signature"
+        x5u = "http://example.com/cert"
+        cert_contents = b"cert_contents"
+        encoded_cert_contents = base64.b64encode(cert_contents).decode()
+
+        mock_der_encode.return_value = cert_contents
+
+        ret = signing.verify_signature_x5u(data, signature, x5u)
+
+        mock_verify_x5u.assert_called_with(x5u)
+        mock_der_encode.assert_called_with(mock_verify_x5u.return_value)
+        mock_verify_signature_pubkey.assert_called_with(data, signature, encoded_cert_contents)
+
+        assert ret == mock_verify_signature_pubkey.return_value
+
+
 class TestExtractCertsFromPem(object):
     def test_empty(self):
         assert signing.extract_certs_from_pem("") == []

--- a/normandy/recipes/tests/test_signing.py
+++ b/normandy/recipes/tests/test_signing.py
@@ -76,7 +76,6 @@ class TestAutographer(object):
                 "hash_algorithm": "sha384",
                 "ref": "fake_ref_1",
                 "signature": "fake_signature_1",
-                "public_key": "fake_pubkey_1",
             },
             {
                 "content-signature": (
@@ -86,7 +85,6 @@ class TestAutographer(object):
                 "hash_algorithm": "sha384",
                 "ref": "fake_ref_2",
                 "signature": "fake_signature_2",
-                "public_key": "fake_pubkey_2",
             },
         ]
 
@@ -100,19 +98,21 @@ class TestAutographer(object):
                 "timestamp": Whatever(),
                 "signature": "fake_signature_1",
                 "x5u": "https://example.com/fake_x5u_1",
-                "public_key": "fake_pubkey_1",
             },
             {
                 "timestamp": Whatever(),
                 "signature": "fake_signature_2",
                 "x5u": "https://example.com/fake_x5u_2",
-                "public_key": "fake_pubkey_2",
             },
         ]
 
         # Assert that logging happened
-        mock_logger.info.assert_called_with(
-            Whatever.contains("2"), extra={"code": signing.INFO_RECEIVED_SIGNATURES}
+        mock_logger.info.assert_has_calls(
+            [
+                call(Whatever.contains("2"), extra={"code": signing.INFO_RECEIVED_SIGNATURES}),
+                call(Whatever.contains("fake_ref_1")),
+                call(Whatever.contains("fake_ref_2")),
+            ]
         )
 
         # Assert the correct request was made


### PR DESCRIPTION
This is meant to address #1890, at least partially. I tried to re-use the existing signature verification logic but I had to jump through a bunch of hoops to get the data back into the form the pubkey check uses. (See commit comments for details.) The test is equally ugly -- this doesn't actually ensure that data is in the right format or anything, it's basically just a restatement of the implementation as a test. @mythmon, how did you get the data for the existing pubkey test? Maybe I can do something similar to generate a real x5u.

With this change, I was able to `update_recipe_signatures`, `update_product_details`, and `update_actions` without crashes.