### PR TITLE
Cache the API root endpoint for longer.

### DIFF
--- a/docs/ops/config.rst
+++ b/docs/ops/config.rst
@@ -243,6 +243,13 @@ in other Django projects.
     set to 0 in non-production environments to ease testing. In production
     environments, setting this value too low can be a denial-of-service risk.
 
+.. envvar:: DJANGO_API_ROOT_CACHE_TIME
+
+    :default: ``86400`` (1 day)
+
+    The time in seconds to set in cache headers for cacheable API root
+    endpoints.
+
 .. envvar:: DJANGO_API_CACHE_ENABLED
 
     :default: ``True``

--- a/normandy/base/api/views.py
+++ b/normandy/base/api/views.py
@@ -29,7 +29,7 @@ class APIRootView(APIView):
     exclude_from_schema = True
     urlconf = None
 
-    @api_cache_control(max_age=settings.API_CACHE_TIME)
+    @api_cache_control(max_age=settings.API_ROOT_CACHE_TIME)
     def get(self, request, *args, **kwargs):
         ret = {}
 

--- a/normandy/settings.py
+++ b/normandy/settings.py
@@ -347,6 +347,7 @@ class Base(Core, CORS, OIDC, Metrics):
     ADMIN_ENABLED = values.BooleanValue(True)
     IMMUTABLE_CACHE_TIME = values.IntegerValue(60 * 60 * 24 * 365)
     NUM_PROXIES = values.IntegerValue(0)
+    API_ROOT_CACHE_TIME = values.IntegerValue(60 * 60 * 24)
     API_CACHE_TIME = values.IntegerValue(30)
     API_CACHE_ENABLED = values.BooleanValue(True)
     PERMANENT_REDIRECT_CACHE_TIME = values.IntegerValue(60 * 60 * 24 * 30)
@@ -440,6 +441,7 @@ class Development(InsecureAuthentication, Base):
     DEFAULT_FILE_STORAGE = values.Value("django.core.files.storage.FileSystemStorage")
 
     API_CACHE_ENABLED = values.BooleanValue(False)
+    API_ROOT_CACHE_TIME = values.IntegerValue(0)
     API_CACHE_TIME = values.IntegerValue(0)
 
     SILENCED_SYSTEM_CHECKS = values.ListValue(["normandy.recipes.E006"])  # geoip db not available


### PR DESCRIPTION
The information at the API root endpoints virtually never changes; it's just a list of endpoints in the API  with no dynamic information. At the same time, it's the endpoint we get by far the most requests for. We can reduce the load on the origin servers considerably if we cache this endpoint for a whole day instead of just 30 seconds.