### PR TITLE
Add two packages to resolutions for yarn-audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "js-yaml": ">=3.13.1",
     "set-value": ">=2.0.1 <3.0.0 || >=3.0.1",
     "mixin-deep": ">=1.3.2 <2.0.0 || >=2.0.1",
-    "serialize-javascript": ">=2.1.1"
+    "serialize-javascript": ">=2.1.1",
+    "acorn": ">=7.1.1",
+    "kind-of": ">=6.0.3" 
   }
 }


### PR DESCRIPTION
fixes #2134 

Two packages were failing the yarn-audit and needed to be added to resolutions section. 