### PR TITLE
Expose 'uses_only_baseline_capabilities' field in Remote Settings (ref #2047)

### DIFF
--- a/normandy/recipes/exports.py
+++ b/normandy/recipes/exports.py
@@ -25,9 +25,14 @@ def recipe_as_record(recipe):
         SignatureSerializer,
     )  # avoid circular imports
 
+    recipe_fields = {
+        **MinimalRecipeSerializer(recipe).data,
+        # Allow to filter retro compatible recipes in Remote Settings.
+        "uses_only_baseline_capabilities": recipe.uses_only_baseline_capabilities(),
+    }
     record = {
         "id": str(recipe.id),
-        "recipe": MinimalRecipeSerializer(recipe).data,
+        "recipe": recipe_fields,
         "signature": SignatureSerializer(recipe.signature).data,
     }
     return record

--- a/normandy/recipes/tests/test_exports.py
+++ b/normandy/recipes/tests/test_exports.py
@@ -333,6 +333,7 @@ class TestRemoteSettings:
                 "name": recipe.name,
                 "revision_id": str(recipe.revision_id),
                 "capabilities": Whatever(lambda caps: set(caps) == recipe.capabilities),
+                "uses_only_baseline_capabilities": False,
             },
             "signature": {
                 "public_key": Whatever.regex(r"[a-zA-Z0-9/+]{160}"),


### PR DESCRIPTION
ref #2047

In order to be able to backport records (using [this new lambda feature](https://github.com/mozilla-services/remote-settings-lambdas/pull/686)), the RS records must have this field!

Note that recipes will have to be republished once released and deployed.