### PR TITLE
Add API parameter to filter by filter object values

### DIFF
--- a/normandy/recipes/api/filters.py
+++ b/normandy/recipes/api/filters.py
@@ -54,3 +54,55 @@ class CharSplitFilter(django_filters.CharFilter):
         if value:
             qs = qs.filter(**{"{}__in".format(self.field_name): value.split(",")})
         return qs
+
+
+class FilterObjectFieldFilter(django_filters.Filter):
+    """
+    Find recipes that have a filter object with the given field
+
+    Format for the filter's value is `key1:value1,key2:value2`. This would
+    include recipes that have a filter object that has a field `key1` that
+    contains the value `value1`, and that have a filter object with a field
+    `key2` that contains `value2`. The two filter objects do not have to be
+    the same, but may be.
+    """
+
+    def filter(self, qs, value):
+        if value is None:
+            return qs
+
+        needles = {k: v for k, v in [p.split(":") for p in value.split(",")]}
+
+        # Let the database do a first pass filter
+        for k, v in needles.items():
+            qs = qs.filter(latest_revision__filter_object_json__contains=k)
+            qs = qs.filter(latest_revision__filter_object_json__contains=v)
+
+        recipes = list(qs)
+        if not all(isinstance(recipe, Recipe) for recipe in recipes):
+            raise TypeError("FilterObjectFieldFilter can only be used to filter recipes")
+
+        # For every recipe that contains the right substrings, look through
+        # their filter objects for an actual match
+        match_ids = []
+        for recipe in recipes:
+            recipe_matches = True
+
+            # Recipes needs to have all the keys and values in the needles
+            for k, v in needles.items():
+                for filter_object in recipe.latest_revision.filter_object:
+                    # Don't consider invalid filter objects
+                    if not filter_object.is_valid():
+                        continue
+                    if k in filter_object.data and v in str(filter_object.data[k]):
+                        # Found a match
+                        break
+                else:
+                    # Did not break, so no match was not found
+                    recipe_matches = False
+                    break
+
+            if recipe_matches:
+                match_ids.append(recipe.id)
+
+        return Recipe.objects.filter(id__in=match_ids)

--- a/normandy/recipes/api/v3/views.py
+++ b/normandy/recipes/api/v3/views.py
@@ -30,6 +30,7 @@ from normandy.recipes.api.filters import (
     CharSplitFilter,
     EnabledStateFilter,
     BaselineCapabilitiesFilter,
+    FilterObjectFieldFilter,
 )
 from normandy.recipes.api.v3 import shield_identicon
 from normandy.recipes.api.v3.serializers import (
@@ -55,6 +56,7 @@ class RecipeFilters(django_filters.FilterSet):
     locales = CharSplitFilter("latest_revision__locales__code")
     countries = CharSplitFilter("latest_revision__countries__code")
     uses_only_baseline_capabilities = BaselineCapabilitiesFilter()
+    filter_object = FilterObjectFieldFilter()
 
     class Meta:
         model = Recipe

--- a/normandy/recipes/tests/__init__.py
+++ b/normandy/recipes/tests/__init__.py
@@ -168,6 +168,7 @@ class RecipeFactory(factory.DjangoModelFactory):
     def filter_object(self, create, extracted, **kwargs):
         if extracted:
             self.latest_revision.filter_object = extracted
+            self.latest_revision.save()
 
     # This should always be before `enabler`
     @factory.post_generation


### PR DESCRIPTION
This will be helpful in making a new version of the namespaces tool. The current
Namespaces tool has to request every single revision from the server (via
graphql). With this API, clients can filter for revisions that have the desired
namespace much more easily.
