### PR TITLE
Add JEXL filter object

### DIFF
--- a/docs/user/filters.rst
+++ b/docs/user/filters.rst
@@ -34,6 +34,7 @@ Filter Objects
 .. autoclass:: NegateFilter()
 .. autoclass:: AddonActiveFilter()
 .. autoclass:: AddonInstalledFilter()
+.. autoclass:: JexlFilter()
 
 
 Filter Expressions

--- a/normandy/recipes/tests/test_filters.py
+++ b/normandy/recipes/tests/test_filters.py
@@ -383,3 +383,27 @@ class TestStableSampleFilter(FilterTestsBase):
     def test_generates_jexl(self):
         filter = self.create_basic_filter(input=["A"], rate=0.1)
         assert filter.to_jexl() == "[A]|stableSample(0.1)"
+
+
+class TestJexlFilter(FilterTestsBase):
+    should_be_baseline = False
+
+    def create_basic_filter(self, expression="true", capabilities=None, comment="a comment"):
+        if capabilities is None:
+            capabilities = ["capabilities-v1"]
+        return filters.JexlFilter.create(
+            expression=expression, capabilities=capabilities, comment=comment
+        )
+
+    def test_generates_jexl(self):
+        filter = self.create_basic_filter(expression="2 + 2")
+        assert filter.to_jexl() == "(2 + 2)"
+
+    def test_it_rejects_invalid_jexl(self):
+        filter = self.create_basic_filter(expression="this is an invalid expression")
+        with pytest.raises(serializers.ValidationError):
+            filter.to_jexl()
+
+    def test_it_has_capabilities(self):
+        filter = self.create_basic_filter(capabilities=["a.b", "c.d"])
+        assert filter.capabilities == {"a.b", "c.d"}


### PR DESCRIPTION
This could be used by NDT to combine with other filter objects, so that we can nest a JEXL filter inside a sticky or OR expression, without having to bail out entirely. It also adds the ability to comment the reasons behind a JEXL expression, and note any additional capabilities that may be needed.