### PR TITLE
Add POSTGRES_HOST_AUTH_METHOD: trust to docker-compose file and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,8 @@ jobs:
     docker:
       - image: circleci/python:3.7-node-browsers
       - image: circleci/postgres:9.6
+        environment:
+          POSTGRES_HOST_AUTH_METHOD: trust
 
     environment:
       # Silence checks about missing geoip, and also the standard silenced warnings from settings.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ jobs:
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: normandy
+          POSTGRES_HOST_AUTH_METHOD: trust
 
     environment:
       DJANGO_SETTINGS_MODULE: normandy.settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - db_volume:/var/lib/postgresql
     environment:
       POSTGRES_DB: normandy
+      POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5432:5432"
     networks:


### PR DESCRIPTION
I think this was previously assumed, but recent Postgres containers
now refuse to start unless given this reassurance. For CI and local
dev, this is totally fine.