### PR TITLE
Improve multi-preference experiments to match expectations

### DIFF
--- a/normandy/recipes/tests/__init__.py
+++ b/normandy/recipes/tests/__init__.py
@@ -267,10 +267,41 @@ class OptOutStudyArgumentsFactory(DictFactory):
     extensionApiId = factory.fuzzy.FuzzyInteger(1, 1000)
 
 
+class MultiPreferenceExperimentBranchFactory(DictFactory):
+    slug = FuzzySlug()
+    ratio = factory.fuzzy.FuzzyInteger(1, 100)
+    preferences = factory.Sequence(
+        lambda n: {
+            f"multi-experiment.pref-{n}": {
+                "preferenceBranchType": "default",
+                "preferenceValue": "test",
+                "preferenceType": "string",
+            }
+        }
+    )
+    value = factory.fuzzy.FuzzyText()
+
+
+class MultiPreferenceExperimentArgumentsFactory(DictFactory):
+    slug = FuzzySlug()
+    userFacingName = factory.faker.Faker("sentence")
+    userFacingDescription = factory.faker.Faker("paragraph")
+
+    @factory.post_generation
+    def branches(self, create, extracted=None, **kwargs):
+        if extracted is not None:
+            self["branches"] = [
+                MultiPreferenceExperimentBranchFactory(**kwargs, **branch) for branch in extracted
+            ]
+        else:
+            self["branches"] = MultiPreferenceExperimentBranchFactory.create_batch(2, **kwargs)
+
+
 argument_factories = {
     "preference-experiment": PreferenceExperimentArgumentsFactory,
     "preference-rollout": PreferenceRolloutArgumentsFactory,
     "opt-out-study": OptOutStudyArgumentsFactory,
+    "multi-preference-experiment": MultiPreferenceExperimentArgumentsFactory,
 }
 
 

--- a/normandy/recipes/tests/api/v3/test_api.py
+++ b/normandy/recipes/tests/api/v3/test_api.py
@@ -287,13 +287,11 @@ class TestRecipeAPI(object):
                     "enabled": True,
                     "extra_filter_expression": "true",
                     "action_id": action.id,
-                    "arguments": {"message": ""},
+                    "arguments": {},
                 },
             )
             assert res.status_code == 400
-            assert res.json()["arguments"]["message"] == (
-                serializers.CharField.default_error_messages["blank"]
-            )
+            assert res.json()["arguments"]["message"] == "This field is required."
 
             recipes = Recipe.objects.all()
             assert recipes.count() == 0
@@ -365,7 +363,7 @@ class TestRecipeAPI(object):
             }
             res = api_client.post("/api/v3/recipe/", data)
             assert res.status_code == 400
-            assert res.data == {"arguments": {"message": "This field may not be blank."}}
+            assert res.data == {"arguments": {"message": "This field is required."}}
 
             recipes = Recipe.objects.all()
             assert recipes.count() == 0

--- a/normandy/recipes/tests/api/v3/test_serializers.py
+++ b/normandy/recipes/tests/api/v3/test_serializers.py
@@ -75,9 +75,8 @@ class TestRecipeSerializer:
                 "name": "Any name",
                 "extra_filter_expression": "true",
                 "arguments": {
-                    "surveyId": "",
                     "surveys": [
-                        {"title": "", "weight": 1},
+                        {"weight": 1},
                         {"title": "bar", "weight": 1},
                         {"title": "foo", "weight": 0},
                         {"title": "baz", "weight": "lorem ipsum"},
@@ -90,9 +89,9 @@ class TestRecipeSerializer:
             serializer.is_valid(raise_exception=True)
 
         assert serializer.errors["arguments"] == {
-            "surveyId": "This field may not be blank.",
+            "surveyId": Whatever(lambda err: str(err) == "This field is required."),
             "surveys": {
-                0: {"title": "This field may not be blank."},
+                0: {"title": "This field is required."},
                 2: {"weight": "0 is less than the minimum of 1"},
                 3: {"weight": "'lorem ipsum' is not of type 'integer'"},
             },

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -302,7 +302,7 @@ class TestArgumentValidation(object):
         def test_unique_branch_slugs(self):
             action = ActionFactory(name="multi-preference-experiment")
             arguments = MultiPreferenceExperimentArgumentsFactory(
-                branches=[{"slug": "unique"}, {"slug": "duplicate"}, {"slug": "duplicate"},],
+                branches=[{"slug": "unique"}, {"slug": "duplicate"}, {"slug": "duplicate"}],
             )
             with pytest.raises(serializers.ValidationError) as exc_info:
                 action.validate_arguments(arguments, RecipeRevisionFactory())
@@ -342,6 +342,26 @@ class TestArgumentValidation(object):
                 recipe.revise(arguments=arguments_a)
             error = action.errors["duplicate_experiment_slug"]
             assert exc_info1.value.detail == {"arguments": {"slug": error}}
+
+        def test_blank_pref_value(self):
+            action = ActionFactory(name="multi-preference-experiment")
+            # Should not throw
+            RecipeFactory(
+                action=action,
+                arguments=MultiPreferenceExperimentArgumentsFactory(
+                    branches=[
+                        {
+                            "preferences": {
+                                "test.pref-1": {
+                                    "preferenceValue": "",
+                                    "preferenceBranchType": "default",
+                                    "preferenceType": "string",
+                                }
+                            }
+                        }
+                    ]
+                ),
+            )
 
 
 @pytest.mark.django_db

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -23,6 +23,7 @@ from normandy.recipes.tests import (
     ActionFactory,
     ApprovalRequestFactory,
     fake_sign,
+    MultiPreferenceExperimentArgumentsFactory,
     OptOutStudyArgumentsFactory,
     PreferenceExperimentArgumentsFactory,
     RecipeFactory,
@@ -283,6 +284,64 @@ class TestArgumentValidation(object):
                 recipe.revise(arguments=arguments_a)
             error = action.errors["duplicate_study_name"]
             assert exc_info1.value.detail == {"arguments": {"name": error}}
+
+    @pytest.mark.django_db
+    class TestMultiPreferenceExperiments(object):
+        def test_no_errors(self):
+            action = ActionFactory(name="multi-preference-experiment")
+            assert action.arguments_schema != {}
+            # does not throw when saving the revision
+            recipe = RecipeFactory(action=action)
+
+            # Approve and enable the revision
+            rev = recipe.latest_revision
+            approval_request = rev.request_approval(UserFactory())
+            approval_request.approve(UserFactory(), "r+")
+            rev.enable(UserFactory())
+
+        def test_unique_branch_slugs(self):
+            action = ActionFactory(name="multi-preference-experiment")
+            arguments = MultiPreferenceExperimentArgumentsFactory(
+                branches=[{"slug": "unique"}, {"slug": "duplicate"}, {"slug": "duplicate"},],
+            )
+            with pytest.raises(serializers.ValidationError) as exc_info:
+                action.validate_arguments(arguments, RecipeRevisionFactory())
+            error = action.errors["duplicate_branch_slug"]
+            assert exc_info.value.detail == {"arguments": {"branches": {2: {"slug": error}}}}
+
+        def test_unique_experiment_slug_no_collision(self):
+            """Two recipes with different slugs can be saved"""
+            action = ActionFactory(name="multi-preference-experiment")
+            arguments_a = MultiPreferenceExperimentArgumentsFactory()
+            arguments_b = MultiPreferenceExperimentArgumentsFactory()
+            # Does not throw when saving revisions
+            RecipeFactory(action=action, arguments=arguments_a)
+            RecipeFactory(action=action, arguments=arguments_b)
+
+        def test_unique_experiment_slug_new_collision(self):
+            """A new recipe can't be made if its slug matches an existing one"""
+            action = ActionFactory(name="multi-preference-experiment")
+            arguments = MultiPreferenceExperimentArgumentsFactory()
+            RecipeFactory(action=action, arguments=arguments)
+
+            with pytest.raises(serializers.ValidationError) as exc_info1:
+                RecipeFactory(action=action, arguments=arguments)
+            error = action.errors["duplicate_experiment_slug"]
+            assert exc_info1.value.detail == {"arguments": {"slug": error}}
+
+        def test_unique_experiment_slug_update_collision(self):
+            """A recipe can't be updated to have the same slug as another existing recipe"""
+            action = ActionFactory(name="multi-preference-experiment")
+            arguments_a = MultiPreferenceExperimentArgumentsFactory()
+            arguments_b = MultiPreferenceExperimentArgumentsFactory()
+            # Does not throw when saving revisions
+            RecipeFactory(action=action, arguments=arguments_a)
+            recipe = RecipeFactory(action=action, arguments=arguments_b)
+
+            with pytest.raises(serializers.ValidationError) as exc_info1:
+                recipe.revise(arguments=arguments_a)
+            error = action.errors["duplicate_experiment_slug"]
+            assert exc_info1.value.detail == {"arguments": {"slug": error}}
 
 
 @pytest.mark.django_db

--- a/normandy/recipes/validators.py
+++ b/normandy/recipes/validators.py
@@ -4,15 +4,15 @@ import jsonschema
 from django.core.exceptions import ValidationError
 
 
-# Add path to required validator so we can get property name
+# Add path to the required validator so we can add a `path` field pointing to the field that is required.
 def _required(validator, requirements, instance, schema):
     """Validate 'required' properties."""
     if not validator.is_type(instance, "object"):
         return
 
     for index, requirement in enumerate(requirements):
-        if instance.get(requirement, "") == "":
-            error = jsonschema.ValidationError("This field may not be blank.", path=[requirement])
+        if instance.get(requirement) is None:
+            error = jsonschema.ValidationError("This field is required.", path=[requirement])
             yield error
 
 


### PR DESCRIPTION
- Add slug and branch duplication checks to multi-preference-experiments
  - This is just something I found while working on this bug.
- Allow empty strings for required fields
  - Fixes #2236
