### PR TITLE
Fix filter names and make them more consistent.

### DIFF
--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -251,7 +251,7 @@ class AddonActiveFilter(BaseAddonFilter):
 
     .. attribute:: type
 
-        ``addon_active``
+        ``addonActive``
 
     .. attribute:: addons
         List of addon ids to filter against.
@@ -267,7 +267,7 @@ class AddonActiveFilter(BaseAddonFilter):
         :example: ``any`` or ``all``
     """
 
-    type = "addon_active"
+    type = "addonActive"
 
     def get_formatted_string(self, addon):
         return f'normandy.addons["{addon}"].isActive'
@@ -282,7 +282,7 @@ class AddonInstalledFilter(BaseAddonFilter):
 
     .. attribute:: type
 
-        ``addon_installed``
+        ``addonInstalled``
 
     .. attribute:: addons
         List of addon ids to filter against.
@@ -298,7 +298,7 @@ class AddonInstalledFilter(BaseAddonFilter):
         :example: ``any`` or ``all``
     """
 
-    type = "addon_installed"
+    type = "addonInstalled"
 
     def get_formatted_string(self, addon):
         return f'normandy.addons["{addon}"]'
@@ -313,7 +313,7 @@ class PrefCompareFilter(BaseFilter):
 
     .. attribute:: type
 
-        ``pref``
+        ``preferenceValue``
 
     .. attribute:: value
 
@@ -327,7 +327,7 @@ class PrefCompareFilter(BaseFilter):
         ``less_than``, ``greater_than_equal`` and ``less_than_equal``.
     """
 
-    type = "preference_value"
+    type = "preferenceValue"
     pref = serializers.CharField()
     value = serializers.JSONField()
     comparison = serializers.CharField()
@@ -366,7 +366,7 @@ class PrefExistsFilter(BaseFilter):
 
     .. attribute:: type
 
-        ``pref``
+        ``preferenceExists``
 
     .. attribute:: value
 
@@ -375,7 +375,7 @@ class PrefExistsFilter(BaseFilter):
         :example: ``true`` or ``false``
     """
 
-    type = "preference_exists"
+    type = "preferenceExists"
     pref = serializers.CharField()
     value = serializers.BooleanField()
 
@@ -398,7 +398,7 @@ class PrefUserSetFilter(BaseFilter):
 
     .. attribute:: type
 
-        ``preference_is_user_set``
+        ``preferenceIsUserSet``
 
     .. attribute:: value
 
@@ -407,7 +407,7 @@ class PrefUserSetFilter(BaseFilter):
         :example: ``true`` or ``false``
     """
 
-    type = "preference_is_user_set"
+    type = "preferenceIsUserSet"
     pref = serializers.CharField()
     value = serializers.BooleanField()
 
@@ -590,7 +590,7 @@ class VersionRangeFilter(BaseFilter):
 
     ..attribute:: type
 
-        ``version_range``
+        ``versionRange``
 
     .. attribute:: min_version
 
@@ -601,7 +601,7 @@ class VersionRangeFilter(BaseFilter):
         :example: ``75.0.1``
     """
 
-    type = "version_range"
+    type = "versionRange"
     min_version = serializers.CharField()
     max_version = serializers.CharField()
 
@@ -630,7 +630,7 @@ class DateRangeFilter(BaseFilter):
 
     .. attribute:: type
 
-        ``date_range``
+        ``dateRange``
 
     .. attribute:: not_before
 
@@ -641,7 +641,7 @@ class DateRangeFilter(BaseFilter):
       :example: ``2020-03-01T00:00:00Z``
     """
 
-    type = "date_range"
+    type = "dateRange"
     not_before = serializers.DateTimeField()
     not_after = serializers.DateTimeField()
 
@@ -668,7 +668,7 @@ class WindowsBuildNumberFilter(BaseComparisonFilter):
 
     .. attribute:: type
 
-        ``windows_build_number``
+        ``windowsBuildNumber``
 
     .. attribute:: value
         integer
@@ -682,7 +682,7 @@ class WindowsBuildNumberFilter(BaseComparisonFilter):
       :example: ``not_equal``
     """
 
-    type = "windows_build_number"
+    type = "windowsBuildNumber"
 
     @property
     def left_of_operator(self):
@@ -703,7 +703,7 @@ class WindowsVersionFilter(BaseComparisonFilter):
 
     .. attribute:: type
 
-        ``windows_version``
+        ``windowsVersion``
 
     .. attribute:: value
         number, decimal, must be one of the following: 6.1, 6.2, 6.3, 10.0
@@ -717,7 +717,7 @@ class WindowsVersionFilter(BaseComparisonFilter):
       :example: ``not_equal``
     """
 
-    type = "windows_version"
+    type = "windowsVersion"
     value = serializers.DecimalField(max_digits=3, decimal_places=1)
 
     @property
@@ -776,7 +776,7 @@ class ProfileCreateDateFilter(BaseFilter):
 
     .. attribute:: type
 
-        ``profile_creation_date``
+        ``profileCreationDate``
 
     .. attribute:: direction
 
@@ -787,7 +787,7 @@ class ProfileCreateDateFilter(BaseFilter):
       :example: ``2020-02-01``
     """
 
-    type = "profile_creation_date"
+    type = "profileCreationDate"
     direction = serializers.CharField()
     date = serializers.DateField()
 
@@ -817,6 +817,14 @@ class ProfileCreateDateFilter(BaseFilter):
 
 
 def _calculate_by_type():
+    """
+    Gather all filters and build a map of types to filters.
+
+    This is done by iterating over all the subclasses, both direct and
+    indirect, of `BaseFilter` and checking their types. Only filters who have
+    their type defined as a static string are used. Duplicate types will
+    cause an error.
+    """
     todo = set([BaseFilter])
     all_filter_classes = set()
 

--- a/normandy/recipes/tests/test_filters.py
+++ b/normandy/recipes/tests/test_filters.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 from rest_framework import serializers
 
 from normandy.recipes import filters
@@ -45,6 +46,11 @@ class FilterTestsBase:
         filter_instance = self.create_basic_filter()
         filter_class = filter_instance.__class__
         assert filter_class in filters.by_type.values()
+
+    def test_its_type_is_camelcase(self):
+        filter_instance = self.create_basic_filter()
+        assert re.match("[a-zA-Z]+", filter_instance.type)
+        assert "_" not in filter_instance.type
 
 
 class TestProfileCreationDateFilter(FilterTestsBase):

--- a/normandy/recipes/tests/test_filters.py
+++ b/normandy/recipes/tests/test_filters.py
@@ -1,26 +1,7 @@
 import pytest
 from rest_framework import serializers
 
-from normandy.recipes.filters import (
-    BucketSampleFilter,
-    ChannelFilter,
-    CountryFilter,
-    LocaleFilter,
-    StableSampleFilter,
-    VersionFilter,
-    VersionRangeFilter,
-    DateRangeFilter,
-    ProfileCreateDateFilter,
-    PlatformFilter,
-    PrefCompareFilter,
-    PrefExistsFilter,
-    PrefUserSetFilter,
-    WindowsBuildNumberFilter,
-    WindowsVersionFilter,
-    NegateFilter,
-    AddonActiveFilter,
-    AddonInstalledFilter,
-)
+from normandy.recipes import filters
 from normandy.recipes.tests import (
     ChannelFactory,
     LocaleFactory,
@@ -60,10 +41,15 @@ class FilterTestsBase:
         else:
             assert capabilities - settings.BASELINE_CAPABILITIES
 
+    def test_it_is_in_the_by_type_list(self):
+        filter_instance = self.create_basic_filter()
+        filter_class = filter_instance.__class__
+        assert filter_class in filters.by_type.values()
+
 
 class TestProfileCreationDateFilter(FilterTestsBase):
     def create_basic_filter(self, direction="olderThan", date="2020-02-01"):
-        return ProfileCreateDateFilter.create(direction=direction, date=date)
+        return filters.ProfileCreateDateFilter.create(direction=direction, date=date)
 
     def test_generates_jexl_older_than(self):
         filter = self.create_basic_filter()
@@ -93,7 +79,7 @@ class TestVersionFilter(FilterTestsBase):
     def create_basic_filter(self, versions=None):
         if versions is None:
             versions = [72, 74]
-        return VersionFilter.create(versions=versions)
+        return filters.VersionFilter.create(versions=versions)
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter(versions=[72, 74])
@@ -107,7 +93,7 @@ class TestVersionRangeFilter(FilterTestsBase):
     should_be_baseline = False
 
     def create_basic_filter(self, min_version="72.0b2", max_version="72.0b8"):
-        return VersionRangeFilter.create(min_version=min_version, max_version=max_version)
+        return filters.VersionRangeFilter.create(min_version=min_version, max_version=max_version)
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter(min_version="72.0b2", max_version="75.0a1")
@@ -121,7 +107,7 @@ class TestDateRangeFilter(FilterTestsBase):
     def create_basic_filter(
         self, not_before="2020-02-01T00:00:00Z", not_after="2020-03-01T00:00:00Z"
     ):
-        return DateRangeFilter.create(not_before=not_before, not_after=not_after)
+        return filters.DateRangeFilter.create(not_before=not_before, not_after=not_after)
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter()
@@ -133,7 +119,7 @@ class TestDateRangeFilter(FilterTestsBase):
 
 class TestWindowsBuildNumberFilter(FilterTestsBase):
     def create_basic_filter(self, value=12345, comparison="equal"):
-        return WindowsBuildNumberFilter.create(value=value, comparison=comparison)
+        return filters.WindowsBuildNumberFilter.create(value=value, comparison=comparison)
 
     @pytest.mark.parametrize(
         "comparison,symbol",
@@ -162,7 +148,7 @@ class TestWindowsVersionFilter(FilterTestsBase):
     def create_basic_filter(self, value=6.1, comparison="equal"):
         WindowsVersionFactory(nt_version=6.1)
 
-        return WindowsVersionFilter.create(value=value, comparison=comparison)
+        return filters.WindowsVersionFilter.create(value=value, comparison=comparison)
 
     @pytest.mark.parametrize(
         "comparison,symbol",
@@ -197,7 +183,7 @@ class TestChannelFilter(FilterTestsBase):
             channel_objs = [ChannelFactory(slug=slug) for slug in channels]
         else:
             channel_objs = [ChannelFactory()]
-        return ChannelFilter.create(channels=[c.slug for c in channel_objs])
+        return filters.ChannelFilter.create(channels=[c.slug for c in channel_objs])
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter(channels=["release", "beta"])
@@ -210,7 +196,7 @@ class TestLocaleFilter(FilterTestsBase):
             locale_objs = [LocaleFactory(code=code) for code in locales]
         else:
             locale_objs = [LocaleFactory()]
-        return LocaleFilter.create(locales=[l.code for l in locale_objs])
+        return filters.LocaleFilter.create(locales=[l.code for l in locale_objs])
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter(locales=["en-US", "en-CA"])
@@ -223,7 +209,7 @@ class TestCountryFilter(FilterTestsBase):
             country_objs = [CountryFactory(code=code) for code in countries]
         else:
             country_objs = [CountryFactory()]
-        return CountryFilter.create(countries=[c.code for c in country_objs])
+        return filters.CountryFilter.create(countries=[c.code for c in country_objs])
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter(countries=["SV", "MX"])
@@ -232,7 +218,7 @@ class TestCountryFilter(FilterTestsBase):
 
 class TestPlatformFilter(FilterTestsBase):
     def create_basic_filter(self, platforms=["all_mac", "all_windows"]):
-        return PlatformFilter.create(platforms=platforms)
+        return filters.PlatformFilter.create(platforms=platforms)
 
     def test_generates_jexl_list_of_two(self):
         filter = self.create_basic_filter()
@@ -251,7 +237,7 @@ class TestPlatformFilter(FilterTestsBase):
 class TestNegateFilter(FilterTestsBase):
     def create_basic_filter(self):
         data_for_filter = {"type": "channel", "channels": ["release", "beta"]}
-        return NegateFilter.create(filter_to_negate=data_for_filter)
+        return filters.NegateFilter.create(filter_to_negate=data_for_filter)
 
     def test_generates_jexl(self):
         negate_filter = self.create_basic_filter()
@@ -260,7 +246,7 @@ class TestNegateFilter(FilterTestsBase):
 
 class TestAddonInstalledFilter(FilterTestsBase):
     def create_basic_filter(self, addons=["@abcdef", "ghijk@lmnop"], any_or_all="any"):
-        return AddonInstalledFilter.create(addons=addons, any_or_all=any_or_all)
+        return filters.AddonInstalledFilter.create(addons=addons, any_or_all=any_or_all)
 
     def test_generates_jexl_installed_any(self):
         filter = self.create_basic_filter()
@@ -284,7 +270,7 @@ class TestAddonInstalledFilter(FilterTestsBase):
 
 class TestAddonActiveFilter(FilterTestsBase):
     def create_basic_filter(self, addons=["@abcdef", "ghijk@lmnop"], any_or_all="any"):
-        return AddonActiveFilter.create(addons=addons, any_or_all=any_or_all)
+        return filters.AddonActiveFilter.create(addons=addons, any_or_all=any_or_all)
 
     def test_generates_jexl_active_any(self):
         filter = self.create_basic_filter()
@@ -310,7 +296,7 @@ class TestPrefCompareFilter(FilterTestsBase):
     def create_basic_filter(
         self, pref="browser.urlbar.maxRichResults", value=10, comparison="equal"
     ):
-        return PrefCompareFilter.create(pref=pref, value=value, comparison=comparison)
+        return filters.PrefCompareFilter.create(pref=pref, value=value, comparison=comparison)
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter()
@@ -345,7 +331,7 @@ class TestPrefCompareFilter(FilterTestsBase):
 
 class TestPrefExistsFilter(FilterTestsBase):
     def create_basic_filter(self, pref="browser.urlbar.maxRichResults", value=True):
-        return PrefExistsFilter.create(pref=pref, value=value)
+        return filters.PrefExistsFilter.create(pref=pref, value=value)
 
     def test_generates_jexl_pref_exists_true(self):
         filter = self.create_basic_filter()
@@ -358,7 +344,7 @@ class TestPrefExistsFilter(FilterTestsBase):
 
 class TestPrefUserSetFilter(FilterTestsBase):
     def create_basic_filter(self, pref="browser.urlbar.maxRichResults", value=True):
-        return PrefUserSetFilter.create(pref=pref, value=value)
+        return filters.PrefUserSetFilter.create(pref=pref, value=value)
 
     def test_generates_jexl_is_user_set_true(self):
         filter = self.create_basic_filter()
@@ -369,22 +355,24 @@ class TestPrefUserSetFilter(FilterTestsBase):
         assert filter.to_jexl() == "!('browser.urlbar.maxRichResults'|preferenceIsUserSet)"
 
 
-class TestBucketSamplefilter(FilterTestsBase):
+class TestBucketSampleFilter(FilterTestsBase):
     def create_basic_filter(self, input=None, start=123, count=10, total=1_000):
         if input is None:
             input = ["normandy.clientId"]
-        return BucketSampleFilter.create(input=input, start=start, count=count, total=total)
+        return filters.BucketSampleFilter.create(
+            input=input, start=start, count=count, total=total
+        )
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter(input=["A"], start=10, count=20, total=1_000)
         assert filter.to_jexl() == "[A]|bucketSample(10,20,1000)"
 
 
-class TestStableSamplefilter(FilterTestsBase):
+class TestStableSampleFilter(FilterTestsBase):
     def create_basic_filter(self, input=None, rate=0.01):
         if input is None:
             input = ["normandy.clientId"]
-        return StableSampleFilter.create(input=input, rate=rate)
+        return filters.StableSampleFilter.create(input=input, rate=rate)
 
     def test_generates_jexl(self):
         filter = self.create_basic_filter(input=["A"], rate=0.1)


### PR DESCRIPTION
There are two problems that I found while working on a new filter object.

1. Some of the filters shared a type, which made them impossible to use. This was the main thing I wanted to fix.
2. Some of the types users `camelCase` naming, and others used `snake_case` naming. All of the "original" filter objects were camel case, so I standardized them all that way, and added a test.