### PR TITLE
Move SSL to container volume fixes #2150

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,17 @@ code_format:
 	docker-compose run app therapist run --fix --disable-git ./!(node_modules|assets|docs|venv)
 check: check_migrations lint test
 
-kill:
-	docker ps -a -q | xargs docker kill;docker ps -a -q | xargs docker rm
+compose_stop:
+	docker-compose kill
+
+compose_rm:
+	docker-compose rm -f -v
+	
+volumes_rm:
+	docker volume ls -q | xargs docker volume rm -f | echo
+
+kill: compose_stop compose_rm volumes_rm
+	echo "All containers removed!"
 
 test: build
 	docker-compose run -e DJANGO_CONFIGURATION=Test app sh -c "/app/bin/wait-for-it.sh db:5432 -- pytest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - .:/app
       - node_modules_volume:/app/node_modules/
+      - ssl_volume:/app/etc/ssl/
     environment:
       - DATABASE_URL=postgres://postgres:postgres@db/normandy
     ports:
@@ -35,6 +36,7 @@ services:
 volumes:
   db_volume:
   node_modules_volume:
+  ssl_volume:
 
 
 networks:


### PR DESCRIPTION
Small change to the compose file so the SSL files stay in a volume, I don't think it should affect non docker workflows in any way.  And I updated the `make kill` command to a more ergonomic pattern I figured out in experimenter.  Both of these things should make it easier for the new API contract tests to run in circle.