### PR TITLE
Add OS filter object

### DIFF
--- a/docs/user/filters.rst
+++ b/docs/user/filters.rst
@@ -22,6 +22,7 @@ Filter Objects
 .. autoclass:: BucketSampleFilter()
 .. autoclass:: StableSampleFilter()
 .. autoclass:: VersionFilter()
+.. autoclass:: PlatformFilter()
 
 Filter Expressions
 ------------------

--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -157,6 +157,41 @@ class CountryFilter(BaseFilter):
         return set()
 
 
+class PlatformFilter(BaseFilter):
+    """Match a user based on what operating system they are using.
+
+    .. attribute:: type
+
+        ``platform``
+
+    .. attribute:: platforms
+
+        List of platforms to filter against. The choices are `all_linux`,
+        `all_windows`, and `all_mac`.
+
+        :example: ``["all_windows", "all_linux"]``
+    """
+
+    type = "platform"
+    platforms = serializers.ListField(child=serializers.CharField(), min_length=1)
+
+    def to_jexl(self):
+        platforms_jexl = []
+        for platform in self.initial_data["platforms"]:
+            if platform == "all_mac":
+                platforms_jexl.append("normandy.os.isMac")
+            elif platform == "all_windows":
+                platforms_jexl.append("normandy.os.isWindows")
+            elif platform == "all_linux":
+                platforms_jexl.append("normandy.os.isLinux")
+
+        return "||".join((f"{p}" for p in platforms_jexl))
+
+    @property
+    def capabilities(self):
+        return set()
+
+
 class BucketSampleFilter(BaseFilter):
     """
     Sample a portion of the users by defining a series of buckets, evenly
@@ -454,6 +489,7 @@ by_type = {
         VersionRangeFilter,
         DateRangeFilter,
         ProfileCreateDateFilter,
+        PlatformFilter,
     ]
 }
 

--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -184,8 +184,10 @@ class PlatformFilter(BaseFilter):
                 platforms_jexl.append("normandy.os.isWindows")
             elif platform == "all_linux":
                 platforms_jexl.append("normandy.os.isLinux")
+            else:
+                raise serializers.ValidationError(f"Unrecognized platform {platform!r}")
 
-        return "||".join((f"{p}" for p in platforms_jexl))
+        return "||".join((p for p in platforms_jexl))
 
     @property
     def capabilities(self):

--- a/normandy/recipes/tests/test_filters.py
+++ b/normandy/recipes/tests/test_filters.py
@@ -11,6 +11,7 @@ from normandy.recipes.filters import (
     VersionRangeFilter,
     DateRangeFilter,
     ProfileCreateDateFilter,
+    PlatformFilter,
 )
 from normandy.recipes.tests import ChannelFactory, LocaleFactory, CountryFactory
 
@@ -154,6 +155,19 @@ class TestCountryFilter(FilterTestsBase):
     def test_generates_jexl(self):
         filter = self.create_basic_filter(countries=["SV", "MX"])
         assert filter.to_jexl() == 'normandy.country in ["SV","MX"]'
+
+
+class TestPlatformFilter(FilterTestsBase):
+    def create_basic_filter(self, platforms=["all_mac", "all_windows"]):
+        return PlatformFilter.create(platforms=platforms)
+
+    def test_generates_jexl_list_of_two(self):
+        filter = self.create_basic_filter()
+        assert set(filter.to_jexl().split("||")) == {"normandy.os.isMac", "normandy.os.isWindows"}
+
+    def test_generates_jexl_list_of_one(self):
+        filter = self.create_basic_filter(platforms=["all_linux"])
+        assert set(filter.to_jexl().split("||")) == {"normandy.os.isLinux"}
 
 
 class TestBucketSamplefilter(FilterTestsBase):

--- a/normandy/recipes/tests/test_filters.py
+++ b/normandy/recipes/tests/test_filters.py
@@ -169,6 +169,11 @@ class TestPlatformFilter(FilterTestsBase):
         filter = self.create_basic_filter(platforms=["all_linux"])
         assert set(filter.to_jexl().split("||")) == {"normandy.os.isLinux"}
 
+    def test_throws_error_on_bad_platform(self):
+        filter = self.create_basic_filter(platforms=["all_linu"])
+        with pytest.raises(serializers.ValidationError):
+            filter.to_jexl()
+
 
 class TestBucketSamplefilter(FilterTestsBase):
     def create_basic_filter(self, input=None, start=123, count=10, total=1_000):


### PR DESCRIPTION
fixes #2101 

I named this PlatformFilter because I thought using OS in the name seemed a bit clunky but I can change it if others want. We use the word "platform" on experimenter a lot to refer to this same thing.

I still am not clear on how to know whether or not this requires a capabilities check. I can see from the capabilities build artifact that there is something referencing OS... again I probably don't have enough information on understanding when a thing I'm doing inside a filter object requires a capabilities check. 

I am assuming the jexl we want this filter object to spit out looks like
`(normandy.os.isMac || normandy.os.isLinux)`
