### PR TITLE
Use a method instead of a property to determine capabilities for filter objects

### DIFF
--- a/normandy/recipes/models.py
+++ b/normandy/recipes/models.py
@@ -392,7 +392,7 @@ class RecipeRevision(DirtyFieldsMixin, models.Model):
         """Calculates the set of capabilities required for this recipe."""
         capabilities = set(self.extra_capabilities) | self.action.capabilities
         for filter in self.filter_object:
-            capabilities.update(filter.capabilities)
+            capabilities.update(filter.get_capabilities())
 
         # "capabilities-v1" is not a baseline capability. If all of the other
         # capabilities are baseline capabilities, don't add it to the recipe.

--- a/normandy/recipes/tests/test_models.py
+++ b/normandy/recipes/tests/test_models.py
@@ -916,8 +916,8 @@ class TestRecipeRevision(object):
         def test_filter_object_capabilities_are_automatically_included(self):
             filter_object = StableSampleFilter.create(input=["A"], rate=0.1)
             recipe = RecipeFactory(filter_object=[filter_object])
-            assert filter_object.capabilities
-            assert filter_object.capabilities <= recipe.latest_revision.capabilities
+            assert filter_object.get_capabilities()
+            assert filter_object.get_capabilities() <= recipe.latest_revision.capabilities
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The property name "capabilities" collided with the field "capabilities" for the JEXLFilterObject. Coincidentally this was ok, but it certainly was not the intended path. Changing to "get_capabilities" stops the collision, and it is unlikely to collide in the future. However, this points out a serious flaw in this way of definining filter objects.
