### PR TITLE
Remove aliases

### DIFF
--- a/contract-tests/test_api.py
+++ b/contract-tests/test_api.py
@@ -100,17 +100,11 @@ def test_recipe_signatures(conf, requests_session):
     if len(data) == 0:
         pytest.skip("No signed recipes")
 
-    cert_urls = set()
-
     for item in data:
         canonical_recipe = canonical_json(item["recipe"])
         signature = item["signature"]["signature"]
-        pubkey = item["signature"]["public_key"]
-        cert_urls.add(item["signature"]["x5u"])
-        assert signing.verify_signature(canonical_recipe, signature, pubkey)
-
-    for url in cert_urls:
-        signing.verify_x5u(url)
+        x5u = item["signature"]["x5u"]
+        assert signing.verify_signature_x5u(canonical_recipe, signature, x5u)
 
 
 def test_action_signatures(conf, requests_session):
@@ -121,17 +115,11 @@ def test_action_signatures(conf, requests_session):
     if len(data) == 0:
         pytest.skip("No signed actions")
 
-    cert_urls = set()
-
     for item in data:
         canonical_action = canonical_json(item["action"])
         signature = item["signature"]["signature"]
-        pubkey = item["signature"]["public_key"]
-        cert_urls.add(item["signature"]["x5u"])
-        assert signing.verify_signature(canonical_action, signature, pubkey)
-
-    for url in cert_urls:
-        signing.verify_x5u(url)
+        x5u = item["signature"]["x5u"]
+        assert signing.verify_signature_x5u(canonical_action, signature, x5u)
 
 
 def test_recipe_api_is_json(conf, requests_session):

--- a/normandy/recipes/api/v1/serializers.py
+++ b/normandy/recipes/api/v1/serializers.py
@@ -73,7 +73,6 @@ class RecipeSerializer(serializers.ModelSerializer):
     name = serializers.CharField()
     action = serializers.SlugRelatedField(slug_field="name", queryset=Action.objects.all())
     arguments = serializers.JSONField()
-    extra_filter_expression = serializers.CharField()
     filter_expression = serializers.CharField(read_only=True)
     latest_revision_id = serializers.IntegerField(source="latest_revision.id", read_only=True)
     approved_revision_id = serializers.IntegerField(
@@ -94,7 +93,6 @@ class RecipeSerializer(serializers.ModelSerializer):
             "revision_id",
             "action",
             "arguments",
-            "extra_filter_expression",
             "filter_expression",
             "latest_revision_id",
             "approved_revision_id",

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -170,10 +170,6 @@ class Recipe(DirtyFieldsMixin, models.Model):
         return self.current_revision.locales
 
     @current_revision_property()
-    def identicon_seed(self):
-        return self.current_revision.identicon_seed
-
-    @current_revision_property()
     def comment(self):
         return self.current_revision.comment
 

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -134,10 +134,6 @@ class Recipe(DirtyFieldsMixin, models.Model):
         return self.current_revision.filter_expression
 
     @current_revision_property()
-    def extra_filter_expression(self):
-        return self.current_revision.extra_filter_expression
-
-    @current_revision_property()
     def filter_object(self):
         return self.current_revision.filter_object
 

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -170,10 +170,6 @@ class Recipe(DirtyFieldsMixin, models.Model):
         return self.current_revision.locales
 
     @current_revision_property()
-    def comment(self):
-        return self.current_revision.comment
-
-    @current_revision_property()
     def capabilities(self):
         return self.current_revision.capabilities
 

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -177,11 +177,6 @@ class Recipe(DirtyFieldsMixin, models.Model):
     def capabilities(self):
         return self.current_revision.capabilities
 
-    @current_revision_property()
-    def extra_capabilities(self):
-        """A list of capabilities manually specified for this recipe."""
-        return self.current_revision.extra_capabilities
-
     def uses_only_baseline_capabilities(self):
         return self.capabilities <= settings.BASELINE_CAPABILITIES
 

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -162,14 +162,6 @@ class Recipe(DirtyFieldsMixin, models.Model):
         return self.current_revision.channels
 
     @current_revision_property()
-    def countries(self):
-        return self.current_revision.countries
-
-    @current_revision_property()
-    def locales(self):
-        return self.current_revision.locales
-
-    @current_revision_property()
     def capabilities(self):
         return self.current_revision.capabilities
 

--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -174,10 +174,6 @@ class Recipe(DirtyFieldsMixin, models.Model):
         return self.current_revision.comment
 
     @current_revision_property()
-    def experimenter_slug(self):
-        return self.current_revision.experimenter_slug
-
-    @current_revision_property()
     def capabilities(self):
         return self.current_revision.capabilities
 

--- a/normandy/recipes/tests/api/v1/test_serializers.py
+++ b/normandy/recipes/tests/api/v1/test_serializers.py
@@ -47,7 +47,6 @@ class TestRecipeSerializer:
                 "approver": None,
                 "comment": None,
             },
-            "identicon_seed": Whatever.startswith("v1:"),
             "capabilities": sorted(recipe.capabilities),
         }
 

--- a/normandy/recipes/tests/api/v1/test_serializers.py
+++ b/normandy/recipes/tests/api/v1/test_serializers.py
@@ -31,7 +31,6 @@ class TestRecipeSerializer:
             "id": recipe.id,
             "last_updated": Whatever(),
             "enabled": recipe.enabled,
-            "extra_filter_expression": recipe.extra_filter_expression,
             "filter_expression": recipe.filter_expression,
             "revision_id": recipe.revision_id,
             "action": action.name,

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -592,7 +592,7 @@ class TestRecipeAPI(object):
             assert res.status_code == 200
 
             r.refresh_from_db()
-            assert r.comment == "bar"
+            assert r.latest_revision.comment == "bar"
 
         def test_update_recipe_experimenter_slug(self, api_client):
             r = RecipeFactory()

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -497,7 +497,7 @@ class TestRecipeAPI(object):
             assert Recipe.objects.count() == 1
             recipe = Recipe.objects.get()
             # Passed extra capabilities:
-            assert recipe.extra_capabilities == ["test.one", "test.two"]
+            assert recipe.latest_revision.extra_capabilities == ["test.one", "test.two"]
             # Extra capabilities get included in capabilities
             assert {"test.one", "test.two"} <= set(recipe.capabilities)
 

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -387,7 +387,7 @@ class TestRecipeAPI(object):
             assert res.status_code == 201, res.json()
 
             recipe = Recipe.objects.get()
-            assert recipe.experimenter_slug == "some-experimenter-slug"
+            assert recipe.latest_revision.experimenter_slug == "some-experimenter-slug"
 
         def test_without_experimenter_slug(self, api_client):
             action = ActionFactory()
@@ -405,7 +405,7 @@ class TestRecipeAPI(object):
             assert res.status_code == 201, res.json()
 
             recipe = Recipe.objects.get()
-            assert recipe.experimenter_slug is None
+            assert recipe.latest_revision.experimenter_slug is None
 
         def test_creating_recipes_stores_the_user(self, api_client):
             action = ActionFactory()
@@ -601,7 +601,7 @@ class TestRecipeAPI(object):
             assert res.status_code == 200
 
             r.refresh_from_db()
-            assert r.experimenter_slug == "a-new-slug"
+            assert r.latest_revision.experimenter_slug == "a-new-slug"
 
         def test_updating_recipes_stores_the_user(self, api_client):
             recipe = RecipeFactory()

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -440,7 +440,7 @@ class TestRecipeAPI(object):
 
             assert Recipe.objects.count() == 1
             recipe = Recipe.objects.get()
-            assert recipe.extra_filter_expression == ""
+            assert recipe.latest_revision.extra_filter_expression == ""
             assert recipe.filter_expression == f'normandy.channel in ["{channel.slug}"]'
 
         def test_it_can_create_extra_filter_expression_omitted(self, api_client):
@@ -478,7 +478,7 @@ class TestRecipeAPI(object):
 
             assert Recipe.objects.count() == 1
             recipe = Recipe.objects.get()
-            assert recipe.extra_filter_expression == ""
+            assert recipe.latest_revision.extra_filter_expression == ""
             assert recipe.filter_expression == f'normandy.channel in ["{channel.slug}"]'
 
         def test_it_accepts_capabilities(self, api_client):
@@ -623,7 +623,7 @@ class TestRecipeAPI(object):
             )
             assert res.status_code == 200, res.json()
             recipe.refresh_from_db()
-            assert recipe.extra_filter_expression == ""
+            assert recipe.latest_revision.extra_filter_expression == ""
             assert recipe.filter_object
             assert recipe.filter_expression == f'normandy.channel in ["{channel.slug}"]'
 
@@ -637,7 +637,7 @@ class TestRecipeAPI(object):
             )
             assert res.status_code == 200, res.json()
             recipe.refresh_from_db()
-            assert recipe.extra_filter_expression == ""
+            assert recipe.latest_revision.extra_filter_expression == ""
 
             # Let's paranoid-check that you can't unset the filter_object too.
             res = api_client.patch(

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -1243,7 +1243,7 @@ class TestRecipeRevisionAPI(object):
     def test_it_has_an_identicon_seed(self, api_client):
         recipe = RecipeFactory(enabler=UserFactory(), approver=UserFactory())
         res = api_client.get(f"/api/v3/recipe_revision/{recipe.latest_revision.id}/")
-        assert res.data["identicon_seed"] == recipe.identicon_seed
+        assert res.data["identicon_seed"] == recipe.latest_revision.identicon_seed
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Refs #1863. This PR removes a bunch of aliases for recipe fields that actually come from revisions. The ones removed in this PR are the easy ones that aren't really used anywhere but it's a good first step and helps clarify that these aliases are exceptions rather than the rule.

@mythmon Could I have like a 10% review? Does this seem directionally accurate? I wasn't sure how much leeway I had in terms of altering the API and in particular dropping fields from serializers. The contract-tests seem to pass (modulo #2017) but maybe they aren't extensive enough?