### PR TITLE
Update Stage Content Signature root key hash in documentation

### DIFF
--- a/docs/qa/environments.rst
+++ b/docs/qa/environments.rst
@@ -61,7 +61,7 @@ server:
 
 .. describe:: security.content.signature.root_hash
 
-   ``DB:74:CE:58:E4:F9:D0:9E:E0:42:36:BE:6C:C5:C4:F6:6A:E7:74:7D:C0:21:42:7A:03:BC:2F:57:0C:8B:9B:90``
+   ``3C:01:44:6A:BE:90:36:CE:A9:A0:9A:CA:A3:A5:20:AC:62:8F:20:A7:AE:32:CE:86:1C:B2:EF:B7:0F:A0:C7:45``
 
 Dev
 ---


### PR DESCRIPTION
The certificate described by this hash has changed, and so we need to update it in our docs.
