### PR TITLE
Update enable state for latest_revision on recipe when disabling

### DIFF
--- a/normandy/recipes/api/v3/views.py
+++ b/normandy/recipes/api/v3/views.py
@@ -168,6 +168,7 @@ class RecipeViewSet(CachingViewsetMixin, UpdateOrCreateModelViewSet):
         except EnabledState.NotActionable as e:
             return Response({"error": str(e)}, status=status.HTTP_409_CONFLICT)
 
+        recipe.latest_revision.refresh_from_db()
         return Response(RecipeSerializer(recipe).data)
 
 


### PR DESCRIPTION
This returns the correct revision data for `latest_revision` after disabling a recipe. The result is that disabling a recipe in DC is reflected in the UI since the state is now correctly updated.

r? 