### PR TITLE
Fix that recipes could not be filtered by FO type

### DIFF
--- a/normandy/recipes/filters.py
+++ b/normandy/recipes/filters.py
@@ -43,6 +43,14 @@ class BaseFilter(serializers.Serializer):
         raise NotImplementedError()
 
     @property
+    def data(self):
+        # Technically the filter's data doesn't include type, since it is hard
+        # coded. However type is an implicit part of the data still. Make it explicit.
+        ret = super().data
+        ret["type"] = self.type
+        return ret
+
+    @property
     def capabilities(self):
         """The capabilities needed by this filter"""
         raise NotImplementedError


### PR DESCRIPTION
I found this while trying to set up automatic namespace allocation. We could filter by all the other filter object fields, but `type` in particular wasn't available. Considering that's one of the most important ones, lets fix that.
