### PR TITLE
Add pref filter object

### DIFF
--- a/docs/user/filters.rst
+++ b/docs/user/filters.rst
@@ -26,6 +26,7 @@ Filter Objects
 .. autoclass:: VersionRangeFilter()
 .. autoclass:: DateRangeFilter()
 .. autoclass:: ProfileCreateDateFilter()
+.. autoclass:: PrefFilter()
 
 
 Filter Expressions

--- a/docs/user/filters.rst
+++ b/docs/user/filters.rst
@@ -26,7 +26,9 @@ Filter Objects
 .. autoclass:: VersionRangeFilter()
 .. autoclass:: DateRangeFilter()
 .. autoclass:: ProfileCreateDateFilter()
-.. autoclass:: PrefFilter()
+.. autoclass:: PrefExistsFilter()
+.. autoclass:: PrefCompareFilter()
+.. autoclass:: PrefUserSetFilter()
 
 
 Filter Expressions

--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -223,24 +223,24 @@ class PrefCompareFilter(BaseFilter):
         value = self.initial_data["value"]
         pref = self.initial_data["pref"]
 
+        if comparison == "contains":
+            return f"{json.dumps(value)} in '{pref}'|preferenceValue"
         if comparison == "equal":
             symbol = "=="
         elif comparison == "not_equal":
             symbol = "!="
         elif comparison == "greater_than":
-            symbol = "<"
-        elif comparison == "greater_than_equal":
-            symbol = "<="
-        elif comparison == "less_than":
             symbol = ">"
-        elif comparison == "less_than_equal":
+        elif comparison == "greater_than_equal":
             symbol = ">="
-        elif comparison == "in":
-            symbol = "in"
+        elif comparison == "less_than":
+            symbol = "<"
+        elif comparison == "less_than_equal":
+            symbol = "<="
         else:
             raise serializers.ValidationError(f"Unrecognized comparison {comparison!r}")
 
-        return f"{json.dumps(value)} {symbol} '{pref}'|preferenceValue"
+        return f"'{pref}'|preferenceValue {symbol} {json.dumps(value)}"
 
     @property
     def capabilities(self):

--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -194,6 +194,76 @@ class PlatformFilter(BaseFilter):
         return set()
 
 
+class PrefFilter(BaseFilter):
+    """Match a user based on a preference having some sort of equality with a value.
+        Also, this filter can match based on if a pref is user set.
+
+    .. attribute:: type
+
+        ``pref``
+
+    .. attribute:: value
+
+        Can be a string representation of a number, characters, or boolean value.
+
+        :example: ``true`` or ``10`` or ``default``
+
+    .. attribute:: comparison
+
+        Options are ``equal``, ``not_equal``, ``greater_than``,
+        ``less_than``, ``is_user_set``, or ``profile_exists``.
+    """
+
+    type = "pref"
+    pref = serializers.CharField()
+    value = serializers.CharField()
+    comparison = serializers.CharField()
+
+    def to_jexl(self):
+        comparison = self.initial_data["comparison"]
+        value = self.initial_data["value"]
+        pref = self.initial_data["pref"]
+
+        if comparison == "is_user_set":
+            if value == "true":
+                return f"'{pref}'|preferenceIsUserSet"
+            elif value == "false":
+                return f"!('{pref}'|preferenceIsUserSet)"
+            else:
+                raise serializers.ValidationError(
+                    f"Unrecognized value {value!r} for comparison {comparison!r}"
+                )
+        elif comparison == "preference_exists":
+            if value == "true":
+                return f"'{pref}'|preferenceExists"
+            elif value == "false":
+                return f"!('{pref}'|preferenceExists)"
+            else:
+                raise serializers.ValidationError(
+                    f"Unrecognized value {value!r} for comparison {comparison!r}"
+                )
+        if comparison == "equal":
+            symbol = "=="
+        elif comparison == "not_equal":
+            symbol = "!="
+        elif comparison == "greater_than":
+            symbol = ">"
+        elif comparison == "less_than":
+            symbol = "<"
+        else:
+            raise serializers.ValidationError(f"Unrecognized comparison {comparison!r}")
+
+        return f"'{pref}'|preferenceValue {symbol} {value}"
+
+    @property
+    def capabilities(self):
+        return {
+            "jexl.transform.preferenceValue",
+            "jexl.transform.preferenceIsUserSet",
+            "jexl.transform.preferenceExists",
+        }
+
+
 class BucketSampleFilter(BaseFilter):
     """
     Sample a portion of the users by defining a series of buckets, evenly

--- a/normandy/recipes/tests/test_filters.py
+++ b/normandy/recipes/tests/test_filters.py
@@ -186,30 +186,27 @@ class TestPrefCompareFilter(FilterTestsBase):
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter()
-        assert filter.to_jexl() == "10 == 'browser.urlbar.maxRichResults'|preferenceValue"
+        assert filter.to_jexl() == "'browser.urlbar.maxRichResults'|preferenceValue == 10"
 
-    def test_generates_jexl_greater_than(self):
-        filter = self.create_basic_filter(comparison="greater_than")
-        assert filter.to_jexl() == "10 < 'browser.urlbar.maxRichResults'|preferenceValue"
-
-    def test_generates_jexl_greater_than_equal(self):
-        filter = self.create_basic_filter(comparison="greater_than_equal")
-        assert filter.to_jexl() == "10 <= 'browser.urlbar.maxRichResults'|preferenceValue"
-
-    def test_generates_jexl_less_than(self):
-        filter = self.create_basic_filter(comparison="less_than")
-        assert filter.to_jexl() == "10 > 'browser.urlbar.maxRichResults'|preferenceValue"
-
-    def test_generates_jexl_less_than_equal(self):
-        filter = self.create_basic_filter(comparison="less_than_equal")
-        assert filter.to_jexl() == "10 >= 'browser.urlbar.maxRichResults'|preferenceValue"
+    @pytest.mark.parametrize(
+        "comparison,symbol",
+        [
+            ("greater_than", ">"),
+            ("greater_than_equal", ">="),
+            ("less_than", "<"),
+            ("less_than_equal", "<="),
+        ],
+    )
+    def test_generates_jexl_number_ops(self, comparison, symbol):
+        filter = self.create_basic_filter(comparison=comparison)
+        assert filter.to_jexl() == f"'browser.urlbar.maxRichResults'|preferenceValue {symbol} 10"
 
     def test_generates_jexl_boolean(self):
         filter = self.create_basic_filter(value=False)
-        assert filter.to_jexl() == "false == 'browser.urlbar.maxRichResults'|preferenceValue"
+        assert filter.to_jexl() == "'browser.urlbar.maxRichResults'|preferenceValue == false"
 
     def test_generates_jexl_string_in(self):
-        filter = self.create_basic_filter(value="default", comparison="in")
+        filter = self.create_basic_filter(value="default", comparison="contains")
         assert filter.to_jexl() == "\"default\" in 'browser.urlbar.maxRichResults'|preferenceValue"
 
     def test_generates_jexl_error(self):


### PR DESCRIPTION
fixes #2103 

update: this is now 3 filter objects. 
__________

So, about the design of this:

you pass three things into the filter... the `pref`, `comparison` and `value`. 

The options for what I call `comparison` are either going to be values that translate to symbols... like "greater_than" or "equal" or they will be the other two things... "is_user_set" and "preference_exists".

then `value` will be a string representation of either characters or a number or bool. So for the `comparison` of "is_user_set" you are passing a value of "true" or "false".