### PR TITLE
Add NamespaceSample filter

### DIFF
--- a/docs/user/filters.rst
+++ b/docs/user/filters.rst
@@ -19,6 +19,7 @@ Filter Objects
 .. autoclass:: ChannelFilter()
 .. autoclass:: LocaleFilter()
 .. autoclass:: CountryFilter()
+.. autoclass:: NamespaceSampleFilter()
 .. autoclass:: BucketSampleFilter()
 .. autoclass:: StableSampleFilter()
 .. autoclass:: VersionFilter()

--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -539,6 +539,56 @@ class StableSampleFilter(BaseFilter):
         return {"jexl.transform.stableSample"}
 
 
+class NamespaceSampleFilter(BaseFilter):
+    """
+    Like ``BucketSampleFilter``, with two major differences:
+
+        - The number of buckets is locked at 10,000
+        - Instead of taking arbitrary inputs, only a namespace is accepted,
+          as a string, and the user's client ID is added automatically.
+
+    .. attribute:: type
+
+        ``namespaceSample``
+
+    .. attribute:: namespace
+
+       The namespace to use for the sample, as a simple unquoted string.
+
+       :example: ``global-v2``
+
+    .. attribute:: start
+
+       The bucket to begin at.
+
+       :example: ``70``
+
+    .. attribute:: count
+
+       The number of buckets to include. The size of the included population
+       will be ``count / 10,000``. For example, a count of 50 would be 0.5%
+       of the population.
+
+       :example: ``50``
+    """
+
+    type = "namespaceSample"
+    start = serializers.FloatField()
+    count = serializers.FloatField(min_value=0)
+    namespace = serializers.CharField(min_length=1)
+
+    def to_jexl(self):
+        namespace = self.initial_data["namespace"]
+        start = self.initial_data["start"]
+        count = self.initial_data["count"]
+        total = 10_000
+        return f'["{namespace}",normandy.userId]|bucketSample({start},{count},{total})'
+
+    @property
+    def capabilities(self):
+        return {"jexl.transform.bucketSample"}
+
+
 class VersionFilter(BaseFilter):
     """
     Match a user running any of the listed versions. This will include dot

--- a/normandy/recipes/tests/test_filters.py
+++ b/normandy/recipes/tests/test_filters.py
@@ -356,6 +356,10 @@ class TestBucketSampleFilter(FilterTestsBase):
         filter = self.create_basic_filter(input=["A"], start=10, count=20, total=1_000)
         assert filter.to_jexl() == "[A]|bucketSample(10,20,1000)"
 
+    def test_supports_floats(self):
+        filter = self.create_basic_filter(input=["A"], start=10, count=0.5, total=1_000)
+        assert filter.to_jexl() == "[A]|bucketSample(10,0.5,1000)"
+
 
 class TestStableSampleFilter(FilterTestsBase):
     def create_basic_filter(self, input=None, rate=0.01):
@@ -366,6 +370,21 @@ class TestStableSampleFilter(FilterTestsBase):
     def test_generates_jexl(self):
         filter = self.create_basic_filter(input=["A"], rate=0.1)
         assert filter.to_jexl() == "[A]|stableSample(0.1)"
+
+
+class TestNamespaceSampleFilter(FilterTestsBase):
+    def create_basic_filter(self, namespace="global-v42", start=123, count=10):
+        return filters.NamespaceSampleFilter.create(namespace=namespace, start=start, count=count)
+
+    def test_generates_jexl(self):
+        filter = self.create_basic_filter(namespace="fancy-rollout", start=10, count=20)
+        assert filter.to_jexl() == '["fancy-rollout",normandy.userId]|bucketSample(10,20,10000)'
+
+    def test_supports_floats(self):
+        filter = self.create_basic_filter(namespace="risky-experiment", start=123, count=0.5)
+        assert (
+            filter.to_jexl() == '["risky-experiment",normandy.userId]|bucketSample(123,0.5,10000)'
+        )
 
 
 class TestJexlFilter(FilterTestsBase):


### PR DESCRIPTION
There was an experiment that went out recently that had a filter of

```js
["pocket-en-gb",normandy.userId]|bucketSample(0,5000,10000)
```

and a corresponding rollout with a filter of

```js
[normandy.userId,"pocket-en-gb"]|bucketSample(5000,5000,10000)
```

(Both of these were actually done with a bucket sample filter object, but the JEXL is terser, so I'm using it here)

They were supposed to be exclusions of each other, and instead we made them independent of eachother, which caused major problems with the study.

I propose we eliminate the possibility of this error by removing the choice of ordering, or even the randomization unit (`normandy.userId`) from the filter object. I've implemented a new filter object here that does that.