### PR TITLE
Remove check about Remote Settings group_check_enabled

### DIFF
--- a/normandy/recipes/exports.py
+++ b/normandy/recipes/exports.py
@@ -127,14 +127,8 @@ class RemoteSettings:
                 for r in signer_config["resources"]
                 if r["source"]["bucket"] == bucket and r["source"]["collection"] == collection
             ]
-            review_disabled = (
-                len(normandy_resource) == 1
-                and not normandy_resource[0].get(
-                    "to_review_enabled", signer_config["to_review_enabled"]
-                )
-                and not normandy_resource[0].get(
-                    "group_check_enabled", signer_config["group_check_enabled"]
-                )
+            review_disabled = len(normandy_resource) == 1 and not normandy_resource[0].get(
+                "to_review_enabled", signer_config["to_review_enabled"]
             )
             if not review_disabled:
                 raise ImproperlyConfigured(

--- a/normandy/recipes/tests/test_exports.py
+++ b/normandy/recipes/tests/test_exports.py
@@ -191,7 +191,6 @@ class TestRemoteSettings:
                                     "collection": "normandy-recipes-capabilities",
                                 },
                                 "to_review_enabled": False,
-                                "group_check_enabled": False,
                             },
                         ],
                     }


### PR DESCRIPTION
From kinto-dist >= 27, we don't offer the possibility to disable the group check on a particular collection. Hence, there's no need to check it anymore (the field will always be `true`).

Plus, the check in this code was wrong, it was raising `Review was not disabled ...` when the `group_check_enabled` field was `True`