### PR TITLE
Ask yarn to run gh-pages to fix path problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
             - "5d:91:56:44:f2:f7:57:2a:29:88:f0:2e:37:fe:86:2a"
       - run:
           name: Deploy docs to gh-pages
-          command: gh-pages --dotfiles --message "[skip ci] Docs updates" --dist docs/_build/html
+          command: yarn gh-pages --dotfiles --message "[skip ci] Docs updates" --dist docs/_build/html
 
   python-tests:
     docker:


### PR DESCRIPTION
After #2016 we still aren't building docs correctly. I think this is just a path problem, which this patch should fix. Unfortunately we can't really tell until this gets to master. :man_shrugging: 