### PR TITLE
Use licence to download the GeoLite2 Country DB (fixes #2069)

### DIFF
--- a/bin/download_geolite2.sh
+++ b/bin/download_geolite2.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # This script downloads and extracts the free GeoLite2 country database
 # from MaxMind for use in development.
+# The licence key is read from environment variable $MAXMIND_LICENCE_KEY, and can be obtained
+# from https://www.maxmind.com
 BASE_DIR="$(dirname "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )")"
-DOWNLOAD_URL=http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz
-LOCAL_ARCHIVE=/tmp/GeoLite2-Country.mmdb.gz
-LOCAL_EXTRACTED=/tmp/GeoLite2-Country.mmdb
+DOWNLOAD_URL=https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${MAXMIND_LICENCE_KEY}&suffix=tar.gz
+LOCAL_ARCHIVE=/tmp/GeoLite2-Country.mmdb
 
 curl -o "$LOCAL_ARCHIVE" "$DOWNLOAD_URL"
-gunzip -f "$LOCAL_ARCHIVE"
-mv "$LOCAL_EXTRACTED" "$BASE_DIR"
+mv "$LOCAL_ARCHIVE" "$BASE_DIR"


### PR DESCRIPTION
Fixes #2069 

An account should be created on maxmind.com and the licence key be put in `MAXMIND_LICENCE_KEY` env var on CircleCI.

@sciurus Do we want a BZ ticket for that?