### PR TITLE
Make recipe enable and disable operations non-atomic

### DIFF
--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -431,7 +431,6 @@ class RecipeRevision(DirtyFieldsMixin, models.Model):
         self.recipe.update_signature()
         self.recipe.save()
 
-    @transaction.atomic
     def enable(self, user, carryover_from=None):
         if self.enabled:
             raise EnabledState.NotActionable("This revision is already enabled.")
@@ -442,7 +441,6 @@ class RecipeRevision(DirtyFieldsMixin, models.Model):
 
         RemoteSettings().publish(self.recipe)
 
-    @transaction.atomic
     def disable(self, user):
         if not self.enabled:
             raise EnabledState.NotActionable("This revision is already disabled.")

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -827,7 +827,9 @@ class TestRecipeRevision(object):
             assert mocked_remotesettings.return_value.unpublish.call_count == 1
             assert mocked_remotesettings.return_value.publish.call_count == 2
 
-        def test_it_rollbacks_changes_if_error_happens_on_publish(self, mocked_remotesettings):
+        def test_it_does_not_rollback_changes_if_rs_error_happens_on_publish(
+            self, mocked_remotesettings
+        ):
             recipe = RecipeFactory(name="Test", approver=UserFactory())
             error = remote_settings_exceptions.KintoException
             mocked_remotesettings.return_value.publish.side_effect = error
@@ -836,9 +838,11 @@ class TestRecipeRevision(object):
                 recipe.approved_revision.enable(user=UserFactory())
 
             saved = Recipe.objects.get(id=recipe.id)
-            assert not saved.approved_revision.enabled
+            assert saved.approved_revision.enabled
 
-        def test_it_rollbacks_changes_if_error_happens_on_unpublish(self, mocked_remotesettings):
+        def test_it_does_not_rollback_changes_if_rs_error_happens_on_unpublish(
+            self, mocked_remotesettings
+        ):
             recipe = RecipeFactory(name="Test", approver=UserFactory(), enabler=UserFactory())
             error = remote_settings_exceptions.KintoException
             mocked_remotesettings.return_value.unpublish.side_effect = error
@@ -847,7 +851,7 @@ class TestRecipeRevision(object):
                 recipe.approved_revision.disable(user=UserFactory())
 
             saved = Recipe.objects.get(id=recipe.id)
-            assert saved.approved_revision.enabled
+            assert not saved.approved_revision.enabled
 
         def test_enable_rollback_enable_rollout_invariance(self):
             rollout_recipe = RecipeFactory(


### PR DESCRIPTION
This was originally added so that if there was a Remote Settings API error, the database changes would be rolled back. However, this gives too much power to the sync process. Instead we should record what the state should be in the database, and if it doesn't sync immediately, then the background job that periodically re-sync RS and the database will catch it.

This avoid confusion such as the API call to Remote Settings seeming to fail, but Remote Settings actually committed the change. Having the potential for the Remote Settings collection to be "ahead" of the database is more damaging then having to wait for eventual consistency.