### PR TITLE
Enforce argument schemas on model creation

### DIFF
--- a/normandy/base/tests/__init__.py
+++ b/normandy/base/tests/__init__.py
@@ -58,6 +58,13 @@ class FuzzyUnicode(fuzzy.FuzzyText):
         super(FuzzyUnicode, self).__init__(prefix=prefix, **kwargs)
 
 
+class FuzzySlug(fuzzy.FuzzyText):
+    """A FuzzyText factory that is suitable for slugs."""
+
+    def __init__(self, **kwargs):
+        super().__init__(chars="abcdefghijklmnopqrstuvwxyz-", **kwargs)
+
+
 class UserFactory(DjangoModelFactory):
     username = FuzzyUnicode()
     email = Sequence(lambda n: "test%s@example.com" % n)

--- a/normandy/studies/tests/api/v3/test_api.py
+++ b/normandy/studies/tests/api/v3/test_api.py
@@ -8,7 +8,7 @@ import pytest
 from django.db import transaction
 
 from normandy.base.tests import Whatever
-from normandy.recipes.tests import ActionFactory, RecipeFactory
+from normandy.recipes.tests import ActionFactory, RecipeFactory, OptOutStudyArgumentsFactory
 from normandy.studies.models import Extension
 from normandy.studies.tests import (
     ExtensionFactory,
@@ -222,8 +222,8 @@ class TestExtensionAPI(object):
         xpi = WebExtensionFileFactory()
         e = ExtensionFactory(xpi__from_func=xpi.open)
         a = ActionFactory(name="opt-out-study")
-        r = RecipeFactory(action=a, arguments={"extensionId": e.id})
-        r.revise(arguments={"extensionId": 0})
+        r = RecipeFactory(action=a, arguments={"extensionId": e.id + 1})
+        r.revise(OptOutStudyArgumentsFactory(extensionId=e.id))
         res = api_client.patch(f"/api/v3/extension/{e.id}/", {"name": "new name"})
         assert res.status_code == 200
         assert res.data["name"] == "new name"
@@ -243,7 +243,7 @@ class TestExtensionAPI(object):
         e = ExtensionFactory(xpi__from_func=xpi.open)
         a = ActionFactory(name="opt-out-study")
         r = RecipeFactory(action=a, arguments={"extensionId": e.id})
-        r.revise(arguments={"extensionId": 0})
+        r.revise(arguments=OptOutStudyArgumentsFactory(extensionId=e.id + 1))
         res = api_client.delete(f"/api/v3/extension/{e.id}/")
         assert res.status_code == 204
         assert Extension.objects.count() == 0


### PR DESCRIPTION
I realized that since we weren't checking schemas at the model level, none of the tests for argument verification checked their schemas. I needed this assurance for the tests I'm writing for #2236, but it's interesting enough to include as a separate PR.